### PR TITLE
feat(cli): add keeweb status, deploy, and MCP bridge commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,12 @@
       "bin": {
         "infra": "src/cli.ts",
       },
+      "dependencies": {
+        "@goke/mcp": "^0.0.9",
+        "goke": "^6.3.2",
+        "string-dedent": "^3.0.2",
+        "zod": "^4.3.6",
+      },
     },
   },
   "packages": {
@@ -111,6 +117,10 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
+    "@goke/mcp": ["@goke/mcp@0.0.9", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "js-yaml": "^4.1.1" }, "peerDependencies": { "goke": "*" } }, "sha512-PYJOHTGjklkhf33jBDdRZiUSyB06OHrDcWxfC/aUJlR5na9+9sDPANpLzldj4Mn1a0Wz0C9aaEvgUSFskqkT5w=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -128,6 +138,8 @@
     "@marcusrbrown/infra": ["@marcusrbrown/infra@workspace:packages/cli"],
 
     "@marcusrbrown/infra-keeweb": ["@marcusrbrown/infra-keeweb@workspace:apps/keeweb"],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -227,11 +239,15 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -253,6 +269,8 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -262,6 +280,12 @@
     "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001784", "", {}, "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw=="],
 
@@ -289,7 +313,17 @@
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
     "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -300,6 +334,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -315,9 +351,15 @@
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -325,7 +367,15 @@
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -389,7 +439,17 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -417,6 +477,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
@@ -427,9 +489,19 @@
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
@@ -445,9 +517,21 @@
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
+    "goke": ["goke@6.3.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-0CSINX0HJiBPBphPvWhce/NkTgXogvLBxeeewT4L1Oh/P1RXxaC1qV1+IGvDN5jHjtjycr4mlGmxd7i14e1V5A=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
@@ -458,6 +542,12 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-builtin-module": ["is-builtin-module@5.0.0", "", { "dependencies": { "builtin-modules": "^5.0.0" } }, "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="],
 
@@ -473,6 +563,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
@@ -480,6 +572,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -492,6 +586,8 @@
     "json-schema-migrate-x": ["json-schema-migrate-x@2.1.0", "", { "dependencies": { "ajv": "^8.17.1" } }, "sha512-idC5B/FLaEsMydSW+I302kEmg9RecqsdG12nAfmgp9SmrqDzmea9wTlE56rQlV3P3cWY6AAcA8/By4gyCQES/A=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -521,6 +617,8 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
@@ -544,6 +642,10 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -607,6 +709,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -623,11 +729,21 @@
 
     "natural-orderby": ["natural-orderby@5.0.0", "", {}, "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "object-deep-merge": ["object-deep-merge@2.0.0", "", {}, "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -651,9 +767,13 @@
 
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -665,6 +785,8 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
@@ -675,11 +797,19 @@
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
@@ -705,6 +835,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -715,9 +847,23 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -743,7 +889,11 @@
 
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-dedent": ["string-dedent@3.0.2", "", {}, "sha512-M4q+HpHCtGXlbyzYDOcOo7V185dlq6YXvGUPcWZqL4vttCX9gFYoWIOxcPd7v5CAYcTJsGLs3ZJCAH2TXONF/g=="],
 
     "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
@@ -767,6 +917,8 @@
 
     "to-valid-identifier": ["to-valid-identifier@1.0.0", "", { "dependencies": { "@sindresorhus/base62": "^1.0.0", "reserved-identifiers": "^1.0.0" } }, "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "toml-eslint-parser": ["toml-eslint-parser@1.0.3", "", { "dependencies": { "eslint-visitor-keys": "^5.0.0" } }, "sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -780,6 +932,8 @@
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -799,11 +953,15 @@
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -815,11 +973,17 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yaml-eslint-parser": ["yaml-eslint-parser@2.0.0", "", { "dependencies": { "eslint-visitor-keys": "^5.0.0", "yaml": "^2.0.0" } }, "sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -853,6 +1017,8 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "@stylistic/eslint-plugin/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "@stylistic/eslint-plugin/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
@@ -880,6 +1046,8 @@
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.56.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.56.1", "@typescript-eslint/tsconfig-utils": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA=="],
+
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -923,6 +1091,8 @@
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
@@ -942,6 +1112,8 @@
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "eslint-plugin-json-schema-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/docs/brainstorms/2026-04-03-cli-commands-requirements.md
+++ b/docs/brainstorms/2026-04-03-cli-commands-requirements.md
@@ -1,0 +1,78 @@
+---
+date: 2026-04-03
+topic: cli-commands
+---
+
+# CLI Commands for Infrastructure Management
+
+## Problem Frame
+
+The `@marcusrbrown/infra` CLI (`packages/cli/src/cli.ts`) is a stub with no real commands. Operational tasks — checking deploy health, triggering deploys, verifying content — require navigating the GitHub Actions UI or running ad-hoc shell commands. A working CLI gives Marcus a local control plane for infra operations and, via the MCP bridge, gives coding agents (Fro Bot, Copilot) programmatic access to the same capabilities.
+
+## Requirements
+
+### Commands
+
+- R1. **`infra keeweb status`** — Show operational health of the KeeWeb deployment:
+  - R1a. HTTP reachability: GET `https://kw.igg.ms` and report status code + response time
+  - R1b. Last deploy timestamp: query GitHub Actions API for the most recent successful run of the Deploy workflow
+  - R1c. Content version check: fetch a known marker from the live site and compare against local `dist/` to detect drift
+
+- R2. **`infra keeweb deploy`** — Trigger a KeeWeb deployment:
+  - R2a. Default: trigger the Deploy workflow via GitHub Actions `workflow_dispatch` API (requires `gh` CLI or GitHub token)
+  - R2b. `--local` flag: run `deploy.sh` directly using `DEPLOY_SSH_KEY` from `.env`, bypassing CI
+  - R2c. `--nginx` flag (local only): pass `--nginx` to `deploy.sh` for config deployment
+  - R2d. `--dry-run` flag: preview what would happen without executing
+
+- R3. **`infra mcp`** — Start a stdio MCP server exposing all CLI commands as MCP tools via `@goke/mcp`. This lets coding agents call `keeweb status` and `keeweb deploy` programmatically.
+
+### Framework
+
+- R4. **Use `goke` as CLI framework** with Zod schemas for typed options, auto-generated help, and space-separated subcommands. A goke skill exists for implementing agents.
+
+### Cross-cutting
+
+- R5. **Global `--verbose` flag** for detailed output across all commands.
+- R6. **Version from `package.json`** — `infra --version` reads version dynamically.
+
+## Success Criteria
+
+- `infra keeweb status` returns actionable health data in under 5 seconds
+- `infra keeweb deploy` triggers the GitHub Actions workflow and reports the run URL
+- `infra keeweb deploy --local` runs deploy.sh and succeeds against the live server
+- `infra mcp` starts a stdio MCP server that exposes commands as callable tools
+- `infra --help` and `infra keeweb --help` produce useful, complete help text
+- All commands work with Bun (`bun run packages/cli/src/cli.ts`)
+
+## Scope Boundaries
+
+- Keeweb-only commands for now. Global `infra status` / `infra deploy` (across all apps) deferred until a second app exists.
+- No interactive prompts needed for v1. All inputs via flags.
+- No TLS certificate checking in v1 status (can add later).
+- No workflow status check (passing/failing) in v1 status.
+- The `@goke/mcp` OAuth flow is not needed — MCP server runs locally over stdio.
+
+## Key Decisions
+
+- **goke framework**: Zero-dependency, type-safe, Zod schemas, space-separated subcommands, MCP bridge built-in. Skill file available for implementing agents.
+- **Dual deploy mode**: Default to GitHub Actions trigger (auditable, uses production approval gate). `--local` flag for direct SSH deploy (faster feedback loop, bypasses CI).
+- **MCP exposure via `@goke/mcp`**: CLI doubles as an MCP server, giving coding agents programmatic access to infra operations without custom tool implementation.
+
+## Dependencies / Assumptions
+
+- `gh` CLI available for GitHub Actions API calls (deploy trigger, workflow run queries). Fall back to `GITHUB_TOKEN` env var if `gh` not available.
+- `.env` contains `DEPLOY_SSH_KEY` for local deploys.
+- `dist/` must exist locally for content version comparison (run `bun run --cwd apps/keeweb build` first).
+- The "known marker" for content version check needs to be defined during planning (could be a hash of `dist/index.html`, a build timestamp, or the KeeWeb version string in the HTML).
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1c][Needs research] What specific marker in the live site should be compared for content version drift? Options: hash of index.html body, KeeWeb version string in HTML, a generated build manifest.
+- [Affects R2a][Technical] Should `infra keeweb deploy` poll the triggered workflow run to completion and report status, or just trigger and return the run URL?
+- [Affects R3][Technical] Should the MCP command be auto-excluded from the MCP tool list (goke default), or should all commands including `mcp` be exposed?
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-03-001-feat-cli-commands-plan.md
+++ b/docs/plans/2026-04-03-001-feat-cli-commands-plan.md
@@ -1,0 +1,287 @@
+---
+title: "feat: Add CLI commands for KeeWeb operations and MCP bridge"
+type: feat
+status: completed
+date: 2026-04-03
+deepened: 2026-04-03
+origin: docs/brainstorms/2026-04-03-cli-commands-requirements.md
+---
+
+# feat: Add CLI commands for KeeWeb operations and MCP bridge
+
+## Overview
+
+Replace the stub CLI at `packages/cli/` with a working `goke`-based CLI providing `keeweb status`, `keeweb deploy`, and an MCP server bridge. This gives Marcus a local control plane for infra operations and gives coding agents (Fro Bot, Copilot) programmatic access via MCP tools.
+
+## Problem Frame
+
+Operational tasks — checking deploy health, triggering deploys, verifying content — require navigating the GitHub Actions UI or running ad-hoc shell commands. The CLI stub has no real commands. (see origin: docs/brainstorms/2026-04-03-cli-commands-requirements.md)
+
+## Requirements Trace
+
+- R1. `infra keeweb status` — HTTP reachability, last deploy timestamp, content version check
+  - R1a. HTTP reachability: GET `https://kw.igg.ms` and report status code + response time
+  - R1b. Last deploy timestamp: query GitHub Actions API for most recent successful Deploy workflow run
+  - R1c. Content version check: hash fetched index.html body vs local `dist/index.html` to detect drift
+- R2. `infra keeweb deploy` — workflow_dispatch trigger (default) + local deploy via `--local` flag
+  - R2a. Default: trigger Deploy workflow via `workflow_dispatch` API, report run URL
+  - R2b. `--local` flag: run deploy.sh directly via SSH
+  - R2c. `--nginx` flag (local only): pass `--nginx` to deploy.sh
+  - R2d. `--dry-run` flag: validate preconditions and report what would happen
+- R3. `infra mcp` — stdio MCP server exposing all commands as tools via `@goke/mcp`
+- R4. Use `goke` framework with Zod schemas
+- R5. Global `--verbose` flag
+- R6. Version from `package.json`
+
+## Scope Boundaries
+
+- Keeweb-only commands. No global `infra status` / `infra deploy` until a second app exists.
+- No interactive prompts. All inputs via flags.
+- No TLS certificate checking in status.
+- No workflow status (passing/failing) in status.
+- MCP server runs locally over stdio — no OAuth flow needed.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/cli/src/cli.ts` — current stub, plain arg parsing, `#!/usr/bin/env bun` shebang
+- `packages/cli/package.json` — bin entry `"infra": "src/cli.ts"`, private, type: module
+- `apps/keeweb/src/build.ts` — async `main()` with try/catch, `process.exit(1)` on error, ANSI color output
+- `apps/keeweb/deploy.sh` — expects `HOST`, `REMOTE_USER`, `SITE_DIR` env vars with defaults, `--nginx` flag
+- `.github/workflows/deploy.yaml` — workflow name `"Deploy"`, no dispatch inputs, post-deploy health check curls `https://kw.igg.ms/`
+- `KEEWEB_VERSION = '1.18.7'` in `build.ts`
+
+### External References
+
+- goke v6.3.2: zero-dep CLI framework (only `picocolors`), Standard Schema support (Zod), space-separated subcommands, async actions via `cli.parse({ run: false })` + `await cli.runMatchedCommand()`
+- @goke/mcp v0.0.9: `createMcpAction({ cli })` exposes all CLI commands as MCP tools, `mcp` command auto-excluded from tool list
+- Zod must be installed separately (not bundled with goke)
+- `string-dedent` is a separate package for multi-line descriptions
+- goke SKILL.md available at `https://raw.githubusercontent.com/remorses/goke/refs/heads/main/goke/SKILL.md` — implementing agent should load this
+
+## Key Technical Decisions
+
+- **goke framework**: Type-safe, Zod schemas for option coercion, space-separated subcommands (`keeweb status`, `keeweb deploy`), auto-generated help, MCP bridge built-in. (see origin)
+- **Dual deploy mode**: Default triggers GitHub Actions `workflow_dispatch` via `gh` CLI. `--local` flag runs `deploy.sh` directly. (see origin)
+- **`gh` CLI for GitHub API**: Use `Bun.spawn` to shell out to `gh` rather than adding `octokit` as a dependency. The `gh` CLI handles auth, pagination, and is already available in dev environments. No `GITHUB_TOKEN` raw fetch fallback — require `gh` CLI for GitHub API operations (simpler, safer, avoids scope validation issues).
+- **Content version check via index.html hash**: No version marker exists in the deployed site. Compare SHA-256 hash of fetched `https://kw.igg.ms/` response body against hash of local `dist/index.html`. Warn if `dist/` doesn't exist. Hash mismatch is a warning (not an error) since nginx content transformation could cause false positives. TLS verification uses Bun's default (do not disable).
+- **Deploy trigger is fire-and-forget for v1**: `infra keeweb deploy` triggers the workflow and returns the run URL. The Deploy workflow requires `production` environment approval, so the run will be pending until approved — inform the user of this. No polling to completion.
+- **`--dry-run` is CLI-level, not deploy.sh**: `deploy.sh` only accepts `--nginx` — it has no `--dry-run` flag. The CLI implements dry-run by validating preconditions and reporting what would happen, without spawning deploy.sh or triggering the workflow.
+- **Explicit env for deploy.sh spawn**: When spawning deploy.sh, construct an explicit env object containing only required vars (`HOST`, `REMOTE_USER`, `SITE_DIR`, `SSH_AUTH_SOCK`, `PATH`, `HOME`) rather than inheriting the full parent environment. This prevents leaking unrelated secrets (e.g., `GITHUB_TOKEN`) to subprocesses.
+- **Local deploy requires ssh-agent, not raw key**: `deploy.sh` uses `ssh`/`rsync` which require an SSH agent. For `--local` mode, check for `SSH_AUTH_SOCK` (agent running with key loaded) rather than `DEPLOY_SSH_KEY` env var. The raw PEM content in `.env` is for CI's `webfactory/ssh-agent` action, not direct use by `ssh`. Document the local SSH setup requirement in the command's help text.
+- **File structure**: Split commands into separate modules under `packages/cli/src/commands/` for maintainability. Main `cli.ts` wires them together.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Content drift marker**: Use SHA-256 hash of `index.html` body. No build manifest needed — KeeWeb is a stable v1.18.7 release, content only changes when config or deploy scripts change. Hash mismatch is a warning, not an error.
+- **Deploy polling**: Fire-and-forget for v1. Return run URL immediately.
+- **MCP tool exclusion**: Use goke default — `mcp` command auto-excluded from tool list.
+- **`.env` loading for local deploy**: Use Bun's built-in `.env` support (`--env-file=.env` or `Bun.env`). No `dotenv` dependency needed.
+
+### Deferred to Implementation
+
+- Exact error messages and exit codes for each failure mode (gh not found, network timeout, deploy.sh missing, etc.)
+- Whether `--verbose` should also pass through to `deploy.sh` output — ensure it does not expose secrets or auth tokens
+- Verify `@goke/mcp` v0.0.9 exported API (`createMcpAction`) matches SKILL.md documentation after install
+- Verify goke MCP tool naming for space-separated subcommands (e.g., does `keeweb status` become `keeweb-status` or `keeweb status` as a tool name?)
+- Parse `gh` CLI JSON output through Zod schema validation before use — prevents issues from gh version changes or malformed output
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+cli = goke('infra')
+  .option('--verbose')
+  .version(pkg.version)
+
+cli.command('keeweb status')     → fetch site, query gh api, hash comparison
+cli.command('keeweb deploy')     → gh workflow run OR spawn deploy.sh --local
+cli.command('mcp')               → createMcpAction({ cli })
+
+cli.parse(process.argv, { run: false })
+await cli.runMatchedCommand()
+```
+
+File layout:
+```
+packages/cli/
+├── src/
+│   ├── cli.ts                  # Entry point: goke setup, wire commands, parse
+│   └── commands/
+│       ├── keeweb-status.ts    # Status command: HTTP check, deploy timestamp, content hash
+│       ├── keeweb-deploy.ts    # Deploy command: workflow_dispatch + local mode
+│       └── mcp.ts              # MCP server command
+└── package.json                # Add goke, zod, @goke/mcp, string-dedent deps
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Install dependencies and scaffold goke CLI skeleton**
+
+  **Goal:** Replace the plain arg-parsing stub with a goke-based CLI that parses commands and shows help/version.
+
+  **Requirements:** R4, R5, R6
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `packages/cli/package.json` (add dependencies)
+  - Modify: `packages/cli/src/cli.ts` (rewrite with goke)
+  - Create: `packages/cli/src/commands/` directory
+
+  **Approach:**
+  - Install `goke`, `zod`, `@goke/mcp`, `string-dedent` as runtime dependencies in the cli package (`bun add --cwd packages/cli goke zod @goke/mcp string-dedent`)
+  - Commit updated `bun.lock` alongside `package.json` changes (CI uses `--frozen-lockfile`)
+  - Rewrite `cli.ts` with goke: global `--verbose` flag, version from `package.json`, help, async parse pattern
+  - Use `cli.parse(process.argv, { run: false })` + `await cli.runMatchedCommand()` wrapped in try/catch
+  - Keep `#!/usr/bin/env bun` shebang
+  - Register placeholder commands for `keeweb status`, `keeweb deploy`, `mcp` that will be filled in subsequent units
+
+  **Patterns to follow:**
+  - goke SKILL.md patterns (schema-based options, space-separated subcommands, detailed descriptions)
+  - `apps/keeweb/src/build.ts` async main() with try/catch error handling
+
+  **Test scenarios:**
+  - `infra --help` shows all commands with descriptions
+  - `infra --version` prints version from package.json
+  - `infra keeweb --help` shows keeweb subcommands
+  - Unknown command shows error + help
+
+  **Verification:**
+  - `bun run packages/cli/src/cli.ts --help` produces correct output
+  - `bun run packages/cli/src/cli.ts --version` prints version
+  - `bunx tsc --noEmit` passes
+  - `bun run lint` passes
+
+- [ ] **Unit 2: Implement `keeweb status` command**
+
+  **Goal:** Show operational health of the KeeWeb deployment with HTTP reachability, last deploy timestamp, and content version check.
+
+  **Requirements:** R1 (R1a, R1b, R1c)
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `packages/cli/src/commands/keeweb-status.ts`
+  - Modify: `packages/cli/src/cli.ts` (import and register command)
+
+  **Approach:**
+  - HTTP reachability: `fetch('https://kw.igg.ms/')` with timeout, report status code + response time
+  - Last deploy: shell out to `gh run list --workflow=Deploy --status=success --limit=1 --json createdAt,url --repo marcusrbrown/infra` and parse JSON output
+  - Content version: hash fetched index.html body vs local `dist/index.html` (using `Bun.CryptoHasher`). Warn if `dist/` doesn't exist. Show match/mismatch.
+  - Output as formatted text. If `--verbose`, show additional details (response headers, full gh output)
+  - Handle errors gracefully: network timeout, gh not installed, dist/ missing — report each check independently
+
+  **Patterns to follow:**
+  - goke SKILL.md: Zod schemas for options, detailed descriptions
+  - Deploy workflow health check pattern: `curl -sf https://kw.igg.ms/`
+
+  **Test scenarios:**
+  - Site reachable: shows HTTP 200, response time, green indicator
+  - Site unreachable: shows error, continues to other checks
+  - `gh` not available: shows warning, skips deploy timestamp
+  - `dist/` missing: shows warning about content check being unavailable
+  - Content matches: shows checkmark
+  - Content drifted: shows warning with hash mismatch
+
+  **Verification:**
+  - `bun run packages/cli/src/cli.ts keeweb status` runs all three checks and produces readable output
+  - Lint and typecheck pass
+
+- [ ] **Unit 3: Implement `keeweb deploy` command**
+
+  **Goal:** Trigger KeeWeb deployment via GitHub Actions or locally via deploy.sh.
+
+  **Requirements:** R2 (R2a, R2b, R2c, R2d)
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `packages/cli/src/commands/keeweb-deploy.ts`
+  - Modify: `packages/cli/src/cli.ts` (import and register command)
+
+  **Approach:**
+  - Default (remote): shell out to `gh workflow run Deploy --repo marcusrbrown/infra`. Since `gh workflow run` returns no URL, construct the workflow URL directly: `https://github.com/marcusrbrown/infra/actions/workflows/deploy.yaml`. Warn the user that `workflow_dispatch` triggers deploy **including nginx config** (per workflow `if` condition). Inform user the run requires production environment approval.
+  - `--local` flag: spawn `bash apps/keeweb/deploy.sh` with explicit env (only `HOST`, `REMOTE_USER`, `SITE_DIR`, `SSH_AUTH_SOCK`, `PATH`, `HOME`). Requires `SSH_AUTH_SOCK` set (ssh-agent running with deploy key loaded). Validate `dist/index.html` exists before deploying.
+  - `--nginx` flag (only with `--local`): pass `--nginx` to deploy.sh. Error if `--nginx` without `--local`.
+  - `--dry-run` flag: CLI-level only (deploy.sh has no dry-run support). For remote: show what would be triggered without calling `gh workflow run`. For local: validate all preconditions (dist/ exists, `SSH_AUTH_SOCK` set, deploy.sh found) and report what would be executed, without spawning deploy.sh.
+  - Resolve `deploy.sh` path relative to `import.meta.dir` with upward traversal to repo root (`../../apps/keeweb/deploy.sh`). Validate the resolved path exists before spawning. Document that `--local` requires running from within the repo tree.
+
+  **Patterns to follow:**
+  - `apps/keeweb/src/build.ts` `Bun.spawn` usage for process spawning
+  - deploy.sh env vars: `HOST`, `REMOTE_USER`, `SITE_DIR` defaults
+
+  **Test scenarios:**
+  - Remote deploy: triggers workflow, reports run URL
+  - `--local` deploy: spawns deploy.sh, streams output
+  - `--local --nginx`: passes --nginx flag through
+  - `--nginx` without `--local`: shows error
+  - `--dry-run` remote: shows "would trigger Deploy workflow" without triggering
+  - `--dry-run --local`: validates preconditions without deploying
+  - `dist/` missing with `--local`: shows error before attempting deploy
+  - `gh` not available for remote deploy: shows error with instructions
+
+  **Verification:**
+  - `bun run packages/cli/src/cli.ts keeweb deploy --dry-run` shows what would happen without side effects
+  - `bun run packages/cli/src/cli.ts keeweb deploy --help` shows all options with descriptions
+  - Lint and typecheck pass
+
+- [ ] **Unit 4: Implement `mcp` command and wire up**
+
+  **Goal:** Add MCP server command that exposes all CLI commands as MCP tools, and do final integration wiring.
+
+  **Requirements:** R3
+
+  **Dependencies:** Units 1, 2, 3
+
+  **Files:**
+  - Create: `packages/cli/src/commands/mcp.ts`
+  - Modify: `packages/cli/src/cli.ts` (import and register mcp command)
+
+  **Approach:**
+  - Use `createMcpAction({ cli })` from `@goke/mcp` — this auto-discovers all registered commands and exposes them as MCP tools
+  - The `mcp` command itself is auto-excluded from the tool list by goke default behavior
+  - Keep it minimal — the bridge does the heavy lifting
+
+  **Patterns to follow:**
+  - goke SKILL.md MCP bridge pattern
+  - @goke/mcp `createMcpAction` API
+
+  **Test scenarios:**
+  - `infra mcp` starts without error (stdio mode)
+  - `infra mcp --help` shows the command description
+  - MCP tool list includes `keeweb-status` and `keeweb-deploy` but not `mcp`
+
+  **Verification:**
+  - `bun run packages/cli/src/cli.ts mcp` starts and accepts MCP protocol messages on stdio
+  - All commands accessible: `infra --help` shows keeweb status, keeweb deploy, mcp
+  - `infra keeweb --help` shows status and deploy subcommands
+  - Full lint and typecheck pass
+  - `bun run --cwd apps/keeweb build` still works (no regressions)
+
+## System-Wide Impact
+
+- **New dependencies**: `goke`, `zod`, `@goke/mcp`, `string-dedent` added to `packages/cli/package.json`. No impact on root or `apps/keeweb/` packages (workspace isolation).
+- **`bun.lock` update**: Lock file will change with new deps. CI uses `--frozen-lockfile` so the lock must be committed.
+- **Bin entry unchanged**: `"infra": "src/cli.ts"` stays the same — goke replaces the internals, not the entry point.
+- **No CI impact**: CLI is not part of any CI workflow. Build/deploy pipelines unaffected.
+- **MCP exposure surface**: `infra mcp` gives agents access to deploy triggers. The `--local` deploy requires `DEPLOY_SSH_KEY` in env, which limits blast radius to environments with the key present.
+
+## Risks & Dependencies
+
+- **`gh` CLI availability**: Status and remote deploy depend on `gh` being installed and authenticated. Mitigated by graceful fallback messaging with install instructions.
+- **goke stability**: v6.3.2, relatively young framework. Mitigated by zero-dep design (only `picocolors`) — easy to vendor or replace if abandoned.
+- **@goke/mcp maturity**: v0.0.9, pre-1.0. MCP bridge is a convenience, not a critical path. If it breaks, the CLI commands work standalone.
+- **Content hash comparison fragility**: Live site response may include dynamic headers or compression differences. Mitigate by comparing only the response body text, not headers.
+- **Production environment approval gate**: The Deploy workflow requires `production` environment approval. When `infra keeweb deploy` triggers `workflow_dispatch`, `gh` returns the run URL immediately but the job queues pending approval. The CLI should inform the user that the run is pending approval and provide the URL to approve it.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-03-cli-commands-requirements.md](../brainstorms/2026-04-03-cli-commands-requirements.md)
+- **goke SKILL.md:** https://raw.githubusercontent.com/remorses/goke/refs/heads/main/goke/SKILL.md
+- Related code: `packages/cli/src/cli.ts`, `apps/keeweb/deploy.sh`, `.github/workflows/deploy.yaml`
+- goke repo: https://github.com/remorses/goke

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,5 +9,11 @@
   },
   "scripts": {
     "cli": "bun run src/cli.ts"
+  },
+  "dependencies": {
+    "@goke/mcp": "^0.0.9",
+    "goke": "^6.3.2",
+    "string-dedent": "^3.0.2",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,45 +1,28 @@
 #!/usr/bin/env bun
 
-const VERSION = '0.0.0'
+import {goke} from 'goke'
+import pkg from '../package.json' with {type: 'json'}
+import {registerKeewebDeploy} from './commands/keeweb-deploy'
+import {registerKeewebStatus} from './commands/keeweb-status'
+import {registerMcp} from './commands/mcp'
 
-function showHelp() {
-  console.log(`infra ${VERSION}
+const cli = goke('infra')
 
-Infrastructure management CLI
+cli.option('--verbose', 'Enable verbose output for all commands')
 
-USAGE:
-  infra [COMMAND] [OPTIONS]
+registerKeewebStatus(cli)
+registerKeewebDeploy(cli)
+registerMcp(cli)
 
-COMMANDS:
-  keeweb      KeeWeb deployment management
-  help        Show this help message
-  --help      Show this help message
-  --version   Show version
+cli.help()
+cli.version(pkg.version)
 
-EXAMPLES:
-  infra --help
-  infra --version
-  infra keeweb
-`)
-}
-
-function showVersion() {
-  console.log(`infra ${VERSION}`)
-}
-
-const args = process.argv.slice(2)
-const command = args[0]
-
-if (!command || command === '--help' || command === 'help') {
-  showHelp()
-} else if (command === '--version') {
-  showVersion()
-} else if (command === 'keeweb') {
-  console.error('keeweb: not yet implemented')
-  process.exit(1)
-} else {
-  console.error(`error: unknown command '${command}'`)
-  console.error('')
-  showHelp()
+try {
+  cli.parse(process.argv, {run: false})
+  await cli.runMatchedCommand()
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message)
+  }
   process.exit(1)
 }

