### PR TITLE
fix(test): make CLI help snapshot version-agnostic

### DIFF
--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`infra CLI shows root help with registered top-level commands 1`] = `
-"infra/0.1.0
+"infra/x.x.x
 
 
 Usage:

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -28,7 +28,9 @@ describe('infra CLI', () => {
     expect(stderr).toBe('')
     expect(stdout).toContain('keeweb')
     expect(stdout).toContain('mcp')
-    expect(stdout).toMatchSnapshot()
+    // Normalize version so snapshot survives changeset bumps
+    const stableOutput = stdout.replace(/infra\/\d+\.\d+\.\d+/, 'infra/x.x.x')
+    expect(stableOutput).toMatchSnapshot()
   })
 
   it('shows keeweb deploy help with expected flags', async () => {


### PR DESCRIPTION
## Summary
Normalize the version string in CLI help output before snapshotting so the test survives changeset version bumps.

## Problem
PR #30 (changeset release) fails CI because `changeset version` bumps `package.json` to `0.2.0`, but the snapshot expects `infra/0.1.0`. This will recur on every version bump.

## Fix
Replace `infra/X.Y.Z` with `infra/x.x.x` via regex before `toMatchSnapshot()`. The version line is still asserted to exist (it's part of the output), just not pinned to a specific value.

## Testing
- `bun test --recursive`: 35 pass, 0 fail
- Snapshot contains `infra/x.x.x` — confirmed version-agnostic
- `bun run lint`: clean

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: test infrastructure change only.