### PR TITLE
ci(deploy): exclude docs, tests, fixtures from change detection

### DIFF
--- a/.changeset/fix-deploy-filter-excludes-docs-tests.md
+++ b/.changeset/fix-deploy-filter-excludes-docs-tests.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Exclude docs, tests, and fixtures from deploy workflow filter so AGENTS.md and test-only changes under `apps/keeweb/` and `apps/cliproxy/` no longer trigger unnecessary production/cliproxy deployments. Adds `predicate-quantifier: every` to make dorny/paths-filter negation patterns actually take effect (default `some` uses OR logic and silently ignores negations).

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,13 +26,22 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          predicate-quantifier: every
           filters: |
             keeweb:
               - 'apps/keeweb/**'
+              - '!apps/keeweb/**/*.md'
+              - '!apps/keeweb/**/*.test.ts'
+              - '!apps/keeweb/**/__fixtures__/**'
+              - '!apps/keeweb/**/__snapshots__/**'
             nginx:
               - 'apps/keeweb/config/kw.igg.ms.conf'
             cliproxy:
               - 'apps/cliproxy/**'
+              - '!apps/cliproxy/**/*.md'
+              - '!apps/cliproxy/**/*.test.ts'
+              - '!apps/cliproxy/**/__fixtures__/**'
+              - '!apps/cliproxy/**/__snapshots__/**'
 
   deploy-keeweb:
     needs: detect-changes


### PR DESCRIPTION
## Problem

AGENTS.md, README, and test-only changes under \`apps/keeweb/\` and \`apps/cliproxy/\` were triggering unnecessary production and cliproxy deployments. See [recent deployments](https://github.com/marcusrbrown/infra/deployments) — the AGENTS.md update PR triggered both environments despite being documentation-only.

## Root Cause

The \`dorny/paths-filter\` config used broad globs (\`apps/keeweb/**\`, \`apps/cliproxy/**\`) with no exclusions, so every file in those directories flagged a deploy.

## Fix

1. **Negation patterns** — exclude markdown, tests, and test support dirs from the keeweb and cliproxy filters:
   - \`!apps/{keeweb,cliproxy}/**/*.md\` (AGENTS.md, README, in-dir compound docs)
   - \`!apps/{keeweb,cliproxy}/**/*.test.ts\` (colocated test files)
   - \`!apps/{keeweb,cliproxy}/**/__fixtures__/**\`
   - \`!apps/{keeweb,cliproxy}/**/__snapshots__/**\`

2. **\`predicate-quantifier: every\`** — critical. Without this, dorny/paths-filter uses default \`some\` (OR logic) and **silently ignores negation patterns**. The file matches the include pattern and is counted regardless of whether it also matches a negation pattern. The \`every\` quantifier switches to AND logic so all patterns (including negations) must be satisfied.

This is documented in the [dorny/paths-filter README](https://github.com/dorny/paths-filter#path-expressions): _"The filters below will match markdown files despite the exclusion syntax UNLESS you specify 'every' as the predicate-quantifier parameter."_

## Verification

After merge, future AGENTS.md / test-only / fixture changes under these directories should:
- Still count as changes in git
- **NOT** trigger the \`deploy-keeweb\` or \`deploy-cliproxy\` jobs
- Still trigger \`ci\` (lint + type-check + tests) since that runs on all PRs

## References

- Real-world examples using the same pattern: [pwndbg/pwndbg](https://github.com/pwndbg/pwndbg/blob/dev/.github/workflows/tests.yml), [mindsdb/mindsdb](https://github.com/mindsdb/mindsdb/blob/main/.github/workflows/build_deploy_dev.yml), [rsbuild](https://github.com/web-infra-dev/rsbuild/blob/main/.github/workflows/test.yml)