### PR TITLE
fix(cli): pipe secrets via stdin to prevent API key exposure in process list

### DIFF
--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -358,6 +358,22 @@ async function createManagementApiKey(baseUrl: string, managementKey: string, ke
 }
 
 async function applyGhValue(kind: 'secret' | 'variable', name: string, repo: string, value: string): Promise<void> {
+  if (kind === 'secret') {
+    const child = Bun.spawn(['gh', 'secret', 'set', name, '--repo', repo], {
+      stdin: new Blob([value]).stream(),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: process.env,
+    })
+
+    const [stderr, exitCode] = await Promise.all([new Response(child.stderr).text(), child.exited])
+
+    if (exitCode !== 0) {
+      throw new Error(`gh secret set ${name} failed: ${stderr.trim()}`.trim())
+    }
+    return
+  }
+
   const result = await runGh([kind, 'set', name, '--repo', repo, '--body', value])
   if (result.exitCode !== 0) {
     throw new Error(`gh ${kind} set ${name} failed: ${result.stderr.trim()}`.trim())


### PR DESCRIPTION
## Summary

Security hardening: `gh secret set` now receives secret values through stdin instead of `--body` CLI argument.

**Before:** `gh secret set NAME --repo REPO --body sk-key-value-here` — key visible in `ps aux` output.

**After:** Secret value piped via `Bun.spawn` stdin stream. `gh secret set` reads from stdin when `--body` is omitted (confirmed via `gh secret set --help`). Variables (non-sensitive, e.g. `FRO_BOT_MODEL`) still use `--body` since they don't contain credentials.

## Verification

- 132 tests pass, tsc clean, 0 lint errors
- Single file changed: `packages/cli/src/commands/cliproxy/setup.ts`
- Only the `kind === 'secret'` branch spawns directly; `kind === 'variable'` still uses `runGh` helper

## Follow-up

**PR C** (next): setup wizard compensating delete + error scrubbing (#2 — orphaned keys on partial failure)
