### PR TITLE
chore(env): rename production GitHub Environment to keeweb

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ bun run --cwd apps/keeweb build
 
 - Never commit secret values to tracked files.
 - `config/config.json` must never be modified by CI or build scripts. Secrets are injected only into `dist/config.json`.
-- `DEPLOY_SSH_KEY` and `DROPBOX_APP_SECRET` are scoped to the `production` GitHub Environment.
+- `DEPLOY_SSH_KEY` and `DROPBOX_APP_SECRET` are scoped to the `keeweb` GitHub Environment.
 - Host keys are pinned in `.github/known_hosts`. Never use `ssh-keyscan`.
 
 ## Collaboration

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: detect-changes
     if: github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.keeweb == 'true'
     runs-on: ubuntu-latest
-    environment: production
+    environment: keeweb
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -167,7 +167,7 @@ env:
        Report findings as issues only for this category. Do NOT modify
        deploy scripts or workflow files.
 
-    6. PRODUCTION SITE REVIEW
+    6. LIVE SITE REVIEW
        Use `npx agent-browser` to verify the live KeeWeb deployment at
        https://kw.igg.ms.
 
@@ -322,10 +322,10 @@ env:
     | --- | --- | --- |
     | Last deploy run | ✅ Pass / ❌ Fail | [run link] |
     | kw.igg.ms reachable | ✅ 200 / ❌ Error | [HTTP status] |
-    | Production env secrets | ✅ Set / ⚠️ Missing | [details] |
+    | Keeweb env secrets | ✅ Set / ⚠️ Missing | [details] |
     | Host keys valid | ✅ Current / ⚠️ Stale | [details] |
 
-    ### Production Site Review
+    ### Live Site Review
     | Check | Status | Details |
     | --- | --- | --- |
     | Page load | ✅ OK / ❌ Error | [load time or error] |

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -160,7 +160,7 @@ env:
          diagnose the root cause from logs and open an issue.
        - Verify kw.igg.ms is reachable: `curl -sf -o /dev/null -w
          "%{http_code}" https://kw.igg.ms` should return 200.
-       - Verify the production environment exists and has required secrets
+       - Verify the keeweb environment exists and has required secrets
          configured (DEPLOY_SSH_KEY, DROPBOX_APP_SECRET).
        - Check that .github/known_hosts contains valid host keys for
          box.heatvision.co.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ bun run apps/keeweb/server/setup-deploy-user.ts # Provision deploy user on serve
 
 ## NOTES
 
-- `DROPBOX_APP_SECRET` and `DEPLOY_SSH_KEY` are GitHub Actions secrets scoped to `production` environment.
+- `DROPBOX_APP_SECRET` and `DEPLOY_SSH_KEY` are GitHub Actions secrets scoped to `keeweb` environment.
 - `CLIPROXY_SSH_KEY`, `CLIPROXY_MANAGEMENT_KEY`, and `CLIPROXY_DOMAIN` are scoped to `cliproxy` environment.
 - `OPENCODE_AUTH_JSON`, `OPENCODE_CONFIG`, `OMO_PROVIDERS`, `FRO_BOT_PAT` are repo-level secrets. `FRO_BOT_MODEL` is a repo variable.
 - `OPENCODE_CONFIG` must set `baseURL` with `/v1` suffix: `{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}`.

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Personal infrastructure management — deploy automation, operational CLI, and t
 
 ## Overview
 
-Bun workspace monorepo for managing personal infrastructure. Hosts KeeWeb deploy automation with CI/CD, and a CLI for operational health checks, deploy triggers, and MCP tool exposure.
+Bun workspace monorepo for managing personal infrastructure. Hosts KeeWeb deploy automation, the CLIProxyAPI proxy that routes Fro Bot agents to Claude via the Claude Code OAuth subscription, and a CLI for operational health checks, deploy triggers, and MCP tool exposure.
 
