### PR TITLE
feat: configure Copilot coding agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# Copilot Instructions
+
+Read `AGENTS.md` at the repository root and `apps/keeweb/AGENTS.md` for full project conventions before making changes.
+
+## Runtime
+
+- **Bun only.** Never use `npm`, `pnpm`, or `yarn`.
+- Run app scripts from the repo root: `bun run --cwd apps/<name> <script>`.
+- There is no root-level `build` script. Build KeeWeb with `bun run --cwd apps/keeweb build`.
+
+## Verification
+
+Run these before marking work complete:
+
+```sh
+bun run lint
+bunx tsc --noEmit
+bun run --cwd apps/keeweb build
+```
+
+## TypeScript
+
+- No `as any`, `@ts-ignore`, or `@ts-expect-error`. Fix the types.
+- Never exclude TypeScript files from type checking.
+- Prefer `satisfies` over type annotations when you want inference.
+- Use discriminated unions over optional properties.
+- Use `import type` for type-only imports.
+
+## Formatting
+
+- ESLint handles all formatting (via `eslint-plugin-prettier`). There is no separate Prettier command.
+- Auto-fix with `bun run fix`.
+- Do not create or modify `.prettierignore` — use `ignores` in `eslint.config.ts`.
+
+## GitHub Actions
+
+- Use `.yaml` extension for workflow files (not `.yml`).
+- SHA-pin all actions to full commit hashes with `# vX.Y.Z` version comments.
+- Never use `secrets: inherit` when calling reusable workflows in another org (e.g., `bfra-me/.github`). Pass secrets explicitly.
+- Use `bun install --frozen-lockfile --ignore-scripts` in CI.
+
+## Scripts
+
+- Only `apps/keeweb/deploy.sh` is Bash. All other scripts must be TypeScript run via `bun run`.
+- The embedded `kw-deploy-activate` script in `setup-deploy-user.ts` must remain Bash (runs standalone as root via sudoers).
+
+## Secrets and Security
+
+- Never commit secret values to tracked files.
+- `config/config.json` must never be modified by CI or build scripts. Secrets are injected only into `dist/config.json`.
+- `DEPLOY_SSH_KEY` and `DROPBOX_APP_SECRET` are scoped to the `production` GitHub Environment.
+- Host keys are pinned in `.github/known_hosts`. Never use `ssh-keyscan`.
+
+## Collaboration
+
+- Read existing PR comments and issue context before making changes.
+- When Fro Bot has reviewed a PR, read its comments and address any blocking findings.
+- Preserve acceptance criteria from issues when creating PRs.

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -1,0 +1,35 @@
+---
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+  pull_request:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: bun run --cwd apps/keeweb build
+
+      - name: Verify environment
+        run: |
+          bun --version
+          bunx tsc --noEmit
+          bun run lint


### PR DESCRIPTION
## Summary

- **Setup steps workflow**: installs Bun + dependencies, builds KeeWeb, runs typecheck + lint — gives Copilot a hot environment before it starts working
- **Instructions**: references AGENTS.md, enforces Bun-only runtime, TypeScript strictness, SHA-pinned actions, secret handling, and Fro Bot collaboration

## Files

- `.github/workflows/copilot-setup-steps.yaml` — environment prep (SHA-pinned actions, `--frozen-lockfile --ignore-scripts`)
- `.github/copilot-instructions.md` — coding conventions distilled from AGENTS.md for Copilot's context