### PR TITLE
fix(cli): check --dry-run before validating preconditions

### DIFF
--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -16,7 +16,7 @@ Commands:
 
     --local      Run local deployment using apps/keeweb/deploy.sh instead of triggering GitHub Actions. (default: false)
     --nginx      Include nginx config deployment. Valid only with --local and passed through to deploy.sh as --nginx. (default: false)
-    --dry-run    Validate preconditions and print planned actions without executing deploy.sh or triggering GitHub Actions. (default: false)
+    --dry-run    Print planned actions without validating preconditions, executing deploy.sh, or triggering GitHub Actions. (default: false)
 
 
   mcp            Start a stdio MCP server exposing all CLI commands as tools for coding agents

--- a/packages/cli/src/commands/keeweb-deploy.test.ts
+++ b/packages/cli/src/commands/keeweb-deploy.test.ts
@@ -1,6 +1,5 @@
-import {mkdir, rm, writeFile} from 'node:fs/promises'
-import {dirname, resolve} from 'node:path'
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn} from 'bun:test'
+import {resolve} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
 import {
   getLocalDeployEnv,
@@ -163,17 +162,6 @@ describe('keeweb deploy', () => {
   })
 
   describe('CLI flag interactions', () => {
-    const distIndexPath = resolveDistIndexPath()
-
-    beforeAll(async () => {
-      await mkdir(dirname(distIndexPath), {recursive: true})
-      await writeFile(distIndexPath, '<html></html>')
-    })
-
-    afterAll(async () => {
-      await rm(distIndexPath, {force: true})
-    })
-
     it('rejects --nginx without --local', async () => {
       const {stdout, stderr, exitCode} = await runDeployCommand(['--nginx'])
 

--- a/packages/cli/src/commands/keeweb-deploy.ts
+++ b/packages/cli/src/commands/keeweb-deploy.ts
@@ -113,12 +113,12 @@ export function registerKeewebDeploy(cli: CliInstance): void {
         .boolean()
         .default(false)
         .describe(
-          'Validate preconditions and print planned actions without executing deploy.sh or triggering GitHub Actions.',
+          'Print planned actions without validating preconditions, executing deploy.sh, or triggering GitHub Actions.',
         ),
     )
     .example('# Trigger GitHub Deploy workflow (default mode)')
     .example('infra keeweb deploy')
-    .example('# Validate local deploy preconditions without side effects')
+    .example('# Preview local deploy plan without side effects')
     .example('infra keeweb deploy --local --dry-run')
     .example('# Run local deploy including nginx config update')
     .example('infra keeweb deploy --local --nginx')
@@ -128,23 +128,25 @@ export function registerKeewebDeploy(cli: CliInstance): void {
       }
 
       if (options.local) {
+        if (options.dryRun) {
+          const deployScriptPath = resolveDeployScriptPath()
+          const args = ['bash', deployScriptPath]
+          if (options.nginx) {
+            args.push('--nginx')
+          }
+          console.log('Dry run: local KeeWeb deploy')
+          console.log(`- deploy script: ${deployScriptPath}`)
+          console.log(`- dist check: ${resolveDistIndexPath()}`)
+          console.log(`- command: ${args.join(' ')}`)
+          return
+        }
+
         const {deployScriptPath} = validateLocalPreconditions({nginx: options.nginx})
         const env = getLocalDeployEnv()
         const args = ['bash', deployScriptPath]
 
         if (options.nginx) {
           args.push('--nginx')
-        }
-
-        if (options.dryRun) {
-          console.log('Dry run: local KeeWeb deploy')
-          console.log(`- deploy script: ${deployScriptPath}`)
-          console.log(`- dist check: ${resolveDistIndexPath()}`)
-          console.log(`- command: ${args.join(' ')}`)
-          console.log(`- HOST=${env.HOST}`)
-          console.log(`- REMOTE_USER=${env.REMOTE_USER}`)
-          console.log(`- SITE_DIR=${env.SITE_DIR}`)
-          return
         }
 
         const child = Bun.spawn(args, {
@@ -161,17 +163,17 @@ export function registerKeewebDeploy(cli: CliInstance): void {
         return
       }
 
-      validateRemotePreconditions()
-
-      console.warn('Warning: the Deploy workflow includes nginx config deployment as part of workflow_dispatch logic.')
-      console.warn('Warning: the workflow requires production environment approval before jobs execute.')
-
       if (options.dryRun) {
         console.log('Dry run: remote KeeWeb deploy')
         console.log(`- command: gh workflow run ${WORKFLOW_NAME} --repo ${REPO}`)
         console.log(`- workflow URL: ${WORKFLOW_URL}`)
         return
       }
+
+      validateRemotePreconditions()
+
+      console.warn('Warning: the Deploy workflow includes nginx config deployment as part of workflow_dispatch logic.')
+      console.warn('Warning: the workflow requires production environment approval before jobs execute.')
 
       const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
         stdout: 'inherit',


### PR DESCRIPTION
## Summary
- Move `--dry-run` check before `validateLocalPreconditions` and `validateRemotePreconditions` so dry-run works on fresh checkouts without build artifacts or env setup
- Update `--dry-run` description: "Print planned actions without validating preconditions..."
- Remove `dist/index.html` fixture workaround from deploy test — no longer needed

## Problem
`keeweb deploy --local --dry-run` failed in CI because `validateLocalPreconditions()` checked for `dist/index.html` before the dry-run could short-circuit. A user running `--dry-run` on a fresh checkout should see the plan, not get an error about missing build artifacts.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `--local --dry-run` (no dist/) | ❌ Error: Missing dist/index.html | ✅ Prints plan |
| `--dry-run` (no gh CLI) | ❌ Error: gh CLI required | ✅ Prints plan |
| `--local` (no dist/) | ❌ Error (correct) | ❌ Error (unchanged) |

## Testing
- `bun test --recursive`: 35 pass, 0 fail, ~725ms
- Manual QA: `keeweb deploy --local --dry-run` succeeds without `dist/index.html`
- Manual QA: `keeweb deploy --dry-run` succeeds without `gh` (prints plan only)
- `bun run lint`: clean
- `bunx tsc --noEmit`: clean

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CLI behavior change only — dry-run prints informational output, no side effects.