### PR TITLE
fix(cliproxy): add auth-dir config for OAuth token storage

### DIFF
--- a/apps/cliproxy/config/config.yaml
+++ b/apps/cliproxy/config/config.yaml
@@ -1,6 +1,7 @@
 # Real values injected at deploy time via env vars. Do not commit secrets.
 host: ''
 port: 8317
+auth-dir: /root/.cli-proxy-api
 
 remote-management:
   allow-remote: true


### PR DESCRIPTION
## Summary
Add `auth-dir: /root/.cli-proxy-api` to `config.yaml` — CLIProxyAPI crashes on startup without it.

## Root Cause
`cli-proxy-api` container exits immediately with:
```
failed to create auth directory : mkdir : no such file or directory
```
The Docker volume mounts `/root/.cli-proxy-api` but the config never tells the app to use that path.

## Post-Deploy Monitoring & Validation
After merge, `cli-proxy-api` container should stay running. Caddy should return 200 instead of 502. Verify with `bunx @marcusrbrown/infra cliproxy status`.