### PR TITLE
docs: add AGENTS.md knowledge base and update README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-04-02
+**Commit:** c342666
+**Branch:** main
+
+## OVERVIEW
+
+Bun workspace monorepo for personal infrastructure — currently KeeWeb deploy automation + CLI scaffold. Deploys static sites to `box.heatvision.co` via SSH/rsync.
+
+## STRUCTURE
+
+```text
+├── apps/keeweb/        KeeWeb deploy package (see apps/keeweb/AGENTS.md)
+├── packages/cli/       @marcusrbrown/infra CLI stub (single file, no framework yet)
+├── docs/               Brainstorms → plans → solutions (compound learning)
+├── .github/            Workflows, pinned host keys, Renovate config, repo settings
+└── .opencode/          OpenCode slash commands (generate-readme)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Add new app | `apps/<name>/` | Copy keeweb structure, add to workspace |
+| Add CLI command | `packages/cli/src/cli.ts` | Plain arg parsing, no framework |
+| Add workflow | `.github/workflows/` | Use `.yaml` extension, SHA-pin all actions |
+| Configure ESLint | `eslint.config.ts` | Flat config via `@bfra.me/eslint-config` |
+| Configure TypeScript | `tsconfig.json` | Extends `@bfra.me/tsconfig`, Bun types |
+| Renovate config | `.github/renovate.json5` | Extends `marcusrbrown/renovate-config` |
+| Repo settings | `.github/settings.yml` | Synced by `bfra-me/.github` reusable workflow |
+| OpenCode commands | `.opencode/commands/` | Markdown slash commands |
+| Document solved problem | `docs/solutions/` | Compound learning with YAML frontmatter |
+
+## CONVENTIONS
+
+- **Only bash script**: `apps/keeweb/deploy.sh`. All other scripts are TypeScript run via `bun run`.
+- **GitHub Actions**: `.yaml` extension (not `.yml`). SHA-pin all actions with `# vX.Y.Z` version comment.
+- **Shared configs**: `@bfra.me/eslint-config`, `@bfra.me/prettier-config/120-proof`, `@bfra.me/tsconfig`.
+- **Git hooks**: `simple-git-hooks` + `lint-staged` → `eslint --fix` on commit.
+- **CI install**: `bun install --frozen-lockfile --ignore-scripts` (skip simple-git-hooks postinstall).
+- **Cross-org reusable workflows**: Pass secrets explicitly (never `secrets: inherit` with `bfra-me/.github`).
+- **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root.
+- **No tests yet**: CI checks lint + typecheck only.
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- **No `as any` / `@ts-ignore` / `@ts-expect-error`** — fix the types.
+- **No secret values in tracked files** — `config/config.json` template has empty `dropboxSecret`; real value injected at build time from env var.
+- **Never modify `config/config.json` in CI** — secret goes into `dist/config.json` only.
+- **Never use `ssh-keyscan`** — host keys pinned in `.github/known_hosts`.
+- **Never `secrets: inherit`** with cross-org reusable workflows.
+
+## UNIQUE STYLES
+
+- Download-based build: KeeWeb v1.18.7 release zip cached in `.cache/`, `dist/` rebuilt every run (source build infeasible — 2017-era tooling).
+- Deploy separation: content-only by default, `--nginx` flag for config deploy (requires explicit flag + environment approval).
+- Scoped deploy user: `deploy-kw` on server has write access to site dir only + sudo for single activation script.
+- `bun.lock` (text format) committed for reproducible CI; `bun.lockb` (binary) is not used.
+
+## COMMANDS
+
+```bash
+bun install                                    # Install dependencies
+bun run lint                                   # ESLint check
+bun run fix                                    # ESLint --fix (includes Prettier)
+bunx tsc --noEmit                              # Type check
+bun run --cwd apps/keeweb build                # Build KeeWeb dist
+bash apps/keeweb/deploy.sh                     # Deploy content only
+bash apps/keeweb/deploy.sh --nginx             # Deploy content + nginx config
+bun run apps/keeweb/server/setup-deploy-user.ts # Provision deploy user on server
+bun run packages/cli/src/cli.ts --help         # CLI usage
+```
+
+## NOTES
+
+- `DROPBOX_APP_SECRET` and `DEPLOY_SSH_KEY` are GitHub Actions secrets scoped to `production` environment. `APPLICATION_ID` and `APPLICATION_PRIVATE_KEY` are repo-level secrets.
+- Deploy target: `box.heatvision.co` (Mail-In-A-Box server). Site path: `/home/user-data/www/kw.igg.ms/`.
+- Activation script on server (`/usr/local/bin/kw-deploy-activate`) sets permissions to 775 with setgid to preserve group-write for deploy user.
+- `dorny/paths-filter@v3` used for change detection because native `paths:` breaks `workflow_dispatch`. Deploy condition: `workflow_dispatch || keeweb-changed`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Personal infrastructure management — deploy automation, configuration, and tooling.
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/marcusrbrown/infra/badge?style=flat-square)](https://scorecard.dev/viewer/?uri=github.com/marcusrbrown/infra)
+
+## Overview
+
+Bun workspace monorepo for managing personal infrastructure. Currently hosts KeeWeb deploy automation with CI/CD, with a CLI scaffold for future tooling.
+
+| Package        | Description                                  |
+| -------------- | -------------------------------------------- |
+| `apps/keeweb`  | KeeWeb v1.18.7 static site deploy automation |
+| `packages/cli` | `@marcusrbrown/infra` CLI (stub)             |
+
 ## Prerequisites
 
 - [Bun](https://bun.sh) v1.0+
@@ -37,7 +48,27 @@ bash apps/keeweb/deploy.sh          # content only
 bash apps/keeweb/deploy.sh --nginx   # content + nginx config
 ```
 
+## CLI
+
+The `@marcusrbrown/infra` CLI (`packages/cli`) is a stub scaffold for future infrastructure commands.
+
+```bash
+bun run packages/cli/src/cli.ts --help
+```
+
 ## CI/CD
+
+### Workflows
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| **CI** | PRs to `main` | Lint + type check |
+| **Deploy** | Push to `main` (keeweb changes), `workflow_dispatch` | Build and deploy KeeWeb |
+| **Renovate** | Push, issue/PR edits, post-deploy | Automated dependency updates |
+| **Scorecard** | Weekly, push to `main` | OpenSSF security analysis |
+| **Update Repo Settings** | Daily, push to `main` | Sync repo settings from `.github/settings.yml` |
+
+### Deploy Pipeline
 
 Pushes to `main` that touch `apps/keeweb/**` trigger an automated deploy via GitHub Actions. Manual deploys are available via `workflow_dispatch`.
 
@@ -45,12 +76,19 @@ Deploys require approval through the `production` GitHub Environment.
 
 ### Required Secrets
 
-Set these in the `production` GitHub Environment:
+**Production environment** (`DEPLOY_SSH_KEY`, `DROPBOX_APP_SECRET`):
 
 | Secret               | Description                                           |
 | -------------------- | ----------------------------------------------------- |
 | `DEPLOY_SSH_KEY`     | Ed25519 private key for `deploy-kw@box.heatvision.co` |
 | `DROPBOX_APP_SECRET` | Dropbox app client credential for KeeWeb config       |
+
+**Repository secrets** (`APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`):
+
+| Secret                    | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `APPLICATION_ID`          | GitHub App ID for Renovate and repo settings sync |
+| `APPLICATION_PRIVATE_KEY` | GitHub App private key                            |
 
 ### Server Setup
 
@@ -63,17 +101,44 @@ bun run apps/keeweb/server/setup-deploy-user.ts
 ## Repository Structure
 
 ```text
-├── apps/keeweb/          KeeWeb deploy package
-│   ├── src/build.ts      Build script (download + config injection)
-│   ├── config/           Config templates (nginx, app config)
-│   ├── server/           Server provisioning scripts
-│   └── deploy.sh         SSH/rsync deploy script
-├── packages/cli/         @marcusrbrown/infra CLI (stub)
+├── apps/keeweb/             KeeWeb deploy package
+│   ├── src/build.ts         Build script (download + config injection)
+│   ├── config/              Config templates (nginx, app config)
+│   ├── server/              Server provisioning scripts
+│   └── deploy.sh            SSH/rsync deploy script
+├── packages/cli/            @marcusrbrown/infra CLI (stub)
+│   └── src/cli.ts           Entry point
 ├── .github/
-│   ├── known_hosts       Pinned SSH host keys
-│   └── workflows/        CI/CD workflows
-└── docs/                 Brainstorms and plans
+│   ├── known_hosts          Pinned SSH host keys
+│   ├── renovate.json5       Renovate configuration
+│   ├── settings.yml         Repository settings definition
+│   └── workflows/           CI/CD and automation workflows
+├── docs/
+│   ├── brainstorms/         Requirements and brainstorms
+│   ├── plans/               Implementation plans
+│   └── solutions/           Compound learning docs
+└── .opencode/
+    └── commands/            OpenCode slash commands
 ```
+
+## Development
+
+```bash
+bun run lint          # ESLint
+bun run fix           # ESLint --fix (includes Prettier)
+bunx tsc --noEmit     # Type check
+```
+
+Pre-commit hook runs `lint-staged` → `eslint --fix` on staged files via `simple-git-hooks`.
+
+### Tooling
+
+| Tool       | Config                                          |
+| ---------- | ----------------------------------------------- |
+| ESLint     | `eslint.config.ts` via `@bfra.me/eslint-config` |
+| Prettier   | `@bfra.me/prettier-config/120-proof`            |
+| TypeScript | `tsconfig.json` via `@bfra.me/tsconfig`         |
+| Git hooks  | `simple-git-hooks` + `lint-staged`              |
 
 ## License
 

--- a/apps/keeweb/AGENTS.md
+++ b/apps/keeweb/AGENTS.md
@@ -1,0 +1,48 @@
+# KeeWeb Deploy Package
+
+Self-hosted KeeWeb v1.18.7 password manager at `kw.igg.ms`. Download-based build (not from source).
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Change KeeWeb version | `src/build.ts` | Update `KEEWEB_VERSION` constant |
+| Modify nginx config | `config/kw.igg.ms.conf` | Requires `--nginx` flag to deploy |
+| Change app config template | `config/config.json` | Never put real secrets here |
+| Modify deploy behavior | `deploy.sh` | Content-only by default |
+| Re-provision server user | `server/setup-deploy-user.ts` | Run via `bun run` locally, SSHes into server |
+
+## BUILD FLOW
+
+1. `src/build.ts` downloads `KeeWeb-{version}.html.zip` from GitHub Releases
+2. Zip cached in `.cache/` (skipped if already present)
+3. `dist/` cleared and rebuilt every run
+4. `DROPBOX_APP_SECRET` env var injected into `dist/config.json` at `.settings.dropboxSecret`
+5. `config/kw.igg.ms.conf` copied to `dist/`
+
+**Critical**: `config/config.json` (template) is never modified. Secret only goes into `dist/config.json`.
+
+## DEPLOY FLOW
+
+```text
+deploy.sh [--nginx]
+  ├── Validates dist/index.html and dist/config.json exist
+  ├── rsync dist/ → deploy-kw@box.heatvision.co:/home/user-data/www/kw.igg.ms/
+  ├── ssh: sudo /usr/local/bin/kw-deploy-activate (set perms 775 + setgid)
+  └── [--nginx] backup existing conf → scp new conf → nginx -t → reload (auto-restore on failure)
+```
+
+## SERVER
+
+- User: `deploy-kw` (uid 997, `www-data` group)
+- Site path: `/home/user-data/www/kw.igg.ms/`
+- Sudo scope: only `/usr/local/bin/kw-deploy-activate`
+- Backup dir: `/home/deploy-kw/backups/`
+- Activation: `chmod -R 775` + `find -type d -exec chmod g+s` for group-write persistence
+
+## ANTI-PATTERNS
+
+- Never commit real `dropboxSecret` — template stays empty, CI injects from env.
+- Never run `deploy.sh` without building first — it validates `dist/` contents.
+- Never deploy nginx config without `--nginx` flag — content-only is the safe default.
+- `rsync` uses `--no-times --no-perms` to avoid permission errors with the deploy user.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@ import {defineConfig} from '@bfra.me/eslint-config'
 export default defineConfig(
   {
     name: '@marcusrbrown/infra',
-    ignores: ['.agents/', 'docs/', 'dist/', '.cache/', '.github/renovate.json5'],
+    ignores: ['.agents/', 'docs/', 'dist/', '.cache/', '.github/renovate.json5', '**/AGENTS.md'],
     typescript: true,
   },
   {


### PR DESCRIPTION
## Summary

- Add hierarchical `AGENTS.md` knowledge base files (root + `apps/keeweb/`) documenting project conventions, anti-patterns, build/deploy flows, and commands
- Rewrite `README.md` with OpenSSF Scorecard badge, CI/CD workflow table, secrets documentation (production + repo scopes), development tooling table, and accurate repo structure
- Exclude `.github/renovate.json5` from ESLint (JSON5 syntax conflicts with jsonc rules)

## Files

| File | Change |
| --- | --- |
| `AGENTS.md` | New — root knowledge base (80 lines) |
| `apps/keeweb/AGENTS.md` | New — keeweb-specific build/deploy/server docs (48 lines) |
| `README.md` | Rewritten — badges, workflows, secrets, tooling |
| `eslint.config.ts` | Add renovate.json5 to ignores |