-| Package         | Description                                  |
-| --------------- | -------------------------------------------- |
-| `apps/keeweb`   | KeeWeb v1.18.7 static site deploy automation |
-| `apps/cliproxy` | CLIProxyAPI deployment (scaffolded)          |
-| `packages/cli`  | `@marcusrbrown/infra` CLI                    |
+| Package         | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| `apps/keeweb`   | KeeWeb v1.18.7 static site deploy automation (`kw.igg.ms`)                 |
+| `apps/cliproxy` | CLIProxyAPI Docker Compose stack behind Caddy (`cliproxy.fro.bot`)         |
+| `packages/cli`  | [`@marcusrbrown/infra`](https://www.npmjs.com/package/@marcusrbrown/infra) |
 
 ## Prerequisites
 
 - [Bun](https://bun.sh) v1.0+
-- [GitHub CLI](https://cli.github.com) (`gh`) — required for `keeweb status` and `keeweb deploy`
+- [GitHub CLI](https://cli.github.com) (`gh`) — required for the remote `keeweb`/`cliproxy` deploy triggers and status commands
 
 ## Quick Start
 
@@ -32,9 +32,9 @@ bun test --recursive
 
 ### KeeWeb (`apps/keeweb`)
 
-Self-hosted [KeeWeb](https://keeweb.info) v1.18.7 password manager at [kw.igg.ms](https://kw.igg.ms).
+Self-hosted [KeeWeb](https://keeweb.info) v1.18.7 password manager at [kw.igg.ms](https://kw.igg.ms). Static site built from the upstream release archive with Dropbox client-credential injection.
 
-**Build** — downloads the KeeWeb release and produces a deploy-ready `dist/`:
+**Build** — downloads the KeeWeb release, verifies SHA-256, produces a deploy-ready `dist/`:
 
 ```bash
 bun run --cwd apps/keeweb build
@@ -49,13 +49,29 @@ DROPBOX_APP_SECRET=<value> bun run --cwd apps/keeweb build
 **Deploy** — pushes `dist/` to the server via SSH/rsync:
 
 ```bash
-bash apps/keeweb/deploy.sh          # content only
+bash apps/keeweb/deploy.sh           # content only
 bash apps/keeweb/deploy.sh --nginx   # content + nginx config
+```
+
+### CLIProxyAPI (`apps/cliproxy`)
+
+[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) Docker Compose stack fronted by Caddy at [cliproxy.fro.bot](https://cliproxy.fro.bot). Authenticates to Claude once via the Claude Code OAuth flow, then issues per-repo API keys so Fro Bot agents across multiple repositories can use Claude models through a single subscription.
+
+**Provision** — creates the DigitalOcean droplet and bootstraps Docker + firewall (one-time, `--force` required to rerun against an existing droplet):
+
+```bash
+bun run --cwd apps/cliproxy provision
+```
+
+**Deploy** — uploads compose files and restarts the stack (idempotent, preserves runtime `config.yaml` unless `--force-config` is set):
+
+```bash
+bun run --cwd apps/cliproxy deploy
 ```
 
 ## CLI
 
-The [`@marcusrbrown/infra`](https://www.npmjs.com/package/@marcusrbrown/infra) CLI provides operational commands for managing infrastructure.
+The [`@marcusrbrown/infra`](https://www.npmjs.com/package/@marcusrbrown/infra) CLI exposes operational commands for both apps plus an MCP bridge.
 
 ```bash
 bunx @marcusrbrown/infra --help
@@ -68,13 +84,9 @@ bun add -g @marcusrbrown/infra
 infra --help
 ```
 
-### Commands
+### KeeWeb commands
 
-**`infra keeweb status`** — operational health check:
-
-- HTTP reachability of kw.igg.ms (status code + response time)
-- Last successful deploy timestamp (via GitHub Actions API)
-- Content hash comparison (SHA-256 of live site vs local `dist/`)
+**`infra keeweb status`** — operational health check (HTTP reachability, last successful deploy timestamp via GitHub Actions API, SHA-256 content hash comparison vs local `dist/`).
 
 ```bash
 bunx @marcusrbrown/infra keeweb status
@@ -83,13 +95,56 @@ bunx @marcusrbrown/infra keeweb status
 **`infra keeweb deploy`** — trigger a deployment:
 
 ```bash
-bunx @marcusrbrown/infra keeweb deploy              # trigger GitHub Actions workflow
-bunx @marcusrbrown/infra keeweb deploy --dry-run     # preview plan without validating preconditions
-bunx @marcusrbrown/infra keeweb deploy --local       # deploy directly via SSH
-bunx @marcusrbrown/infra keeweb deploy --local --nginx  # include nginx config
+bunx @marcusrbrown/infra keeweb deploy                  # trigger GitHub Actions workflow (default)
+bunx @marcusrbrown/infra keeweb deploy --dry-run        # validate preconditions without triggering
+bunx @marcusrbrown/infra keeweb deploy --local          # deploy directly via SSH (content only)
+bunx @marcusrbrown/infra keeweb deploy --local --nginx  # include nginx config deploy
 ```
 
 Local deploy requires `ssh-agent` running with the deploy key loaded (`SSH_AUTH_SOCK`).
+
+### CLIProxyAPI commands
+
+**`infra cliproxy status`** — HTTP reachability, version, usage statistics.
+
+```bash
+bunx @marcusrbrown/infra cliproxy status
+```
+
+**`infra cliproxy deploy`** — trigger a deployment (remote by default, `--local` for direct SSH):
+
+```bash
+bunx @marcusrbrown/infra cliproxy deploy                       # trigger GitHub Actions workflow
+bunx @marcusrbrown/infra cliproxy deploy --dry-run             # validate without triggering
+bunx @marcusrbrown/infra cliproxy deploy --local               # deploy directly via SSH
+bunx @marcusrbrown/infra cliproxy deploy --local --force-config  # overwrite server config.yaml
+```
+
+**`infra cliproxy config`** — read or update runtime configuration via the management API:
+
+```bash
+bunx @marcusrbrown/infra cliproxy config get
+bunx @marcusrbrown/infra cliproxy config get --output /tmp/cliproxy.yaml  # write to file (chmod 600)
+bunx @marcusrbrown/infra cliproxy config set debug true
+bunx @marcusrbrown/infra cliproxy config set request-retry 3
+bunx @marcusrbrown/infra cliproxy config set proxy-url https://proxy.example.com
+```
+
+**`infra cliproxy keys`** — manage proxy API keys (opaque bearer tokens distributed to Fro Bot repos):
+
+```bash
+bunx @marcusrbrown/infra cliproxy keys list
+bunx @marcusrbrown/infra cliproxy keys add "fro-bot-<repo>"
+bunx @marcusrbrown/infra cliproxy keys remove "fro-bot-<repo>"
+```
+
+**`infra cliproxy login`** — OAuth authentication with a Claude subscription (runs over SSH with TTY):
+
+```bash
+bunx @marcusrbrown/infra cliproxy login claude
+```
+
+### MCP bridge
 
 **`infra mcp`** — start a stdio MCP server exposing all CLI commands as tools:
 
@@ -97,7 +152,7 @@ Local deploy requires `ssh-agent` running with the deploy key loaded (`SSH_AUTH_
 bunx @marcusrbrown/infra mcp
 ```
 
-This lets coding agents (Fro Bot, Copilot) call `keeweb status` and `keeweb deploy` programmatically via the [Model Context Protocol](https://modelcontextprotocol.io).
+Lets coding agents (Fro Bot, Copilot) call commands programmatically via the [Model Context Protocol](https://modelcontextprotocol.io).
 
 ## CI/CD
 
@@ -106,88 +161,110 @@ This lets coding agents (Fro Bot, Copilot) call `keeweb status` and `keeweb depl
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
 | **CI** | PRs to `main` | Lint, type check, and test |
-| **Deploy** | Push to `main` (keeweb changes), `workflow_dispatch` | Build and deploy KeeWeb |
-| **Release** | Push to `main` | Version packages via Changesets |
-| **Renovate** | Push, issue/PR edits, post-deploy | Automated dependency updates |
-| **Renovate Changesets** | PRs from Renovate | Auto-create changeset files for dependency updates |
-| **Fro Bot** | PRs, @mentions, daily schedule, `workflow_dispatch` | AI code review + autohealing |
+| **Deploy** | Push to `main`, `workflow_dispatch` | Build and deploy KeeWeb and/or CLIProxyAPI (path-filtered) |
+| **Release** | Push to `main` | Version and publish `@marcusrbrown/infra` via Changesets |
+| **Renovate** | Schedule, issue/PR edits, post-deploy | Automated dependency updates |
+| **Renovate Changesets** | Renovate PRs | Auto-create changeset files for dependency updates |
+| **Fro Bot** | PRs, @mentions, daily schedule, `workflow_dispatch` | AI code review and autohealing |
 | **Copilot Setup Steps** | `workflow_dispatch`, changes to workflow file | Prepare environment for Copilot coding agent |
 | **Scorecard** | Weekly, push to `main` | OpenSSF security analysis |
 | **Update Repo Settings** | Daily, push to `main` | Sync repo settings from `.github/settings.yml` |
 
 ### Deploy Pipeline
 
-Pushes to `main` that touch `apps/keeweb/**` trigger an automated deploy via GitHub Actions. Manual deploys are available via `workflow_dispatch`.
+The Deploy workflow uses `dorny/paths-filter` to detect changes under `apps/keeweb/**` and `apps/cliproxy/**` (docs, tests, fixtures, and snapshots are excluded from the filter). Each app has a dedicated job gated by the matching sub-filter and GitHub Environment approval.
 
-Deploys require approval through the `production` GitHub Environment.
+- **`deploy-keeweb`** runs in the `keeweb` environment and requires approval.
+- **`deploy-cliproxy`** runs in the `cliproxy` environment and requires approval.
+
+Manual deploys are available via `workflow_dispatch` and trigger both jobs.
 
 ### Required Secrets
 
-**Production environment** (`DEPLOY_SSH_KEY`, `DROPBOX_APP_SECRET`):
+**`keeweb` environment:**
 
 | Secret               | Description                                           |
 | -------------------- | ----------------------------------------------------- |
 | `DEPLOY_SSH_KEY`     | Ed25519 private key for `deploy-kw@box.heatvision.co` |
 | `DROPBOX_APP_SECRET` | Dropbox app client credential for KeeWeb config       |
 
-**Repository secrets** (`APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`):
+**`cliproxy` environment:**
 
-| Secret                      | Description                                                        |
-| --------------------------- | ------------------------------------------------------------------ |
-| `APPLICATION_ID`            | GitHub App ID for Renovate and repo settings sync                  |
-| `APPLICATION_PRIVATE_KEY`   | GitHub App private key                                             |
-| `FRO_BOT_PAT`               | PAT for the fro-bot user (AI agent identity for @fro-bot mentions) |
-| `OPENCODE_AUTH_JSON`        | LLM provider auth JSON (e.g. `{"anthropic":{"apiKey":"..."}}}`)    |
-| `NPM_TOKEN`                 | npm publish token for `@marcusrbrown/infra` package                |
-| `OMO_PROVIDERS`             | Comma-separated oMo provider list (e.g. `claude`)                  |
-| `OPENCODE_CONFIG`           | OpenCode provider config JSON (e.g. anthropic baseURL override)    |
-| `DIGITALOCEAN_ACCESS_TOKEN` | API token for DigitalOcean management                              |
+| Secret                    | Description                                                  |
+| ------------------------- | ------------------------------------------------------------ |
+| `CLIPROXY_SSH_KEY`        | Ed25519 private key for the `cliproxy.fro.bot` DO droplet    |
+| `CLIPROXY_MANAGEMENT_KEY` | Management API bearer token for runtime config / key updates |
+| `CLIPROXY_DOMAIN`         | FQDN of the CLIProxyAPI instance                             |
+
+**Repository secrets:**
+
+| Secret                      | Description                                                         |
+| --------------------------- | ------------------------------------------------------------------- |
+| `APPLICATION_ID`            | GitHub App ID for Renovate and repo settings sync                   |
+| `APPLICATION_PRIVATE_KEY`   | GitHub App private key                                              |
+| `DIGITALOCEAN_ACCESS_TOKEN` | DigitalOcean API token (used by `apps/cliproxy` provision scripts)  |
+| `FRO_BOT_PAT`               | PAT for the `fro-bot` user (agent identity for `@fro-bot` mentions) |
+| `NPM_TOKEN`                 | npm publish token for `@marcusrbrown/infra` package                 |
+| `OMO_PROVIDERS`             | Comma-separated oMo provider list (e.g. `claude-max20`)             |
+| `OPENCODE_AUTH_JSON`        | LLM provider credentials JSON injected into Fro Bot runs            |
+| `OPENCODE_CONFIG`           | OpenCode provider config JSON (e.g. Anthropic `baseURL` override)   |
 
 **Repository variables:**
 
-| Variable        | Description                        |
-| --------------- | ---------------------------------- |
-| `FRO_BOT_MODEL` | LLM model ID for the Fro Bot agent |
+| Variable        | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `FRO_BOT_MODEL` | LLM model ID for the Fro Bot agent (e.g. `claude-sonnet-4-6`) |
 
 ### Server Setup
 
-The deploy target uses a dedicated `deploy-kw` user with scoped permissions. To provision (or re-provision) the user:
+The KeeWeb deploy target uses a dedicated `deploy-kw` user with scoped sudo for the nginx activation script. To provision or re-provision the user:
 
 ```bash
 bun run apps/keeweb/server/setup-deploy-user.ts
 ```
 
+Host keys for `box.heatvision.co` and `cliproxy.fro.bot` are pinned in `.github/known_hosts` — no runtime `ssh-keyscan`.
+
 ## Repository Structure
 
 ```text
-├── apps/keeweb/             KeeWeb deploy package
-│   ├── src/build.ts         Build script (download + config injection)
-│   ├── config/              Config templates (nginx, app config)
-│   ├── server/              Server provisioning scripts
-│   └── deploy.sh            SSH/rsync deploy script
-├── apps/cliproxy/           CLIProxyAPI deployment (scaffolded)
-├── packages/cli/            @marcusrbrown/infra CLI
+├── apps/
+│   ├── keeweb/                  KeeWeb deploy package
+│   │   ├── src/build.ts         Build script (download + SHA-256 verify + config injection)
+│   │   ├── config/              Config templates (nginx, app config)
+│   │   ├── server/              Deploy user provisioning script
+│   │   └── deploy.sh            SSH/rsync deploy script
+│   └── cliproxy/                CLIProxyAPI deployment package
+│       ├── config/              docker-compose.yaml, Caddyfile, config.yaml template
+│       ├── server/              Droplet provisioning script
+│       └── src/deploy.ts        Deploy script
+├── packages/cli/                @marcusrbrown/infra CLI
 │   └── src/
-│       ├── cli.ts           Entry point (goke framework)
-│       ├── cli.test.ts      CLI snapshot + discovery tests
-│       └── commands/        Command modules
+│       ├── cli.ts               Entry point (goke framework)
+│       ├── cli.test.ts          CLI snapshot + discovery tests
+│       └── commands/            Command modules
 │           ├── keeweb-status.ts
 │           ├── keeweb-deploy.ts
+│           ├── cliproxy-status.ts
+│           ├── cliproxy-deploy.ts
+│           ├── cliproxy-config.ts
+│           ├── cliproxy-keys.ts
+│           ├── cliproxy-login.ts
 │           └── mcp.ts
 ├── .agents/
-│   └── skills/              Agent skill context packets
+│   └── skills/                  Agent skill context packets (goke)
 ├── .github/
 │   ├── copilot-instructions.md  Copilot coding agent instructions
-│   ├── known_hosts          Pinned SSH host keys
-│   ├── renovate.json5       Renovate configuration
-│   ├── settings.yml         Repository settings definition
-│   └── workflows/           CI/CD and automation workflows
+│   ├── known_hosts              Pinned SSH host keys
+│   ├── renovate.json5           Renovate configuration
+│   ├── settings.yml             Repository settings definition
+│   └── workflows/               CI/CD and automation workflows
 ├── docs/
-│   ├── brainstorms/         Requirements and brainstorms
-│   ├── plans/               Implementation plans
-│   └── solutions/           Compound learning docs
+│   ├── brainstorms/             Requirements and brainstorms
+│   ├── plans/                   Implementation plans
+│   └── solutions/               Compound learning docs
 └── .opencode/
-    └── commands/            OpenCode slash commands
+    └── commands/                OpenCode slash commands
 ```
 
 ## Testing
@@ -197,7 +274,7 @@ bun test --recursive  # Run all tests from repo root
 bun test              # Run tests in current package
 ```
 
-Tests are colocated alongside source files (`*.test.ts`). Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Tests mock at boundaries (fetch, Bun.spawn) and use `NO_COLOR=1` for deterministic subprocess output. CI runs tests as a parallel job alongside lint and type-check.
+Tests are colocated alongside source files (`*.test.ts`). Fixtures live in `__fixtures__/`, snapshots in `__snapshots__/`. Tests mock at boundaries (`fetch`, `Bun.spawn`) and use `NO_COLOR=1` for deterministic subprocess output. CI runs tests as a parallel job alongside lint and type-check.
 
 ## Development
 
@@ -211,14 +288,14 @@ Pre-commit hook runs `lint-staged` → `eslint --fix` on staged files via `simpl
 
 ### Tooling
 
-| Tool       | Config                                          |
-| ---------- | ----------------------------------------------- |
-| ESLint     | `eslint.config.ts` via `@bfra.me/eslint-config` |
-| Prettier   | `@bfra.me/prettier-config/120-proof`            |
-| TypeScript | `tsconfig.json` via `@bfra.me/tsconfig`         |
-| Git hooks  | `simple-git-hooks` + `lint-staged`              |
-| CLI        | [goke](https://github.com/remorses/goke) + Zod  |
-| Changesets | `@changesets/cli` for versioning                |
+| Tool       | Config                                                          |
+| ---------- | --------------------------------------------------------------- |
+| ESLint     | `eslint.config.ts` via `@bfra.me/eslint-config`                 |
+| Prettier   | `@bfra.me/prettier-config/120-proof`                            |
+| TypeScript | `tsconfig.json` via `@bfra.me/tsconfig`                         |
+| Git hooks  | `simple-git-hooks` + `lint-staged`                              |
+| CLI        | [goke](https://github.com/remorses/goke) + Zod Standard Schemas |
+| Changesets | `@changesets/cli` for versioning                                |
 
 ## License
 

--- a/apps/keeweb/server/setup-deploy-user.ts
+++ b/apps/keeweb/server/setup-deploy-user.ts
@@ -203,7 +203,7 @@ async function provision() {
   console.log()
   console.log('  Next steps:')
   console.log("    1. Retrieve the private key: ssh root@%s 'cat /home/%s/.ssh/id_ed25519'", HOST, DEPLOY_USER)
-  console.log('    2. Store it as DEPLOY_SSH_KEY in GitHub (scoped to production Environment)')
+  console.log('    2. Store it as DEPLOY_SSH_KEY in GitHub (scoped to keeweb Environment)')
   console.log("    3. Verify: ssh %s@%s 'id'", DEPLOY_USER, HOST)
 }
 

--- a/packages/cli/src/commands/cliproxy-deploy.ts
+++ b/packages/cli/src/commands/cliproxy-deploy.ts
@@ -152,6 +152,6 @@ export function registerCliproxyDeploy(cli: CliInstance): void {
       }
 
       console.log(`Workflow triggered: ${WORKFLOW_URL}`)
-      console.log('Approve the production environment deployment in GitHub Actions to continue.')
+      console.log('Approve the cliproxy environment deployment in GitHub Actions to continue.')
     })
 }

--- a/packages/cli/src/commands/keeweb-deploy.ts
+++ b/packages/cli/src/commands/keeweb-deploy.ts
@@ -173,7 +173,7 @@ export function registerKeewebDeploy(cli: CliInstance): void {
       validateRemotePreconditions()
 
       console.warn('Warning: the Deploy workflow includes nginx config deployment as part of workflow_dispatch logic.')
-      console.warn('Warning: the workflow requires production environment approval before jobs execute.')
+      console.warn('Warning: the workflow requires keeweb environment approval before jobs execute.')
 
       const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
         stdout: 'inherit',
@@ -186,6 +186,6 @@ export function registerKeewebDeploy(cli: CliInstance): void {
       }
 
       console.log(`Workflow triggered: ${WORKFLOW_URL}`)
-      console.log('Approve the production environment deployment in GitHub Actions to continue.')
+      console.log('Approve the keeweb environment deployment in GitHub Actions to continue.')
     })
 }


### PR DESCRIPTION
## Summary

Renames the `production` GitHub Environment to `keeweb` so deploy environment names match app names. The `production` name was a holdover from when this repo only deployed KeeWeb — it predates `cliproxy` — and the naming asymmetry is confusing now that both apps have their own environments.

Also fixes a latent bug in `cliproxy-deploy.ts` that printed `Approve the production environment deployment` even though the cliproxy workflow runs in the `cliproxy` environment, not `production`.

## Why

| Before                                       | After                                 |
| -------------------------------------------- | ------------------------------------- |
| `deploy-keeweb` → `production` env              | `deploy-keeweb` → `keeweb` env              |
| `deploy-cliproxy` → `cliproxy` env              | `deploy-cliproxy` → `cliproxy` env          |
| CLI: "Approve the production env deployment" | CLI: "Approve the keeweb env deployment" |

## What changed

**Workflow + repo config:**
- `.github/workflows/deploy.yaml` — `deploy-keeweb` job now uses `environment: keeweb`
- `.github/workflows/fro-bot.yaml` — autohealing "DEPLOY PIPELINE HEALTH" prompt now verifies the `keeweb` environment
- `.github/copilot-instructions.md` — secret-scope documentation updated
- `AGENTS.md` — project knowledge base secret-scope note updated

**Operational scripts:**
- `apps/keeweb/server/setup-deploy-user.ts` — post-provision instructions reference the `keeweb` environment
- `packages/cli/src/commands/keeweb-deploy.ts` — pre-deploy warning + approval prompts now name `keeweb`
- `packages/cli/src/commands/cliproxy-deploy.ts` — **bonus fix**: approval prompt now correctly says `cliproxy` (was leaking the copy-paste "production" from when the command was cloned from `keeweb-deploy.ts`)

**Docs:**
- `README.md` — regenerated via `/generate-readme`. Updates:
  - `apps/cliproxy` is no longer "scaffolded" — fully operational stack
  - Both `keeweb` and `cliproxy` environment tables documented
  - Full CLIProxyAPI CLI command catalog (status, deploy, config, keys, login)
  - Deploy Pipeline section describes the path-filtered dual-app flow
  - Repository structure tree reflects current 8-command CLI + cliproxy app layout

## GitHub environment operations (already done outside this PR)

1. Created new `keeweb` environment mirroring `cliproxy`'s protection rules (required reviewer: `@marcusrbrown`, branch policy: `main` only).
2. Transferred `DEPLOY_SSH_KEY` from the local `.env` to the new `keeweb` environment via `gh secret set --env keeweb`.

**Action still required from you before merging this PR:** set `DROPBOX_APP_SECRET` on the new `keeweb` environment. It is not stored in `.env`, so I cannot transfer it programmatically. Run:

```bash
gh secret set DROPBOX_APP_SECRET --env keeweb --repo marcusrbrown/infra
```

Or paste the value via the GitHub UI: **Settings → Environments → keeweb → Environment secrets → Add secret**.

Once that is set and this PR is merged, I can delete the old `production` environment on your instruction.

## Verification

- `bun run lint` → 0 errors (17 pre-existing `no-console` warnings on CLI scripts, unchanged)
- `bunx tsc --noEmit` → clean
- `bun test --recursive` → 104 pass, 0 fail
- No stale `production` references remain in active code, workflows, or docs (historical records in `docs/brainstorms/`, `docs/plans/`, `packages/cli/CHANGELOG.md`, and the vendored `.agents/skills/goke/SKILL.md` are intentionally left alone)

## Not changed (on purpose)

- **Historical records**: `docs/brainstorms/**`, `docs/plans/**`, and `packages/cli/CHANGELOG.md` still reference `production`. These are point-in-time artifacts of decisions that were made when `production` was the correct name; rewriting them would rewrite history.
- **Vendored skill content**: `.agents/skills/goke/SKILL.md` contains example CLI snippets mentioning `production` that are illustrative of the `goke` framework, not references to our environment.
- **Settings sync**: `.github/settings.yml` does not define environments (GitHub's settings app does not manage environments), so no change there. The `production` → `keeweb` rename is a pure API operation.
