### PR TITLE
docs: update AGENTS.md, README, and add 0.2.0 changeset

### DIFF
--- a/.changeset/test-infra-dry-run.md
+++ b/.changeset/test-infra-dry-run.md
@@ -1,0 +1,11 @@
+---
+'@marcusrbrown/infra': minor
+---
+
+Add test infrastructure and fix --dry-run behavior
+
+- First test suite: 35 tests across CLI commands, build pipeline, deploy contracts, and status checks
+- Wire Bun's built-in test runner into CI as a parallel job alongside lint and type-check
+- Fix `--dry-run` to print the deploy plan without requiring build artifacts or environment setup
+- Export internal functions with path-override parameters for testability
+- Add `import.meta.main` guard on `build.ts` for safe test imports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-04-03
-**Commit:** d820e4d
+**Generated:** 2026-04-05
+**Commit:** main
 **Branch:** main
 
 ## OVERVIEW
@@ -12,6 +12,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation 
 
 ```text
 ├── apps/keeweb/        KeeWeb deploy package (see apps/keeweb/AGENTS.md)
+├── apps/cliproxy/      CLIProxyAPI deployment (scaffolded, not yet deployed)
 ├── packages/cli/       @marcusrbrown/infra CLI (see packages/cli/AGENTS.md)
 ├── docs/               Brainstorms → plans → solutions (compound learning)
 ├── .changeset/         Changesets config for versioning
@@ -47,7 +48,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation 
 - **Cross-org reusable workflows**: Pass secrets explicitly (never `secrets: inherit` with `bfra-me/.github`).
 - **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root.
 - **Changesets**: `@changesets/cli` for versioning. Renovate PRs get auto-generated changeset files.
-- **No tests yet**: CI checks lint + typecheck only.
+- **Tests**: Colocated `*.test.ts` alongside source. Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic snapshots. Mock at boundaries (fetch, Bun.spawn), not internals. CI runs `bun test --recursive` as a parallel job alongside lint/type-check.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
@@ -72,6 +73,8 @@ bun install                                    # Install dependencies
 bun run lint                                   # ESLint check
 bun run fix                                    # ESLint --fix (includes Prettier)
 bunx tsc --noEmit                              # Type check
+bun test --recursive                           # Run all tests (from repo root)
+bun test                                       # Run tests in current package
 bun run --cwd apps/keeweb build                # Build KeeWeb dist
 bash apps/keeweb/deploy.sh                     # Deploy content only
 bash apps/keeweb/deploy.sh --nginx             # Deploy content + nginx config

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Personal infrastructure management — deploy automation, operational CLI, and t
 
 Bun workspace monorepo for managing personal infrastructure. Hosts KeeWeb deploy automation with CI/CD, and a CLI for operational health checks, deploy triggers, and MCP tool exposure.
 
-| Package        | Description                                  |
-| -------------- | -------------------------------------------- |
-| `apps/keeweb`  | KeeWeb v1.18.7 static site deploy automation |
-| `packages/cli` | `@marcusrbrown/infra` CLI                    |
+| Package         | Description                                  |
+| --------------- | -------------------------------------------- |
+| `apps/keeweb`   | KeeWeb v1.18.7 static site deploy automation |
+| `apps/cliproxy` | CLIProxyAPI deployment (scaffolded)          |
+| `packages/cli`  | `@marcusrbrown/infra` CLI                    |
 
 ## Prerequisites
 
@@ -22,6 +23,9 @@ Bun workspace monorepo for managing personal infrastructure. Hosts KeeWeb deploy
 
 ```bash
 bun install
+bun run lint
+bunx tsc --noEmit
+bun test --recursive
 ```
 
 ## Apps
@@ -80,7 +84,7 @@ bunx @marcusrbrown/infra keeweb status
 
 ```bash
 bunx @marcusrbrown/infra keeweb deploy              # trigger GitHub Actions workflow