--- a/packages/cli/src/commands/keeweb-deploy.ts
+++ b/packages/cli/src/commands/keeweb-deploy.ts
@@ -1,0 +1,186 @@
+import type {goke} from 'goke'
+import {existsSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {z} from 'zod'
+
+const REPO = 'marcusrbrown/infra'
+const WORKFLOW_NAME = 'Deploy'
+const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy.yaml'
+
+const DEFAULT_HOST = 'box.heatvision.co'
+const DEFAULT_REMOTE_USER = 'deploy-kw'
+const DEFAULT_SITE_DIR = '/home/user-data/www/kw.igg.ms'
+
+type CliInstance = ReturnType<typeof goke>
+
+function resolveDeployScriptPath(): string {
+  const instructedPath = resolve(import.meta.dir, '../../../apps/keeweb/deploy.sh')
+
+  if (existsSync(instructedPath)) {
+    return instructedPath
+  }
+
+  const fallbackPath = resolve(import.meta.dir, '../../../../apps/keeweb/deploy.sh')
+
+  return fallbackPath
+}
+
+function resolveDistIndexPath(): string {
+  return resolve(import.meta.dir, '../../../../apps/keeweb/dist/index.html')
+}
+
+function getLocalDeployEnv(): Record<string, string> {
+  const path = process.env.PATH
+  const home = process.env.HOME
+  const sshAuthSock = process.env.SSH_AUTH_SOCK
+
+  if (!path) {
+    throw new Error('PATH is required for local deploy')
+  }
+
+  if (!home) {
+    throw new Error('HOME is required for local deploy')
+  }
+
+  if (!sshAuthSock) {
+    throw new Error('SSH_AUTH_SOCK is required for local deploy. Start ssh-agent and load your deploy key first.')
+  }
+
+  return {
+    HOST: process.env.HOST ?? DEFAULT_HOST,
+    REMOTE_USER: process.env.REMOTE_USER ?? DEFAULT_REMOTE_USER,
+    SITE_DIR: process.env.SITE_DIR ?? DEFAULT_SITE_DIR,
+    SSH_AUTH_SOCK: sshAuthSock,
+    PATH: path,
+    HOME: home,
+  }
+}
+
+function validateLocalPreconditions(options: {nginx?: boolean}): {deployScriptPath: string; distIndexPath: string} {
+  const deployScriptPath = resolveDeployScriptPath()
+  if (!existsSync(deployScriptPath)) {
+    throw new Error(`deploy.sh not found at expected path: ${deployScriptPath}`)
+  }
+
+  const distIndexPath = resolveDistIndexPath()
+  if (!existsSync(distIndexPath)) {
+    throw new Error(`Local deploy requires built assets. Missing: ${distIndexPath}`)
+  }
+
+  getLocalDeployEnv()
+
+  if (options.nginx) {
+    // no-op placeholder to keep validation branch explicit
+  }
+
+  return {deployScriptPath, distIndexPath}
+}
+
+function validateRemotePreconditions(): void {
+  if (!Bun.which('gh')) {
+    throw new Error('gh CLI is required for remote deploy. Install gh and run `gh auth login`.')
+  }
+}
+
+export function registerKeewebDeploy(cli: CliInstance): void {
+  cli
+    .command(
+      'keeweb deploy',
+      'Trigger KeeWeb deployment. Default mode dispatches the GitHub Deploy workflow. Use --local to run apps/keeweb/deploy.sh directly from this repo.',
+    )
+    .option(
+      '--local',
+      z
+        .boolean()
+        .default(false)
+        .describe('Run local deployment using apps/keeweb/deploy.sh instead of triggering GitHub Actions.'),
+    )
+    .option(
+      '--nginx',
+      z
+        .boolean()
+        .default(false)
+        .describe(
+          'Include nginx config deployment. Valid only with --local and passed through to deploy.sh as --nginx.',
+        ),
+    )
+    .option(
+      '--dry-run',
+      z
+        .boolean()
+        .default(false)
+        .describe(
+          'Validate preconditions and print planned actions without executing deploy.sh or triggering GitHub Actions.',
+        ),
+    )
+    .example('# Trigger GitHub Deploy workflow (default mode)')
+    .example('infra keeweb deploy')
+    .example('# Validate local deploy preconditions without side effects')
+    .example('infra keeweb deploy --local --dry-run')
+    .example('# Run local deploy including nginx config update')
+    .example('infra keeweb deploy --local --nginx')
+    .action(async options => {
+      if (options.nginx && !options.local) {
+        throw new Error('--nginx is only valid with --local')
+      }
+
+      if (options.local) {
+        const {deployScriptPath} = validateLocalPreconditions({nginx: options.nginx})
+        const env = getLocalDeployEnv()
+        const args = ['bash', deployScriptPath]
+
+        if (options.nginx) {
+          args.push('--nginx')
+        }
+
+        if (options.dryRun) {
+          console.log('Dry run: local KeeWeb deploy')
+          console.log(`- deploy script: ${deployScriptPath}`)
+          console.log(`- dist check: ${resolveDistIndexPath()}`)
+          console.log(`- command: ${args.join(' ')}`)
+          console.log(`- HOST=${env.HOST}`)
+          console.log(`- REMOTE_USER=${env.REMOTE_USER}`)
+          console.log(`- SITE_DIR=${env.SITE_DIR}`)
+          return
+        }
+
+        const child = Bun.spawn(args, {
+          env,
+          stdout: 'inherit',
+          stderr: 'inherit',
+        })
+
+        const exitCode = await child.exited
+        if (exitCode !== 0) {
+          throw new Error(`Local deploy failed with exit code ${exitCode}`)
+        }
+
+        return
+      }
+
+      validateRemotePreconditions()
+
+      console.warn('Warning: the Deploy workflow includes nginx config deployment as part of workflow_dispatch logic.')
+      console.warn('Warning: the workflow requires production environment approval before jobs execute.')
+
+      if (options.dryRun) {
+        console.log('Dry run: remote KeeWeb deploy')
+        console.log(`- command: gh workflow run ${WORKFLOW_NAME} --repo ${REPO}`)
+        console.log(`- workflow URL: ${WORKFLOW_URL}`)
+        return
+      }
+
+      const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+      })
+
+      const exitCode = await child.exited
+      if (exitCode !== 0) {
+        throw new Error(`Failed to trigger Deploy workflow (exit code ${exitCode})`)
+      }
+
+      console.log(`Workflow triggered: ${WORKFLOW_URL}`)
+      console.log('Approve the production environment deployment in GitHub Actions to continue.')
+    })
+}

