### PR TITLE
fix(cliproxy): wait for container health before post-deploy check

### DIFF
--- a/.changeset/fix-cliproxy-deploy-wait-for-healthy.md
+++ b/.changeset/fix-cliproxy-deploy-wait-for-healthy.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix cliproxy deploy race condition where the post-deploy health check fired before the `cli-proxy-api` container finished booting (~3-5s startup). The `docker compose up -d` now uses `--wait --wait-timeout 90` to block until the container's Docker-level healthcheck reports `healthy` before continuing. The existing app-level HTTP health check remains as the second verification layer.

--- a/apps/cliproxy/src/deploy.ts
+++ b/apps/cliproxy/src/deploy.ts
@@ -215,7 +215,10 @@ async function deploy(): Promise<void> {
 
   await runCommand(
     'Updating Docker Compose stack',
-    sshCommand(host, `cd ${REMOTE_DIR} && docker compose pull && docker compose up -d`),
+    // --wait blocks until cli-proxy-api reports healthy per its Docker healthcheck
+    // (start_period: 10s, retries: 3). --wait-timeout caps the block at 90s.
+    // The healthCheck() below is the app-level verification layer on top.
+    sshCommand(host, `cd ${REMOTE_DIR} && docker compose pull && docker compose up -d --wait --wait-timeout 90`),
     env,
   )
 


### PR DESCRIPTION
## Problem

Post-deploy health check was racing the container startup. The [failed deploy](https://github.com/marcusrbrown/infra/actions/runs/24275849747/job/70889530386) timeline:

- \`14:03:53\` — \`docker compose up -d\` returns
- \`14:03:56\` — CLI-side HTTP health check fires → **502 Bad Gateway**
- \`14:03:56\` — Container logs show it finished booting at exactly that second
- \`14:04:01\` — Container serves its first request successfully

The container was booting *while* the health check was running. \`docker compose up -d\` returns as soon as containers are started, not when they're ready.

## Fix

Add \`--wait --wait-timeout 90\` to the \`docker compose up\` invocation. This blocks until the service's Docker-level healthcheck reports \`healthy\`.

\`\`\`diff
- sshCommand(host, \`cd \${REMOTE_DIR} && docker compose pull && docker compose up -d\`),
+ sshCommand(host, \`cd \${REMOTE_DIR} && docker compose pull && docker compose up -d --wait --wait-timeout 90\`),
\`\`\`

### Why \`--wait\` is the right tool

- The \`cli-proxy-api\` service already has a healthcheck configured (\`start_period: 10s\`, \`retries: 3\`, \`interval: 30s\`) from the stability hardening plan.
- \`--wait\` respects each service's healthcheck and blocks until they report \`healthy\`.
- The \`caddy\` service has no healthcheck, so \`--wait\` only requires it to be \`running\` (instant).
- \`--wait-timeout 90\` caps the block to prevent indefinite hangs.
- The existing app-level \`healthCheck(env)\` HTTP fetch remains as the **second verification layer** — it tests the Caddy → cli-proxy-api → management API path, not just container readiness.

### Layered verification

1. **Container level** (Docker healthcheck via \`--wait\`) — is the process running and responding on localhost?
2. **App level** (HTTP fetch to public URL) — is Caddy routing correctly and is the management API accepting auth?

## References

- Docker Compose \`--wait\` docs: https://docs.docker.com/reference/cli/docker/compose/up/
- Real-world usage: [zulip/docker-zulip](https://github.com/zulip/docker-zulip/blob/main/upgrade-postgresql#L7), [linera-io/linera-protocol](https://github.com/linera-io/linera-protocol/blob/main/docker/ci-compose.sh#L65)
- \`--wait\` introduced in Docker Compose v2.1.1 (GitHub Actions runners ship much newer)

## Testing

- \`bun test --recursive\` — 104 pass ✅
- \`bunx tsc --noEmit\` — clean ✅
- Next deploy will exercise the \`--wait\` path