### PR TITLE
chore(cliproxy): pin image to semver tag v6.9.23

### DIFF
--- a/apps/cliproxy/docker-compose.yaml
+++ b/apps/cliproxy/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - ./config/Caddyfile:/etc/caddy/Caddyfile
 
   cli-proxy-api:
-    image: eceasy/cli-proxy-api:latest@sha256:6a454fe6b710bda1cd740971fe172d729b5f8ca77feffc3b2a24ac9f9ca0b14b
+    image: eceasy/cli-proxy-api:v6.9.23@sha256:6a454fe6b710bda1cd740971fe172d729b5f8ca77feffc3b2a24ac9f9ca0b14b
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
## Summary

Switch the `eceasy/cli-proxy-api` pin in `apps/cliproxy/docker-compose.yaml` from `:latest@sha256:...` to `:v6.9.23@sha256:...`. Same digest — this is the tag that currently resolves to `sha256:6a454fe6b710bda1cd740971fe172d729b5f8ca77feffc3b2a24ac9f9ca0b14b`. No deploy required (digest unchanged).

## Why

Two problems fell out of using a floating `:latest` tag with a digest pin, both surfaced when PR #91 merged:

### 1. Dead `changelogUrl`

In #55 I added a Renovate packageRule with `sourceUrl` + `changelogUrl` for `eceasy/cli-proxy-api` hoping it would populate release notes in Renovate PR bodies. It never worked because **digest-only updates on a floating tag carry no version metadata**. Renovate has no version delta to look up, so there are no "release notes between X and Y" to fetch. The link just sat in the PR body as a plain hyperlink.

With a semver tag pin, Renovate treats each update as a real version bump (`v6.9.23` → `v6.9.24`) and fetches the corresponding release notes from `router-for-me/CLIProxyAPI`.

### 2. The `to v6 (6)` changeset output

PR #91's generated changeset was:

    ⚠️ Update Docker image `eceasy/cli-proxy-api` to v6 (6)

That's useless. The bug lives in `bfra-me/.github`'s renovate-changesets action — `summary-helpers.ts` `formatVersionText()` plus the dependency extractor's `VERSION_PATTERN` regex `v?(\d+(?:\.\d+){0,2})`, which happily matches the leading digit group of a SHA hash (`6a454fe...` → version `6`). It then routes through the major-bump template:

```typescript
if (overallImpact === 'major') {
  const stripped = newVersion.replace(/^v/i, '')
  const majorVersion = stripped.split('.')[0]
  if (majorVersion != null && /^\d+$/.test(majorVersion)) {
    return ` to v${majorVersion} (${newVersion})`  // ← "to v6 (6)"
  }
  // ...
}
```

Pinning a real semver tag routes `formatVersionText` through the `from X to Y` branch instead, so future Renovate PRs will produce changesets like `Update Docker image eceasy/cli-proxy-api from v6.9.23 to v6.9.24`. The upstream bug still exists for anyone else using floating tag + digest pins — I'll file a separate issue against `bfra-me/.github`.

## Research

- [`eceasy/cli-proxy-api` Docker Hub tags API](https://hub.docker.com/v2/repositories/eceasy/cli-proxy-api/tags/?page_size=100&ordering=last_updated) confirms 549 tags in `vX.Y.Z` format, every release gets a unique tag, no major aliases (`v6`), no moving minor aliases (`v6.9`)
- Current `:latest` digest maps to `v6.9.23` (pushed 2026-04-11)
- GitHub releases at [router-for-me/CLIProxyAPI/releases](https://github.com/router-for-me/CLIProxyAPI/releases) match the Docker tag versions 1:1

## Local verification

- `bun run lint` → 0 errors (17 pre-existing `no-console` warnings)
- `bunx tsc --noEmit` → clean
- `bun test --recursive` → 104 pass

No functional change — Docker pull will resolve the same digest. Next Renovate update (likely within 24 hours given the release cadence) will produce the first proper semver bump changeset.