### PR TITLE
fix(release): use app bot identity for changesets commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
+          setupGitUser: false
           commit: 'chore(changesets): version packages'
           title: 'chore(🦋📦): version packages'
           version: bun run version-changesets


### PR DESCRIPTION
## Summary

- Set `setupGitUser: false` on `changesets/action` so it uses the `mrbro-bot[bot]` git identity configured earlier in the workflow instead of overriding with `github-actions[bot]`

## Context

The Release workflow already configures git user as `mrbro-bot[bot]` via the GitHub App token, but `changesets/action` defaults `setupGitUser: true` which overwrites it with `github-actions[bot]`.