### PR TITLE
refactor(cliproxy): remove CLIPROXY_HOST, use CLIPROXY_DOMAIN everywhere

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -99,7 +99,6 @@ jobs:
       - name: Deploy cliproxy
         run: bun run --cwd apps/cliproxy deploy
         env:
-          CLIPROXY_HOST: ${{ secrets.CLIPROXY_HOST }}
           CLIPROXY_DOMAIN: ${{ secrets.CLIPROXY_DOMAIN }}
           CLIPROXY_MANAGEMENT_KEY: ${{ secrets.CLIPROXY_MANAGEMENT_KEY }}
 

--- a/apps/cliproxy/src/deploy.ts
+++ b/apps/cliproxy/src/deploy.ts
@@ -11,7 +11,6 @@ interface DeployEnv {
   PATH: string
   HOME: string
   SSH_AUTH_SOCK: string
-  CLIPROXY_HOST: string
   CLIPROXY_DOMAIN: string
   CLIPROXY_MANAGEMENT_KEY: string
 }
@@ -30,7 +29,7 @@ function getDeployEnv(): DeployEnv {
   const path = process.env.PATH
   const home = process.env.HOME
   const sshAuthSock = process.env.SSH_AUTH_SOCK
-  const host = process.env.CLIPROXY_HOST
+  const host = process.env.CLIPROXY_DOMAIN
 
   if (!path) {
     throw new Error('PATH is required for deploy')
@@ -45,15 +44,14 @@ function getDeployEnv(): DeployEnv {
   }
 
   if (!host) {
-    throw new Error('CLIPROXY_HOST is required for deploy.')
+    throw new Error('CLIPROXY_DOMAIN is required for deploy.')
   }
 
   return {
     PATH: path,
     HOME: home,
     SSH_AUTH_SOCK: sshAuthSock,
-    CLIPROXY_HOST: host,
-    CLIPROXY_DOMAIN: process.env.CLIPROXY_DOMAIN ?? '',
+    CLIPROXY_DOMAIN: host,
     CLIPROXY_MANAGEMENT_KEY: process.env.CLIPROXY_MANAGEMENT_KEY ?? '',
   }
 }
@@ -121,7 +119,7 @@ function scpCommand(host: string, source: string, destination: string): string[]
 }
 
 async function healthCheck(env: DeployEnv): Promise<void> {
-  const host = env.CLIPROXY_DOMAIN || env.CLIPROXY_HOST
+  const host = env.CLIPROXY_DOMAIN
   const url = `https://${host}/v0/management/latest-version`
 
   const headers = new Headers()
@@ -142,7 +140,7 @@ async function healthCheck(env: DeployEnv): Promise<void> {
 async function deploy(): Promise<void> {
   const files = validatePreconditions()
   const env = getDeployEnv()
-  const host = env.CLIPROXY_HOST
+  const host = env.CLIPROXY_DOMAIN
 
   await runCommand('Creating remote directories', sshCommand(host, `mkdir -p ${REMOTE_DIR}/config`), env)
   await runCommand(

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -63,7 +63,7 @@ Commands:
 
   cliproxy login <provider>          Run provider login on the remote CLIProxyAPI host and print OAuth URL output.
 
-    --host [host]                    CLIProxyAPI droplet host for SSH execution. Falls back to CLIPROXY_HOST or cliproxy.fro.bot.
+    --host [host]                    CLIProxyAPI droplet host for SSH execution. Falls back to CLIPROXY_DOMAIN or cliproxy.fro.bot.
 
 
   mcp                                Start a stdio MCP server exposing all CLI commands as tools for coding agents

--- a/packages/cli/src/commands/cliproxy-config.test.ts
+++ b/packages/cli/src/commands/cliproxy-config.test.ts
@@ -122,28 +122,28 @@ describe('cliproxy keys helpers', () => {
 
 describe('cliproxy login helpers', () => {
   describe('resolveHost', () => {
-    const originalHost = process.env.CLIPROXY_HOST
+    const originalHost = process.env.CLIPROXY_DOMAIN
 
     beforeEach(() => {
-      delete process.env.CLIPROXY_HOST
+      delete process.env.CLIPROXY_DOMAIN
     })
 
     afterEach(() => {
       if (originalHost === undefined) {
-        delete process.env.CLIPROXY_HOST
+        delete process.env.CLIPROXY_DOMAIN
       } else {
-        process.env.CLIPROXY_HOST = originalHost
+        process.env.CLIPROXY_DOMAIN = originalHost
       }
     })
 
     it('returns explicit input when provided', () => {
-      process.env.CLIPROXY_HOST = 'env.example.com'
+      process.env.CLIPROXY_DOMAIN = 'env.example.com'
 
       expect(resolveHost('explicit.example.com')).toBe('explicit.example.com')
     })
 
-    it('falls back to CLIPROXY_HOST', () => {
-      process.env.CLIPROXY_HOST = 'env.example.com'
+    it('falls back to CLIPROXY_DOMAIN', () => {
+      process.env.CLIPROXY_DOMAIN = 'env.example.com'
 
       expect(resolveHost()).toBe('env.example.com')
     })

--- a/packages/cli/src/commands/cliproxy-deploy.test.ts
+++ b/packages/cli/src/commands/cliproxy-deploy.test.ts
@@ -5,14 +5,7 @@ import {getLocalDeployEnv, resolveLocalDeployScriptPath, validateRemotePrecondit
 
 const cliDir = resolve(import.meta.dir, '../..')
 
-const envKeys = [
-  'CLIPROXY_DOMAIN',
-  'CLIPROXY_HOST',
-  'CLIPROXY_MANAGEMENT_KEY',
-  'HOME',
-  'PATH',
-  'SSH_AUTH_SOCK',
-] as const
+const envKeys = ['CLIPROXY_DOMAIN', 'CLIPROXY_MANAGEMENT_KEY', 'HOME', 'PATH', 'SSH_AUTH_SOCK'] as const
 
 type ManagedEnvKey = (typeof envKeys)[number]
 
@@ -103,7 +96,6 @@ describe('cliproxy deploy', () => {
     it('returns the expected deploy environment when required variables are present', () => {
       setManagedEnv({
         CLIPROXY_DOMAIN: 'cliproxy.example.com',
-        CLIPROXY_HOST: 'example-host',
         CLIPROXY_MANAGEMENT_KEY: 'test-management-key',
         HOME: '/tmp/test-home',
         PATH: '/usr/bin:/bin',
@@ -112,7 +104,6 @@ describe('cliproxy deploy', () => {
 
       expect(getLocalDeployEnv()).toEqual({
         CLIPROXY_DOMAIN: 'cliproxy.example.com',
-        CLIPROXY_HOST: 'example-host',
         CLIPROXY_MANAGEMENT_KEY: 'test-management-key',
         HOME: '/tmp/test-home',
         PATH: '/usr/bin:/bin',
@@ -178,7 +169,7 @@ describe('cliproxy deploy', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('Dry run: local CLIProxyAPI deploy')
       expect(stdout).toContain(deployScriptPath)
-      expect(stdout).toContain('CLIPROXY_HOST=')
+      expect(stdout).toContain('CLIPROXY_DOMAIN=')
     })
 
     it('rejects invalid options with a non-zero exit code', async () => {

--- a/packages/cli/src/commands/cliproxy-deploy.ts
+++ b/packages/cli/src/commands/cliproxy-deploy.ts
@@ -40,7 +40,6 @@ export function getLocalDeployEnv(): Record<string, string> {
     PATH: path,
     HOME: home,
     SSH_AUTH_SOCK: sshAuthSock,
-    CLIPROXY_HOST: process.env.CLIPROXY_HOST ?? '',
     CLIPROXY_DOMAIN: process.env.CLIPROXY_DOMAIN ?? '',
     CLIPROXY_MANAGEMENT_KEY: process.env.CLIPROXY_MANAGEMENT_KEY ?? '',
   }
@@ -103,7 +102,7 @@ export function registerCliproxyDeploy(cli: CliInstance): void {
           console.log('Dry run: local CLIProxyAPI deploy')
           console.log(`- deploy script: ${deployScriptPath}`)
           console.log(`- command: ${command.join(' ')}`)
-          console.log(`- CLIPROXY_HOST=${env.CLIPROXY_HOST || '(unset)'}`)
+          console.log(`- CLIPROXY_DOMAIN=${env.CLIPROXY_DOMAIN || '(unset)'}`)
           return
         }
 

--- a/packages/cli/src/commands/cliproxy-login.ts
+++ b/packages/cli/src/commands/cliproxy-login.ts
@@ -6,10 +6,10 @@ const DEFAULT_HOST = 'cliproxy.fro.bot'
 const DEFAULT_REMOTE_USER = 'root'
 
 export function resolveHost(input?: string): string {
-  const host = input ?? process.env.CLIPROXY_HOST ?? DEFAULT_HOST
+  const host = input ?? process.env.CLIPROXY_DOMAIN ?? DEFAULT_HOST
 
   if (!host) {
-    throw new Error('CLIPROXY_HOST is required. Pass --host or set CLIPROXY_HOST.')
+    throw new Error('CLIPROXY_DOMAIN is required. Pass --host or set CLIPROXY_DOMAIN.')
   }
 
   return host
@@ -34,7 +34,7 @@ export function registerCliproxyLogin(cli: ReturnType<typeof goke>): void {
       '--host [host]',
       z
         .string()
-        .describe('CLIProxyAPI droplet host for SSH execution. Falls back to CLIPROXY_HOST or cliproxy.fro.bot.'),
+        .describe('CLIProxyAPI droplet host for SSH execution. Falls back to CLIPROXY_DOMAIN or cliproxy.fro.bot.'),
     )
     .example('# Start Claude login flow on remote CLIProxyAPI instance')
     .example('infra cliproxy login claude')


### PR DESCRIPTION
## Summary
Remove `CLIPROXY_HOST` — unnecessary indirection. The domain IS the host.

## Changes
- `deploy.yaml`: Remove `CLIPROXY_HOST` env var, use only `CLIPROXY_DOMAIN`
- `deploy.ts`: Replace `CLIPROXY_HOST` with `CLIPROXY_DOMAIN` in env interface and validation
- `cliproxy-deploy.ts`: Use `CLIPROXY_DOMAIN` in env allowlist and dry-run output
- `cliproxy-login.ts`: Fall back to `CLIPROXY_DOMAIN` instead of `CLIPROXY_HOST`
- All tests + snapshot updated

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: env var rename only — same secret value, same behavior.