### PR TITLE
fix(release): normalize changeset targets from workspace root

### DIFF
--- a/.changeset/renovate-05ccc6d.md
+++ b/.changeset/renovate-05ccc6d.md
@@ -1,5 +1,5 @@
 ---
-'@marcusrbrown/infra-workspace': patch
+'@marcusrbrown/infra': patch
 ---
 
 ⚙️ Update GitHub Actions workflow dependency `actions/create-github-app-token` from `v3.1.0` to `v3.1.1`

--- a/.changeset/renovate-13f1c45.md
+++ b/.changeset/renovate-13f1c45.md
@@ -1,5 +1,5 @@
 ---
-'@marcusrbrown/infra-workspace': patch
+'@marcusrbrown/infra': patch
 ---
 
 ⚙️ Update GitHub Actions workflow dependency `bfra-me/.github` from `4.16.2` to `4.16.3`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,19 +61,28 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Workaround for bfra-me/.github renovate-changesets action bug:
-      # the action's getRootPackageName() returns the workspace root package name
+      # Workaround for bfra-me/.github#2012: renovate-changesets action's
+      # getRootPackageName() returns the workspace root package name
       # (@marcusrbrown/infra-workspace) for github-actions updates because those
       # files don't belong to any workspace member. The root package is private
       # and not in manypkg's workspace list, so `changeset version` fails with
       # "package not in the workspace". Rewrite any such entries to target the
-      # published CLI package before running changesets/action.
+      # published CLI package before running changesets/action. Remove this step
+      # when bfra-me/.github#2012 is fixed upstream.
       - name: Normalize changeset targets
         run: |
           shopt -s nullglob
