### PR TITLE
fix(cli): fix cliproxy login and bunx dependency resolution

### DIFF
--- a/.changeset/fix-login-and-bunx.md
+++ b/.changeset/fix-login-and-bunx.md
@@ -1,0 +1,8 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix cliproxy login command and bunx dependency resolution
+
+- Fix `cliproxy login claude` failing with "no configuration file provided" by running docker compose from `/opt/cliproxy/` on the remote host
+- Fix `bunx @marcusrbrown/infra` failing with "Cannot find package 'zod'" by bundling all runtime dependencies in the published tarball

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,12 @@
     "string-dedent": "^3.0.2",
     "zod": "^4.3.6"
   },
+  "bundledDependencies": [
+    "@goke/mcp",
+    "goke",
+    "string-dedent",
+    "zod"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/cli/src/commands/cliproxy-login.ts
+++ b/packages/cli/src/commands/cliproxy-login.ts
@@ -56,7 +56,8 @@ export function registerCliproxyLogin(cli: ReturnType<typeof goke>): void {
         throw new Error('HOME is required to invoke ssh')
       }
 
-      const remoteCommand = 'docker compose exec cli-proxy-api /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login'
+      const remoteCommand =
+        'cd /opt/cliproxy && docker compose exec cli-proxy-api /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login'
 
       const child = Bun.spawn(
         ['ssh', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10', `${DEFAULT_REMOTE_USER}@${host}`, remoteCommand],


### PR DESCRIPTION
## Summary
- Fix `cliproxy login claude` failing with `no configuration file provided` — `docker compose exec` ran from root's home dir instead of `/opt/cliproxy/`
- Fix `bunx @marcusrbrown/infra` failing with `Cannot find package 'zod'` — add `bundledDependencies` to ship deps in the tarball
- Patch changeset for 0.3.1

## Root Causes
1. SSH runs commands in the remote user's home dir by default. `docker compose exec` looks for `docker-compose.yaml` in cwd. Fix: `cd /opt/cliproxy && docker compose exec ...`
2. `bunx` installs packages in a temp dir. Bun's temp resolution doesn't always find transitive deps. Fix: `bundledDependencies` packs them inside the tarball.