### PR TITLE
fix(renovate): restore bun install in postUpgradeTasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>marcusrbrown/renovate-config#4.5.7", "group:allNonMajor"],
+  // postUpgradeTasks run after Renovate applies file changes but before the commit.
+  // For github-actions manager updates (workflow SHA pins), Renovate does NOT run
+  // any install step, so node_modules is empty and eslint is not available. We
+  // explicitly install with --ignore-scripts (simple-git-hooks postinstall crashes
+  // in the Renovate sandbox because .git/ is not present) before running the linter.
   "postUpgradeTasks": {
-    "commands": ["bun run fix", "bun run fix"],
+    "commands": ["bun install --ignore-scripts", "bun run fix"],
     "executionMode": "branch"
   },
   "packageRules": [


### PR DESCRIPTION
## Problem

Renovate's \`postUpgradeTasks\` fails on github-actions manager updates with:

\`\`\`
stderr: \$ eslint --fix
/usr/bin/bash: line 1: eslint: command not found
error: script "fix" exited with code 127
\`\`\`

[Failed run](https://github.com/marcusrbrown/infra/actions/runs/24276474868/job/70891176373) — a Renovate PR bumping \`bfra-me/.github\` SHA pins in three workflow files.

## Root Cause

PR #71 removed \`bun install\` from \`postUpgradeTasks\` based on an incorrect diagnosis: I claimed Renovate's Bun manager auto-runs \`bun install --ignore-scripts\` as part of artifact updates. That's **only** true when the **Bun manager** is involved — i.e., when \`package.json\` changes.

For **github-actions manager** updates (workflow SHA pin bumps), no package-manager install step runs at all. The Renovate sandbox has an empty \`node_modules\`, so \`bun run fix\` → \`eslint --fix\` fails with \`command not found\`.

The deploy ran this same error cascade before and will again for every non-Bun Renovate update until fixed.

## Fix

\`\`\`diff
 "postUpgradeTasks": {
-  "commands": ["bun run fix", "bun run fix"],
+  "commands": ["bun install --ignore-scripts", "bun run fix"],
   "executionMode": "branch"
 },
\`\`\`

Two changes:

1. **Restore \`bun install --ignore-scripts\`** — populates \`node_modules\` so \`eslint\` is on PATH for the linter step. The \`--ignore-scripts\` flag is required because \`simple-git-hooks\` postinstall crashes in the Renovate sandbox (no \`.git/\`).

2. **Deduplicate** — \`bun run fix\` was listed twice. One pass is sufficient; if ESLint introduces new fixable issues, they get caught by the CI lint-staged hook on the final commit.

## Why This Is Idempotent

| Scenario | \`bun install --ignore-scripts\` result |
|---|---|
| Only workflow files changed (github-actions manager) | Fetches deps, ESLint now available |
| Only \`package.json\` changed (Bun manager) | No-op — Renovate already ran install for the Bun manager |
| Mixed updates | Safe — redundant install is fast |

## References

- [Renovate docs: postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks)
- PR #71 (the wrong diagnosis being corrected here)
- Real-world example with explicit install: [angular/angular renovate.json](https://github.com/angular/angular/blob/main/renovate.json)

## Verification

After merge, the next Renovate PR (or manually triggering Renovate on this repo) should succeed in \`postUpgradeTasks\` without the \`eslint: command not found\` error.