+          # Match the package name at the start of a line (YAML frontmatter key),
+          # tolerating single-quoted, double-quoted, or unquoted forms so the
+          # workaround survives if upstream changes its serialization style. The
+          # line-start anchor and trailing colon scope the match to frontmatter
+          # keys, leaving prose in the changeset body untouched. We don't back-
+          # reference the opening quote because BSD sed doesn't support \1 in
+          # ERE; mismatched quotes (e.g. '"...) don't occur in valid YAML.
+          pattern="^['\"]?@marcusrbrown/infra-workspace['\"]?:"
           for file in .changeset/*.md; do
-            if grep -q "'@marcusrbrown/infra-workspace':" "$file"; then
-              sed -i "s|'@marcusrbrown/infra-workspace':|'@marcusrbrown/infra':|g" "$file"
+            if grep -Eq "$pattern" "$file"; then
+              sed -i -E "s|$pattern|'@marcusrbrown/infra':|" "$file"
               echo "Rewrote changeset target in $file"
             fi
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,23 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      # Workaround for bfra-me/.github renovate-changesets action bug:
+      # the action's getRootPackageName() returns the workspace root package name
+      # (@marcusrbrown/infra-workspace) for github-actions updates because those
+      # files don't belong to any workspace member. The root package is private
+      # and not in manypkg's workspace list, so `changeset version` fails with
+      # "package not in the workspace". Rewrite any such entries to target the
+      # published CLI package before running changesets/action.
+      - name: Normalize changeset targets
+        run: |
+          shopt -s nullglob
+          for file in .changeset/*.md; do
+            if grep -q "'@marcusrbrown/infra-workspace':" "$file"; then
+              sed -i "s|'@marcusrbrown/infra-workspace':|'@marcusrbrown/infra':|g" "$file"
+              echo "Rewrote changeset target in $file"
+            fi
+          done
+
       - id: changesets
         name: Create Release Pull Request or Publish
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0


### PR DESCRIPTION
## Problem

The [Release workflow](https://github.com/marcusrbrown/infra/actions/runs/24277697504/job/70894353113) fails with:

```
🦋  error Error: Found changeset renovate-05ccc6d for package @marcusrbrown/infra-workspace which is not in the workspace
```

Two Renovate-generated changesets on main target `@marcusrbrown/infra-workspace` (the private workspace root), which isn't a real workspace package as far as `@changesets/cli` is concerned.

## Root Cause

The `bfra-me/.github` reusable `renovate-changeset` workflow uses a custom action at [`.github/actions/renovate-changesets`](https://github.com/bfra-me/.github/tree/v4.16.3/.github/actions/renovate-changesets). That action's [`getRootPackageName()`](https://github.com/bfra-me/.github/blob/v4.16.3/.github/actions/renovate-changesets/src/run-generation-helpers.ts#L5):

```ts
export function getRootPackageName(
  workspacePackages: WorkspacePackage[],
  fallbackName: string,
): string {
  const rootPackage = workspacePackages.find(pkg => pkg.path === '.' || pkg.path === '')
  return rootPackage?.name ?? fallbackName
}
```

picks the workspace-root `package.json` (ours is `@marcusrbrown/infra-workspace`, `private: true`) whenever the changed files don't belong to any workspace member. GitHub Actions manager updates (workflow SHA pin bumps) touch only `.github/workflows/*.yaml` at repo root — not inside any workspace directory — so the fallback always hits.

Downstream, `changeset version` fails because `@marcusrbrown/infra-workspace` is not in manypkg's workspace package list (Bun workspace pattern `["apps/*", "packages/*"]` doesn't include the root). The validation in [`get-relevant-changesets.ts`](https://github.com/changesets/changesets/blob/main/packages/assemble-release-plan/src/index.ts):

```ts
const packageByName = mapGetOrThrow(
  packagesByName,
  release.name,
  `Found changeset ${changeset.id} for package ${release.name} which is not in the workspace`
);
```

throws before `shouldSkipPackage` is ever consulted — so **adding the root to `.changeset/config.json`'s `ignore` array does NOT fix this**. Verified empirically: `ignore` requires the package to exist in the workspace first.

## Fix (Two Parts)

### 1. Rewrite existing bad changesets

The two existing Renovate-generated changesets represent real workflow updates (`actions/create-github-app-token` v3.1.0 → v3.1.1, `bfra-me/.github` v4.16.2 → v4.16.3) that should ship with the next CLI release. Rewrite their target from `@marcusrbrown/infra-workspace` to `@marcusrbrown/infra` (the published CLI package).

### 2. Prevent recurrence

Add a `Normalize changeset targets` step to the Release workflow, right before `changesets/action`, that sed-rewrites any `'@marcusrbrown/infra-workspace:'` occurrence in `.changeset/*.md` to `'@marcusrbrown/infra:'`. Idempotent, skips files with no match, no-op once the upstream bug is fixed:

```yaml
- name: Normalize changeset targets
  run: |
    shopt -s nullglob
    for file in .changeset/*.md; do
      if grep -q "'@marcusrbrown/infra-workspace':" "$file"; then
        sed -i "s|'@marcusrbrown/infra-workspace':|'@marcusrbrown/infra':|g" "$file"
        echo "Rewrote changeset target in $file"
      fi
    done
```

## Alternatives Considered and Rejected

| Option | Why rejected |
|---|---|
| Add `@marcusrbrown/infra-workspace` to `.changeset/config.json` `ignore` | Changesets config validation rejects it: "specified in `ignore` but not found in the project". Verified locally. |
| Remove `name` field from root `package.json` | Doesn't help existing changeset files, and may break other tools that rely on workspace root having a name. |
| Rename root package to `@marcusrbrown/infra` | Collides with `packages/cli/package.json` (`@marcusrbrown/infra`). |
| Inline the reusable workflow | Previously rejected — the point of the reusable workflow is to not repeat boilerplate across repos. |
| Switch to `@scaleway/changesets-renovate` directly (`bfra-me/works` pattern) | Viable, but abandons the `bfra-me/.github` reusable workflow convention. |

## Verification

- `bun run changeset status` locally with rewritten changesets → resolves cleanly:
  ```
  🦋  info Packages to be bumped at patch:
  🦋  - @marcusrbrown/infra
  ```
- `bun run lint` → 0 errors
- `bunx tsc --noEmit` → clean (unchanged)

## Upstream

Filed: [bfra-me/.github#2012](https://github.com/bfra-me/.github/issues/2012) with full analysis and four proposed fix options. Once resolved upstream, the `Normalize changeset targets` step in `release.yaml` can be removed.