### PR TITLE
fix(cli): add compensating delete for setup wizard partial failures

### DIFF
--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -357,6 +357,26 @@ async function createManagementApiKey(baseUrl: string, managementKey: string, ke
   })
 }
 
+async function deleteManagementApiKey(baseUrl: string, managementKey: string, keyValue: string): Promise<void> {
+  const endpoint = `${baseUrl}/v0/management/api-keys`
+  const currentPayload = await requestJson(endpoint, {
+    method: 'GET',
+    headers: managementHeaders(managementKey),
+  })
+  const currentKeys = toStringArray(currentPayload)
+  const filtered = currentKeys.filter(k => k !== keyValue)
+
+  if (filtered.length === currentKeys.length) {
+    return
+  }
+
+  await requestJson(endpoint, {
+    method: 'PUT',
+    headers: managementHeaders(managementKey),
+    body: JSON.stringify(filtered),
+  })
+}
+
 async function applyGhValue(kind: 'secret' | 'variable', name: string, repo: string, value: string): Promise<void> {
   const result = await runGh([kind, 'set', name, '--repo', repo, '--body', value])
   if (result.exitCode !== 0) {
@@ -625,28 +645,45 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
           }
         }
 
-        if (plan.createKey) {
+        let keyCreatedByThisRun = false
+        const managementKey = plan.createKey ? resolveManagementKey() : undefined
+
+        if (plan.createKey && managementKey) {
           await withSpinner('Creating a new CLIProxyAPI key', async () => {
-            const managementKey = resolveManagementKey()
             await createManagementApiKey(baseUrl, managementKey, plan.keyValue)
+            keyCreatedByThisRun = true
           })
         }
 
-        await withSpinner('Writing GitHub secrets and variables', async spinnerInstance => {
-          for (const secret of plan.template.secrets) {
-            spinnerInstance.message(`Setting secret ${secret.name}`)
-            await applyGhValue('secret', secret.name, plan.repo, secret.value)
-          }
+        try {
+          await withSpinner('Writing GitHub secrets and variables', async spinnerInstance => {
+            for (const secret of plan.template.secrets) {
+              spinnerInstance.message(`Setting secret ${secret.name}`)
+              await applyGhValue('secret', secret.name, plan.repo, secret.value)
+            }
 
-          for (const variable of plan.template.variables) {
-            spinnerInstance.message(`Setting variable ${variable.name}`)
-            await applyGhValue('variable', variable.name, plan.repo, variable.value)
-          }
-        })
+            for (const variable of plan.template.variables) {
+              spinnerInstance.message(`Setting variable ${variable.name}`)
+              await applyGhValue('variable', variable.name, plan.repo, variable.value)
+            }
+          })
 
-        await withSpinner('Verifying the new key through the proxy', async () => {
-          await assertProxyKeyWorks(baseUrl, plan.keyValue)
-        })
+          await withSpinner('Verifying the new key through the proxy', async () => {
+            await assertProxyKeyWorks(baseUrl, plan.keyValue)
+          })
+        } catch (mutationError) {
+          if (keyCreatedByThisRun && managementKey) {
+            try {
+              await deleteManagementApiKey(baseUrl, managementKey, plan.keyValue)
+              log.warn('Rolled back the newly created CLIProxyAPI key after failure.')
+            } catch {
+              log.warn(
+                'Failed to roll back the newly created CLIProxyAPI key. Remove it manually via: infra cliproxy keys remove',
+              )
+            }
+          }
+          throw mutationError
+        }
 
         if (interactive) {
           outro(`Setup complete for ${plan.repo}. The ${plan.harness} harness can now use ${baseUrl}/v1.`)


### PR DESCRIPTION
## Summary

Adds best-effort compensating cleanup to the `cliproxy setup` wizard when mutations fail partway through.

**The problem:** If key creation succeeds but GitHub secret/variable writes fail, an orphaned API key remains on the proxy with no automatic cleanup. The user has to manually discover and remove it.

**The fix:** After key creation, the GitHub write + verification steps are wrapped in a try/catch. On failure:
1. If this run created the key, attempt to delete it via `PUT /v0/management/api-keys` (filter-and-replace pattern — avoids `DELETE ?value=<key>` which would expose the key in query string logs)
2. If cleanup succeeds, log a warning: "Rolled back the newly created CLIProxyAPI key after failure."
3. If cleanup also fails, log a warning with manual removal instructions
4. The original error is always re-thrown — cleanup failure never masks it

**Design decisions (from Oracle + Metis consultation):**
- Best-effort only — no retry loop, no transaction framework, no new files
- Uses PUT (get-filter-replace) instead of DELETE query param to avoid key exposure in logs
- `keyCreatedByThisRun` flag prevents cleanup when using `--key` (existing key path)
- Management key resolved once at the start of the mutation window, reused for both create and cleanup

## Verification

- 132 tests pass, tsc clean, 0 lint errors
- Single file changed: `packages/cli/src/commands/cliproxy/setup.ts` (+52/-15)
