### PR TITLE
fix: quick hardening wins — CI secret guard, fire-and-forget open, early key validation

### DIFF
--- a/apps/keeweb/src/build.test.ts
+++ b/apps/keeweb/src/build.test.ts
@@ -123,7 +123,7 @@ describe('writeConfigWithSecret', () => {
     expect(await Bun.file(realConfigTemplatePath).text()).toBe(originalRealTemplate)
   })
 
-  it('writes an empty secret when DROPBOX_APP_SECRET is unset', async () => {
+  it('writes an empty secret when DROPBOX_APP_SECRET is unset (non-CI)', async () => {
     const tempDir = await createTempDir()
     const tempTemplatePath = join(tempDir, 'config.template.json')
     const outputPath = join(tempDir, 'dist-config.json')
@@ -131,16 +131,40 @@ describe('writeConfigWithSecret', () => {
 
     await Bun.write(tempTemplatePath, Bun.file(realConfigTemplatePath))
     delete process.env.DROPBOX_APP_SECRET
+    const savedCI = process.env.CI
+    delete process.env.CI
 
-    await writeConfigWithSecret({configTemplatePath: tempTemplatePath, distConfigPath: outputPath})
+    try {
+      await writeConfigWithSecret({configTemplatePath: tempTemplatePath, distConfigPath: outputPath})
 
-    const output = JSON.parse(await Bun.file(outputPath).text()) as {
-      settings?: {dropboxSecret?: string}
+      const output = JSON.parse(await Bun.file(outputPath).text()) as {
+        settings?: {dropboxSecret?: string}
+      }
+
+      expect(output.settings?.dropboxSecret).toBe('')
+      expect(await Bun.file(tempTemplatePath).text()).toBe(await Bun.file(realConfigTemplatePath).text())
+      expect(await Bun.file(realConfigTemplatePath).text()).toBe(originalRealTemplate)
+    } finally {
+      if (savedCI !== undefined) process.env.CI = savedCI
     }
+  })
 
-    expect(output.settings?.dropboxSecret).toBe('')
-    expect(await Bun.file(tempTemplatePath).text()).toBe(await Bun.file(realConfigTemplatePath).text())
-    expect(await Bun.file(realConfigTemplatePath).text()).toBe(originalRealTemplate)
+  it('throws in CI when DROPBOX_APP_SECRET is unset', async () => {
+    const tempDir = await createTempDir()
+    const tempTemplatePath = join(tempDir, 'config.template.json')
+    const outputPath = join(tempDir, 'dist-config.json')
+
+    await Bun.write(tempTemplatePath, Bun.file(realConfigTemplatePath))
+    delete process.env.DROPBOX_APP_SECRET
+    process.env.CI = 'true'
+
+    try {
+      await expect(
+        writeConfigWithSecret({configTemplatePath: tempTemplatePath, distConfigPath: outputPath}),
+      ).rejects.toThrow('DROPBOX_APP_SECRET is required in CI')
+    } finally {
+      delete process.env.CI
+    }
   })
 })
 

--- a/apps/keeweb/src/build.ts
+++ b/apps/keeweb/src/build.ts
@@ -149,7 +149,11 @@ export async function writeConfigWithSecret(
   const settings =
     typeof config.settings === 'object' && config.settings !== null ? (config.settings as Record<string, unknown>) : {}
 
-  settings.dropboxSecret = process.env.DROPBOX_APP_SECRET || ''
+  const dropboxSecret = process.env.DROPBOX_APP_SECRET || ''
+  if (process.env.CI && !dropboxSecret) {
+    throw new Error('DROPBOX_APP_SECRET is required in CI — deployed KeeWeb cannot connect to Dropbox without it')
+  }
+  settings.dropboxSecret = dropboxSecret
   config.settings = settings
 
   await Bun.write(_distConfigPath, `${JSON.stringify(config, null, 2)}\n`)

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -560,6 +560,10 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
           ? await buildInteractivePlan(options, baseUrl)
           : buildNonInteractivePlan(options, baseUrl)
 
+        if (plan.createKey) {
+          resolveManagementKey()
+        }
+
         await withSpinner(`Checking GitHub access for ${plan.repo}`, async () => {
           await assertRepoAccess(plan.repo)
         })

--- a/packages/cli/src/commands/keeweb/open.ts
+++ b/packages/cli/src/commands/keeweb/open.ts
@@ -20,11 +20,11 @@ export function registerKeewebOpen(cli: CliInstance): void {
       return
     }
 
-    const child = Bun.spawn([opener, KEEWEB_URL], {
-      stdout: 'inherit',
-      stderr: 'inherit',
+    // Fire-and-forget — don't await. macOS `open` returns immediately but
+    // Linux `xdg-open` may block until the browser closes.
+    Bun.spawn([opener, KEEWEB_URL], {
+      stdout: 'ignore',
+      stderr: 'ignore',
     })
-
-    await child.exited
   })
 }


### PR DESCRIPTION
## Summary

Three surgical hardening fixes from the PR #98 code review residual items:

**#95 (P1)**: `build.ts` CI guard — `DROPBOX_APP_SECRET` missing in CI now throws with a clear message instead of silently writing an empty string. Local dev behavior (empty fallback) preserved.

**#3 (P2)**: `keeweb open` fire-and-forget — browser launcher no longer awaits `child.exited`. macOS `open` returns immediately, but Linux `xdg-open` may block until the browser closes, hanging the CLI.

**#5 (P2)**: Early management key validation — `resolveManagementKey()` now fires right after plan construction, before confirmation prompts and collision checks. Previously, users completed the entire wizard only to discover `CLIPROXY_MANAGEMENT_KEY` was missing at step 8 of 10.

Note: `cliproxy open` (SSH + TUI) correctly awaits — it's an interactive session, not a fire-and-forget launcher.

## Verification

- 133 tests pass (up from 132 — new CI guard test)
- tsc clean
- 0 lint errors

## Follow-up

- **PR B** (next): stdin piping for `gh secret set` (#4 — API key visible in `ps`)
- **PR C** (after B): setup wizard compensating delete + error scrubbing (#2 — orphaned keys on partial failure)

Closes #95.
