### PR TITLE
chore(lint): restore JSON5 linting of .github/renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,22 +1,22 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>marcusrbrown/renovate-config#4.5.7", "group:allNonMajor"],
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['github>marcusrbrown/renovate-config#4.5.7', 'group:allNonMajor'],
+  packageRules: [
+    {
+      description: 'Add changelog context for CLIProxyAPI Docker digest updates',
+      matchDatasources: ['docker'],
+      matchPackageNames: ['eceasy/cli-proxy-api'],
+      sourceUrl: 'https://github.com/router-for-me/CLIProxyAPI',
+      changelogUrl: 'https://github.com/router-for-me/CLIProxyAPI/releases',
+    },
+  ],
   // postUpgradeTasks run after Renovate applies file changes but before the commit.
   // For github-actions manager updates (workflow SHA pins), Renovate does NOT run
   // any install step, so node_modules is empty and eslint is not available. We
   // explicitly install with --ignore-scripts (simple-git-hooks postinstall crashes
   // in the Renovate sandbox because .git/ is not present) before running the linter.
-  "postUpgradeTasks": {
-    "commands": ["bun install --ignore-scripts", "bun run fix"],
-    "executionMode": "branch"
+  postUpgradeTasks: {
+    commands: ['bun install --ignore-scripts', 'bun run fix'],
+    executionMode: 'branch',
   },
-  "packageRules": [
-    {
-      "description": "Add changelog context for CLIProxyAPI Docker digest updates",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["eceasy/cli-proxy-api"],
-      "sourceUrl": "https://github.com/router-for-me/CLIProxyAPI",
-      "changelogUrl": "https://github.com/router-for-me/CLIProxyAPI/releases"
-    }
-  ]
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@ import {defineConfig} from '@bfra.me/eslint-config'
 export default defineConfig(
   {
     name: '@marcusrbrown/infra',
-    ignores: ['.agents/', '.opencode/', 'docs/', 'dist/', '.cache/', '.github/renovate.json5', '**/AGENTS.md'],
+    ignores: ['.agents/', '.opencode/', 'docs/', 'dist/', '.cache/', '**/AGENTS.md'],
     typescript: true,
   },
   {
@@ -17,6 +17,24 @@ export default defineConfig(
     files: ['**/cli.ts', '**/build.ts', '**/setup-*.ts'],
     rules: {
       'no-console': 'off',
+    },
+  },
+  // The preset auto-loads eslint-plugin-jsonc's "prettier" compat rules, but
+  // isPackageExists('eslint-plugin-jsonc') returns false under Bun's .bun/
+  // symlink layout, so the compat rules never get applied. Disable the
+  // stylistic jsonc rules that conflict with Prettier's JSON5 output.
+  {
+    name: '@marcusrbrown/infra/json5-prettier-compat',
+    files: ['**/*.json5'],
+    rules: {
+      'jsonc/quote-props': 'off',
+      'jsonc/quotes': 'off',
+      'jsonc/comma-dangle': 'off',
+      'jsonc/indent': 'off',
+      'jsonc/array-bracket-spacing': 'off',
+      'jsonc/object-curly-spacing': 'off',
+      'jsonc/object-curly-newline': 'off',
+      'jsonc/object-property-newline': 'off',
     },
   },
 )


### PR DESCRIPTION
## Why

You asked why `.github/renovate.json5` was ignored by ESLint — you prefer JSON5 formatting and your other projects don't ignore it. I added the ignore in commit `c342666` without a good reason. This PR removes the ignore and fixes the underlying rule conflict.

## Root Cause

`@bfra.me/eslint-config` tries to handle the JSON5 formatting conflict automatically: when `eslint-plugin-jsonc` is installed, the `prettier()` config function imports `eslint-plugin-jsonc`'s built-in `configs.prettier` compat config, which disables all the stylistic `jsonc/*` rules that fight Prettier's JSON5 output.

That check lives in [`packages/eslint-config/src/configs/prettier.ts`](https://github.com/bfra-me/works/blob/main/packages/eslint-config/src/configs/prettier.ts#L49):

```ts
isPackageExists('eslint-plugin-jsonc')
  ? interopDefault(import('eslint-plugin-jsonc'))
  : Promise.resolve(undefined),
```

Under **Bun**, `eslint-plugin-jsonc` is a transitive dependency of `@bfra.me/eslint-config`, not a direct one. Bun's `.bun/` symlink layout hides transitive deps from the top-level `node_modules/`, so `isPackageExists('eslint-plugin-jsonc')` returns `false`. The `jsonc` plugin is still loaded via the internal `jsonc()` config (which imports it directly), so the rules fire — but the compat overrides never get applied.

The symptoms were 23 errors where `prettier/prettier` and `jsonc/quote-props`/`jsonc/quotes`/`jsonc/comma-dangle` would ping-pong on `--fix`: one rule's fix becomes the other rule's error.

Confirmed by comparing with [`bfra-me/works/.github/renovate.json5`](https://github.com/bfra-me/works/blob/main/.github/renovate.json5) which IS linted cleanly in JSON5 style — that repo uses pnpm with flat `node_modules` where `isPackageExists` works as intended.

## Fix

Add a scoped override in `eslint.config.ts` that disables the conflicting `jsonc/*` stylistic rules for `**/*.json5` files:

```ts
{
  name: '@marcusrbrown/infra/json5-prettier-compat',
  files: ['**/*.json5'],
  rules: {
    'jsonc/quote-props': 'off',
    'jsonc/quotes': 'off',
    'jsonc/comma-dangle': 'off',
    'jsonc/indent': 'off',
    'jsonc/array-bracket-spacing': 'off',
    'jsonc/object-curly-spacing': 'off',
    'jsonc/object-curly-newline': 'off',
    'jsonc/object-property-newline': 'off',
  },
},
```

These are the same rules `eslint-plugin-jsonc`'s upstream `configs.prettier` compat config would turn off. The override is scoped to `.json5` so `.jsonc` and `.json` files still get strict jsonc linting.

Remove `.github/renovate.json5` from the root ignores.

## Secondary: Reformat `.github/renovate.json5`

With linting restored, `bun run fix` cleanly formats it into idiomatic JSON5:
- Unquoted keys (`$schema:` instead of `"$schema":`)
- Single quotes
- Trailing commas

Matches [`bfra-me/works/.github/renovate.json5`](https://github.com/bfra-me/works/blob/main/.github/renovate.json5).

## Verification

- `bun run lint .github/renovate.json5` → 0 errors ✅
- `bun run lint` (full repo) → 0 errors, warnings pre-existing (console in CLI scripts) ✅
- `bun run fix .github/renovate.json5` → idempotent, no flip-flopping ✅

## Upstream

Filed: [bfra-me/works#3045](https://github.com/bfra-me/works/issues/3045) — once fixed upstream, the scoped override in this PR can be removed and the preset will handle it correctly.