--- a/packages/cli/src/commands/keeweb-status.ts
+++ b/packages/cli/src/commands/keeweb-status.ts
@@ -1,0 +1,290 @@
+import type {goke} from 'goke'
+
+import path from 'node:path'
+import {z} from 'zod'
+
+const SITE_URL = 'https://kw.igg.ms/'
+const GH_REPO = 'marcusrbrown/infra'
+const HTTP_TIMEOUT_MS = 10_000
+
+type CheckLevel = 'ok' | 'warning' | 'error'
+
+interface CheckResult {
+  title: string
+  level: CheckLevel
+  summary: string
+  details?: string[]
+}
+
+const ghRunSchema = z.array(
+  z.object({
+    createdAt: z.string().min(1),
+    url: z.url(),
+  }),
+)
+
+function levelLabel(level: CheckLevel): string {
+  if (level === 'ok') {
+    return 'OK'
+  }
+
+  if (level === 'warning') {
+    return 'WARN'
+  }
+
+  return 'ERROR'
+}
+
+function formatDurationMs(durationMs: number): string {
+  return `${Math.max(0, Math.round(durationMs))}ms`
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleString()
+}
+
+function hashSha256(value: string): string {
+  const hasher = new Bun.CryptoHasher('sha256')
+  hasher.update(value)
+  return hasher.digest('hex')
+}
+
+async function streamToText(stream?: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) {
+    return ''
+  }
+
+  return await new Response(stream).text()
+}
+
+async function checkHttpReachability(verbose: boolean): Promise<CheckResult> {
+  const startedAt = performance.now()
+
+  try {
+    const response = await fetch(SITE_URL, {
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    })
+    const elapsedMs = performance.now() - startedAt
+    const details: string[] = []
+
+    if (verbose) {
+      details.push(`URL: ${SITE_URL}`)
+      details.push(`Status text: ${response.statusText || '(none)'}`)
+
+      if (response.headers.get('content-type')) {
+        details.push(`Content-Type: ${response.headers.get('content-type')}`)
+      }
+
+      if (response.headers.get('server')) {
+        details.push(`Server: ${response.headers.get('server')}`)
+      }
+    }
+
+    return {
+      title: 'HTTP reachability',
+      level: response.ok ? 'ok' : 'error',
+      summary: `GET ${SITE_URL} → ${response.status} (${formatDurationMs(elapsedMs)})`,
+      details,
+    }
+  } catch (error) {
+    const elapsedMs = performance.now() - startedAt
+    const message = error instanceof Error ? error.message : String(error)
+
+    return {
+      title: 'HTTP reachability',
+      level: 'error',
+      summary: `Request failed after ${formatDurationMs(elapsedMs)}: ${message}`,
+      details: verbose ? [`URL: ${SITE_URL}`, `Timeout: ${HTTP_TIMEOUT_MS}ms`] : undefined,
+    }
+  }
+}
+
+async function checkLastDeploy(verbose: boolean): Promise<CheckResult> {
+  try {
+    const proc = Bun.spawn(
+      [
+        'gh',
+        'run',
+        'list',
+        '--workflow=Deploy',
+        '--status=success',
+        '--limit=1',
+        '--json',
+        'createdAt,url',
+        '--repo',
+        GH_REPO,
+      ],
+      {
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    )
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      streamToText(proc.stdout),
+      streamToText(proc.stderr),
+    ])
+
+    if (exitCode !== 0) {
+      const baseDetails = stderr.trim() ? [stderr.trim()] : []
+      const verboseDetails = verbose && stdout.trim() ? [...baseDetails, `Raw stdout: ${stdout.trim()}`] : baseDetails
+
+      return {
+        title: 'Last successful deploy',
+        level: 'warning',
+        summary: `Unable to query GitHub Actions (gh exited ${exitCode})`,
+        details: verboseDetails,
+      }
+    }
+
+    const parsed = ghRunSchema.safeParse(JSON.parse(stdout))
+    if (!parsed.success) {
+      return {
+        title: 'Last successful deploy',
+        level: 'warning',
+        summary: 'GitHub CLI output did not match expected schema',
+        details: verbose ? [parsed.error.message, `Raw stdout: ${stdout.trim()}`] : undefined,
+      }
+    }
+
+    const [latestRun] = parsed.data
+
+    if (!latestRun) {
+      return {
+        title: 'Last successful deploy',
+        level: 'warning',
+        summary: 'No successful Deploy workflow runs found',
+      }
+    }
+
+    const details = [`Run URL: ${latestRun.url}`]
+
+    if (verbose) {
+      details.push(`Raw createdAt: ${latestRun.createdAt}`)
+    }
+
+    return {
+      title: 'Last successful deploy',
+      level: 'ok',
+      summary: `${formatDate(latestRun.createdAt)}`,
+      details,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    return {
+      title: 'Last successful deploy',
+      level: 'warning',
+      summary: `Unable to query GitHub Actions: ${message}`,
+      details: verbose
+        ? ['Requires GitHub CLI authenticated with access to marcusrbrown/infra', 'Install: https://cli.github.com/']
+        : undefined,
+    }
+  }
+}
+
+async function checkContentHash(verbose: boolean): Promise<CheckResult> {
+  const distIndexPath = path.resolve(import.meta.dir, '../../../../apps/keeweb/dist/index.html')
+  const localFile = Bun.file(distIndexPath)
+  const localExists = await localFile.exists()
+
+  if (!localExists) {
+    return {
+      title: 'Content hash',
+      level: 'warning',
+      summary: `Local dist file not found: ${distIndexPath}`,
+      details: ['Run: bun run --cwd apps/keeweb build'],
+    }
+  }
+
+  try {
+    const response = await fetch(SITE_URL, {
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+      return {
+        title: 'Content hash',
+        level: 'warning',
+        summary: `Could not fetch remote index.html (HTTP ${response.status})`,
+        details: verbose ? [`URL: ${SITE_URL}`] : undefined,
+      }
+    }
+
+    const [remoteBody, localBody] = await Promise.all([response.text(), localFile.text()])
+    const remoteHash = hashSha256(remoteBody)
+    const localHash = hashSha256(localBody)
+
+    const details = verbose ? [`Remote SHA-256: ${remoteHash}`, `Local SHA-256: ${localHash}`] : undefined
+
+    if (remoteHash === localHash) {
+      return {
+        title: 'Content hash',
+        level: 'ok',
+        summary: 'Remote index.html matches local dist/index.html',
+        details,
+      }
+    }
+
+    return {
+      title: 'Content hash',
+      level: 'warning',
+      summary: 'Remote index.html differs from local dist/index.html',
+      details,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      title: 'Content hash',
+      level: 'warning',
+      summary: `Could not compare hashes: ${message}`,
+      details: verbose ? [`URL: ${SITE_URL}`, `Local path: ${distIndexPath}`] : undefined,
+    }
+  }
+}
+
+function printCheckResult(result: CheckResult): void {
+  console.log(`[${levelLabel(result.level)}] ${result.title}`)
+  console.log(`  ${result.summary}`)
+
+  if (result.details && result.details.length > 0) {
+    for (const detail of result.details) {
+      console.log(`  - ${detail}`)
+    }
+  }
+}
+
+export function registerKeewebStatus(cli: ReturnType<typeof goke>): void {
+  cli.command('keeweb status', 'Show operational health of the KeeWeb deployment').action(async options => {
+    const verbose = options.verbose === true
+
+    console.log('KeeWeb status')
+    console.log('')
+
+    const results = await Promise.all([
+      checkHttpReachability(verbose),
+      checkLastDeploy(verbose),
+      checkContentHash(verbose),
+    ])
+
+    for (const result of results) {
+      printCheckResult(result)
+      console.log('')
+    }
+
+    const errorCount = results.filter(result => result.level === 'error').length
+    const warningCount = results.filter(result => result.level === 'warning').length
+
+    console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
+
+    if (errorCount > 0) {
+      process.exitCode = 1
+    }
+  })
+}

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,8 @@
+import type {goke} from 'goke'
+import {createMcpAction} from '@goke/mcp'
+
+export function registerMcp(cli: ReturnType<typeof goke>): void {
+  cli
+    .command('mcp', 'Start a stdio MCP server exposing all CLI commands as tools for coding agents')
+    .action(createMcpAction({cli}))
+}


### PR DESCRIPTION
## Summary

Replace the stub CLI with working `goke`-based commands for KeeWeb operations and MCP bridge.

- **`infra keeweb status`** — 3 independent health checks: HTTP reachability (kw.igg.ms), last deploy timestamp (via `gh` CLI), SHA-256 content hash comparison
- **`infra keeweb deploy`** — trigger GitHub Actions workflow (default) or local deploy.sh with `--local` flag. Explicit env allowlist, SSH_AUTH_SOCK validation, nginx deploy warning
- **`infra mcp`** — stdio MCP server via `@goke/mcp` exposing all commands as tools for coding agents

## Key decisions from planning

- **goke framework** (v6.3.2): type-safe, Zod schemas, space-separated subcommands, MCP bridge built-in
- **SSH_AUTH_SOCK** for local deploy (not raw DEPLOY_SSH_KEY) — deploy.sh uses ssh/rsync which require an agent
- **Explicit env allowlist** when spawning deploy.sh — only HOST, REMOTE_USER, SITE_DIR, SSH_AUTH_SOCK, PATH, HOME
- **Construct workflow URL directly** — `gh workflow run` returns no URL, avoids race condition from `gh run list`
- **--dry-run is CLI-level** — deploy.sh has no dry-run support

## New dependencies (packages/cli only)

`goke`, `zod`, `@goke/mcp`, `string-dedent`

## Verification

- `infra --help` ✅
- `infra keeweb status` ✅ (all 3 checks passing)
- `infra keeweb deploy --dry-run` ✅
- `infra keeweb deploy --help` ✅
- `infra mcp --help` ✅
- `bunx tsc --noEmit` ✅
- `bun run lint` ✅
- `bun run --cwd apps/keeweb build` ✅

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: CLI is a local development tool, not deployed to production. No CI workflow changes.