### PR TITLE
ci(renovate): add changelog context for CLIProxyAPI digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,5 +4,14 @@
   "postUpgradeTasks": {
     "commands": ["bun install", "bun run fix", "bun run fix"],
     "executionMode": "branch"
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Add changelog context for CLIProxyAPI Docker digest updates",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["eceasy/cli-proxy-api"],
+      "sourceUrl": "https://github.com/router-for-me/CLIProxyAPI",
+      "changelogUrl": "https://github.com/router-for-me/CLIProxyAPI/releases"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds `sourceUrl` and `changelogUrl` to Renovate config for `eceasy/cli-proxy-api` Docker digest updates. Renovate can't auto-discover the source repo because the image lacks an `org.opencontainers.image.source` OCI label.

With this config, future digest PRs will include release notes from [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI/releases) instead of just showing `cc2995d → c88f90a`.