-bunx @marcusrbrown/infra keeweb deploy --dry-run     # preview without executing
+bunx @marcusrbrown/infra keeweb deploy --dry-run     # preview plan without validating preconditions
 bunx @marcusrbrown/infra keeweb deploy --local       # deploy directly via SSH
 bunx @marcusrbrown/infra keeweb deploy --local --nginx  # include nginx config
 ```
@@ -101,7 +105,7 @@ This lets coding agents (Fro Bot, Copilot) call `keeweb status` and `keeweb depl
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| **CI** | PRs to `main` | Lint + type check |
+| **CI** | PRs to `main` | Lint, type check, and test |
 | **Deploy** | Push to `main` (keeweb changes), `workflow_dispatch` | Build and deploy KeeWeb |
 | **Release** | Push to `main` | Version packages via Changesets |
 | **Renovate** | Push, issue/PR edits, post-deploy | Automated dependency updates |
@@ -128,14 +132,15 @@ Deploys require approval through the `production` GitHub Environment.
 
 **Repository secrets** (`APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`):
 
-| Secret                    | Description                                                        |
-| ------------------------- | ------------------------------------------------------------------ |
-| `APPLICATION_ID`          | GitHub App ID for Renovate and repo settings sync                  |
-| `APPLICATION_PRIVATE_KEY` | GitHub App private key                                             |
-| `FRO_BOT_PAT`             | PAT for the fro-bot user (AI agent identity for @fro-bot mentions) |
-| `OPENCODE_AUTH_JSON`      | LLM provider auth JSON (e.g. `{"anthropic":{"apiKey":"..."}}}`)    |
-| `NPM_TOKEN`               | npm publish token for `@marcusrbrown/infra` package                |
-| `OMO_PROVIDERS`           | OhMyOpenCode provider configuration                                |
+| Secret                      | Description                                                        |
+| --------------------------- | ------------------------------------------------------------------ |
+| `APPLICATION_ID`            | GitHub App ID for Renovate and repo settings sync                  |
+| `APPLICATION_PRIVATE_KEY`   | GitHub App private key                                             |
+| `FRO_BOT_PAT`               | PAT for the fro-bot user (AI agent identity for @fro-bot mentions) |
+| `OPENCODE_AUTH_JSON`        | LLM provider auth JSON (e.g. `{"anthropic":{"apiKey":"..."}}}`)    |
+| `NPM_TOKEN`                 | npm publish token for `@marcusrbrown/infra` package                |
+| `OMO_PROVIDERS`             | OhMyOpenCode provider configuration                                |
+| `DIGITALOCEAN_ACCESS_TOKEN` | API token for DigitalOcean management                              |
 
 **Repository variables:**
 
@@ -159,13 +164,17 @@ bun run apps/keeweb/server/setup-deploy-user.ts
 │   ├── config/              Config templates (nginx, app config)
 │   ├── server/              Server provisioning scripts
 │   └── deploy.sh            SSH/rsync deploy script
+├── apps/cliproxy/           CLIProxyAPI deployment (scaffolded)
 ├── packages/cli/            @marcusrbrown/infra CLI
 │   └── src/
 │       ├── cli.ts           Entry point (goke framework)
+│       ├── cli.test.ts      CLI snapshot + discovery tests
 │       └── commands/        Command modules
 │           ├── keeweb-status.ts
 │           ├── keeweb-deploy.ts
 │           └── mcp.ts
+├── .agents/
+│   └── skills/              Agent skill context packets
 ├── .github/
 │   ├── copilot-instructions.md  Copilot coding agent instructions
 │   ├── known_hosts          Pinned SSH host keys
@@ -179,6 +188,15 @@ bun run apps/keeweb/server/setup-deploy-user.ts
 └── .opencode/
     └── commands/            OpenCode slash commands
 ```
+
+## Testing
+
+```bash
+bun test --recursive  # Run all tests from repo root
+bun test              # Run tests in current package
+```
+
+Tests are colocated alongside source files (`*.test.ts`). Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Tests mock at boundaries (fetch, Bun.spawn) and use `NO_COLOR=1` for deterministic subprocess output. CI runs tests as a parallel job alongside lint and type-check.
 
 ## Development
 

--- a/apps/keeweb/AGENTS.md
+++ b/apps/keeweb/AGENTS.md
@@ -11,6 +11,7 @@ Self-hosted KeeWeb v1.18.7 password manager at `kw.igg.ms`. Download-based build
 | Change app config template | `config/config.json` | Never put real secrets here |
 | Modify deploy behavior | `deploy.sh` | Content-only by default |
 | Re-provision server user | `server/setup-deploy-user.ts` | Run via `bun run` locally, SSHes into server |
+| Build tests | `src/build.test.ts` | Colocated alongside `build.ts` |
 
 ## BUILD FLOW
 
@@ -21,6 +22,8 @@ Self-hosted KeeWeb v1.18.7 password manager at `kw.igg.ms`. Download-based build
 5. `config/kw.igg.ms.conf` copied to `dist/`
 
 **Critical**: `config/config.json` (template) is never modified. Secret only goes into `dist/config.json`.
+
+**Testability**: `build.ts` exports `buildKeeweb(options?)` and guards its top-level execution with `import.meta.main` so tests can import it without triggering a build. Fixtures in `src/__fixtures__/` (e.g., `test-archive.zip`) stand in for real downloads.
 
 ## DEPLOY FLOW
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -9,6 +9,8 @@ Published to npm as [`@marcusrbrown/infra`](https://www.npmjs.com/package/@marcu
 | Add new command | `src/commands/<name>.ts` | Export `register<Name>(cli)`, import in cli.ts |
 | Modify CLI skeleton | `src/cli.ts` | Global options, parse pattern, command registration |
 | Change goke patterns | goke SKILL.md | `https://raw.githubusercontent.com/remorses/goke/refs/heads/main/goke/SKILL.md` |
+| CLI tests | `src/cli.test.ts` | Snapshots in `src/__snapshots__/` |
+| Command tests | `src/commands/<name>.test.ts` | Colocated alongside each command |
 
 ## COMMAND PATTERN
 
@@ -30,6 +32,8 @@ Space-separated subcommands: `cli.command('keeweb status', '...')`. Zod schemas 
 - Parse `gh` JSON output through Zod schemas before use
 - SHA-256 via `Bun.CryptoHasher('sha256')`, not crypto module
 - Resolve paths with `import.meta.dir` + `path.resolve()` — validate existence before use
+- **`--dry-run` semantics**: prints the plan/action that would be taken without executing it. Does NOT validate preconditions (e.g., build artifacts, env vars, ssh-agent). Safe to run anywhere.
+- **Tests**: colocated `*.test.ts` files. Snapshots in `src/__snapshots__/`. Use `NO_COLOR=1` in subprocess env when spawning the CLI to get deterministic output. Mock `fetch` and `Bun.spawn` at the boundary, not internals.
 
 ## ANTI-PATTERNS
 


### PR DESCRIPTION
## Summary
- Update all 3 AGENTS.md files with test conventions, cliproxy, and recent changes
- Update README with testing section, cliproxy package, `DIGITALOCEAN_ACCESS_TOKEN`, `.agents/` directory
- Add changeset for `@marcusrbrown/infra` 0.2.0 (test infra + dry-run fix)

## Changes

### AGENTS.md Updates
- **Root**: Test conventions (colocated files, fixtures, `NO_COLOR=1`, mock at boundaries), test commands, cliproxy in structure
- **apps/keeweb**: `import.meta.main` guard, `build.test.ts` reference, testability section
- **packages/cli**: `--dry-run` semantics (prints plan, no precondition validation), test conventions

### README Updates
- Added `apps/cliproxy` to packages table (scaffolded)
- Added Testing section with conventions and commands
- Updated CI workflow description: "Lint, type check, and test"
- Updated `--dry-run` description: "preview plan without validating preconditions"
- Added `DIGITALOCEAN_ACCESS_TOKEN` to repo secrets table
- Added `.agents/skills/` to repository structure tree
- Added quick start commands (lint, tsc, test)

### Changeset
Minor bump for `@marcusrbrown/infra` → 0.2.0 covering PRs #26 and #27

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: documentation and changeset only.