### PR TITLE
docs: update AGENTS.md + invert Fro Bot cross-project check

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -213,42 +213,43 @@ env:
        "Needs Human Attention" in the summary. Do not fail the workflow.
        Close the browser when done: `npx agent-browser close`.
 
-    7. CROSS-PROJECT PROGRESSIVE IMPROVEMENT
-       This category is strictly observation-only. Survey marcusrbrown repos
-       to identify opportunities for progressive improvement across the
-       portfolio. Use `gh` CLI for all queries.
+    7. CROSS-PROJECT INTELLIGENCE (INBOUND)
+       Survey Marcus's other repos for patterns, tooling, and conventions
+       that could improve THIS repo. The goal is inbound intelligence —
+       what can we learn from the portfolio to make infra better?
 
-       Scope: Only repos owned by marcusrbrown (not forks, not archived).
-       Run: `gh repo list marcusrbrown --no-archived --source -L 50 --json name,defaultBranchRef,pushedAt`
+       Use `gh` CLI for all queries. Observation only — never modify
+       other repos.
 
-       For each active repo (pushed within 90 days), check:
-       a. CI health: `gh run list -R marcusrbrown/{repo} -b {default_branch} -L 3 --json conclusion`
-          Flag repos with 2+ consecutive failures on the default branch.
-       b. Fro Bot workflow presence: check if `.github/workflows/fro-bot.yaml`
-          exists. Flag repos without one.
-       c. AGENTS.md presence: check if `AGENTS.md` exists at repo root.
-          Flag repos without one.
-       d. Security alerts: `gh api repos/marcusrbrown/{repo}/vulnerability-alerts`
-          Flag repos with unaddressed critical/high advisories.
-          If the API is unavailable for a repo, note "alerts unavailable"
-          and continue.
-       e. Stale PRs: `gh pr list -R marcusrbrown/{repo} --json number,title,updatedAt -L 10`
-          Flag PRs with no activity >14 days.
-       f. Action version drift: if fro-bot.yaml exists, check the
-          `fro-bot/agent@` version. Flag repos using a version older than
-          this repo's pinned version.
+       Focus repos (check these every run, update the list if repos
+       become stale or new ones become relevant):
+       - `marcusrbrown/containers` — Docker patterns, base images
+       - `marcusrbrown/sparkle` — @bfra.me config versions, monorepo patterns
+       - `marcusrbrown/gpt` — Vitest/Playwright testing, AI patterns
+       - `marcusrbrown/copiloting` — @bfra.me config versions, AI patterns
+       - `marcusrbrown/renovate-config` — Renovate preset evolution
+       - `marcusrbrown/.github` — Shared workflows, templates
 
-       Hard boundaries for this category:
+       For each focus repo, check:
+       a. @bfra.me config versions: compare eslint-config, prettier-config,
+          tsconfig versions against this repo. Flag if they're ahead.
+       b. Tooling patterns: any build/test/CI tools we don't use?
+          (e.g., Turbo, Vitest, Playwright, Biome)
+       c. Fro Bot version: compare `fro-bot/agent@` SHA if present.
+       d. CI patterns: any workflow improvements we could adopt?
+       e. New dependencies or conventions worth evaluating.
+
+       Keep findings actionable and specific to infra. Skip repos with
+       nothing notable. The list of focus repos should evolve — drop
+       repos that consistently have nothing actionable, add repos that
+       become relevant.
+
+       Hard boundaries:
        - NEVER modify other repositories. Observation only.
        - NEVER open PRs, issues, or comments in other repositories.
        - NEVER clone or check out other repositories.
        - All findings go into the summary issue in THIS repository only.
-       - If `gh` queries fail for a repo (permissions, rate limits), skip
-         it and note why.
-
-       Purpose: Create a single dashboard of portfolio health so Marcus
-       can prioritize which repos to improve next. This category drives
-       progressive improvement by surfacing drift and decay early.
+       - If `gh` queries fail for a repo, skip it and note why.
 
     Hard boundaries:
     - Never force-push, rewrite history, or delete branches.
@@ -336,10 +337,10 @@ env:
     | Security headers | ✅ Present / ⚠️ Missing | [list missing] |
     | Mobile layout (375px) | ✅ OK / ⚠️ Broken | [details] |
 
-    ### Cross-Project Health
-    | Repo | CI | Fro Bot | AGENTS.md | Alerts | Stale PRs |
-    | --- | --- | --- | --- | --- | --- |
-    | [repo] | ✅/❌ | ✅/❌ [version] | ✅/❌ | N alerts | N stale |
+    ### Cross-Project Intelligence (Inbound)
+    | Repo | Finding | Actionable for infra? | Priority |
+    | --- | --- | --- | --- |
+    | [repo] | [what they do that we don't] | [specific action or "monitor"] | High/Med/Low |
 
     ### Needs Human Attention
     - [items that could not be auto-fixed, with context]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-04-10
-**Commit:** 49f7d6e
+**Generated:** 2026-04-13
+**Commit:** 1331fda
 **Branch:** main
 
 ## OVERVIEW
@@ -29,9 +29,13 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 | Add CLI command | `packages/cli/src/commands/` | goke command module, register in cli.ts |
 | Check deploy health | `bunx @marcusrbrown/infra keeweb status` | HTTP, last deploy, content hash |
 | Trigger deploy | `bunx @marcusrbrown/infra keeweb deploy` | Remote (default) or `--local` |
+| Open KeeWeb | `bunx @marcusrbrown/infra keeweb open` | Opens in browser, fire-and-forget |
 | Check proxy health | `bunx @marcusrbrown/infra cliproxy status` | HTTP, usage stats, version |
 | Manage proxy | `bunx @marcusrbrown/infra cliproxy config|keys|login` | Management API |
 | Trigger proxy deploy | `bunx @marcusrbrown/infra cliproxy deploy` | Remote (default) or `--local` |
+| Open proxy TUI | `bunx @marcusrbrown/infra cliproxy open` | SSH + interactive TUI |
+| Onboard repo | `bunx @marcusrbrown/infra cliproxy setup` | Interactive wizard with @clack/prompts |
+| Unified status | `bunx @marcusrbrown/infra status` | All deployments, `--json` for machine output |
 | Add workflow | `.github/workflows/` | Use `.yaml` extension, SHA-pin all actions |
 | Configure ESLint | `eslint.config.ts` | Flat config via `@bfra.me/eslint-config` |
 | Configure TypeScript | `tsconfig.json` | Extends `@bfra.me/tsconfig`, Bun types |
@@ -52,6 +56,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 - **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root.
 - **Changesets**: `@changesets/cli` for versioning. Renovate PRs get auto-generated changeset files.
 - **Tests**: Colocated `*.test.ts` alongside source. Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic snapshots. Mock at boundaries (fetch, Bun.spawn), not internals. CI runs `bun test --recursive` as a parallel job alongside lint/type-check.
+- **CI Node pin**: All workflows running `bun run lint` or `bunx tsc` must pin Node 24 via `actions/setup-node` — ESLint binary shebang uses system Node, which on ubuntu-latest is Node 20 (lacks ES2024 APIs like `Object.groupBy`).
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
@@ -85,9 +90,14 @@ bash apps/keeweb/deploy.sh                     # Deploy content only
 bash apps/keeweb/deploy.sh --nginx             # Deploy content + nginx config
 bunx @marcusrbrown/infra keeweb status          # Check deploy health
 bunx @marcusrbrown/infra keeweb deploy          # Trigger deploy (GitHub Actions)
-bunx @marcusrbrown/infra cliproxy status        # Check proxy health
-bunx @marcusrbrown/infra cliproxy deploy        # Trigger proxy deploy (GitHub Actions)
-bunx @marcusrbrown/infra mcp                    # Start MCP server
+bunx @marcusrbrown/infra keeweb open              # Open KeeWeb in browser
+bunx @marcusrbrown/infra cliproxy status          # Check proxy health
+bunx @marcusrbrown/infra cliproxy deploy          # Trigger proxy deploy (GitHub Actions)
+bunx @marcusrbrown/infra cliproxy open            # Open proxy TUI via SSH
+bunx @marcusrbrown/infra cliproxy setup           # Onboard repo to CLIProxyAPI
+bunx @marcusrbrown/infra status                   # Unified status (all deployments)
+bunx @marcusrbrown/infra status --json            # Machine-readable status
+bunx @marcusrbrown/infra mcp                      # Start MCP server
 bun run apps/keeweb/server/setup-deploy-user.ts # Provision deploy user on server
 ```
 

--- a/apps/cliproxy/AGENTS.md
+++ b/apps/cliproxy/AGENTS.md
@@ -10,7 +10,7 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 | Docker stack | `docker-compose.yaml` | Caddy + cli-proxy-api, restart: unless-stopped, healthcheck on root |
 | Provision droplet | `server/provision-droplet.ts` | One-time. Refuses re-run on existing droplet without `--force` |
 | Deploy updates | `src/deploy.ts` | Preserves `config.yaml`, preflight management key check |
-| CLI commands | `packages/cli/src/commands/cliproxy-*.ts` | Wrapper commands (see packages/cli/AGENTS.md) |
+| CLI commands | `packages/cli/src/commands/cliproxy/` | See packages/cli/AGENTS.md for command pattern |
 
 ## DEPLOY FLOW
 
@@ -30,7 +30,7 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 
 ## MANAGEMENT API
 
-Verified endpoint surface (see `apps/cliproxy/src/deploy.ts` and `packages/cli/src/commands/cliproxy-*.ts`). Auth: `x-management-key` header **only**. The `Authorization: Bearer` header is for client API key auth (proxied requests to Claude), not management endpoints.
+Verified endpoint surface (see `apps/cliproxy/src/deploy.ts` and `packages/cli/src/commands/cliproxy/`). Auth: `x-management-key` header **only**. The `Authorization: Bearer` header is for client API key auth (proxied requests to Claude), not management endpoints.
 
 | Endpoint | Method | Body | Notes |
 | --- | --- | --- | --- |

--- a/apps/keeweb/AGENTS.md
+++ b/apps/keeweb/AGENTS.md
@@ -52,6 +52,7 @@ The `packages/cli/` provides wrapper commands for keeweb operations:
 - `bunx @marcusrbrown/infra keeweb status` — HTTP check, last deploy, content hash comparison
 - `bunx @marcusrbrown/infra keeweb deploy` — triggers GitHub Actions workflow or local deploy.sh
 - `bunx @marcusrbrown/infra keeweb deploy --local` — runs deploy.sh directly (requires ssh-agent)
+- `bunx @marcusrbrown/infra keeweb open` — opens https://kw.igg.ms/ in default browser (fire-and-forget)
 
 See `packages/cli/AGENTS.md` for CLI conventions.
 
@@ -61,3 +62,4 @@ See `packages/cli/AGENTS.md` for CLI conventions.
 - Never run `deploy.sh` without building first — it validates `dist/` contents.
 - Never deploy nginx config without `--nginx` flag — content-only is the safe default.
 - `rsync` uses `--no-times --no-perms` to avoid permission errors with the deploy user.
+- In CI, `DROPBOX_APP_SECRET` must be set and non-empty — `build.ts` throws. Locally, empty secret is tolerated (Dropbox storage disabled).

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -54,6 +54,9 @@ Space-separated subcommands: `cli.command('keeweb status', '...')`. Zod schemas 
 - **`--dry-run` semantics**: Prints the planned action without validating preconditions or executing side effects. Safe to run anywhere.
 - **`--force-config` (cliproxy deploy)**: Override the safe default that skips uploading `config.yaml` when it exists on the server. Wipes runtime API keys — print a WARNING when set.
 - **`--output <file>` (cliproxy config get)**: Write JSON to a file with `0600` perms instead of stdout. Wraps `Bun.write` + `chmod` in try/catch.
+- **Fire-and-forget opens**: `keeweb open` and `cliproxy open` spawn the child process without awaiting `child.exited` — prevents blocking on Linux `xdg-open` or long-lived SSH sessions. Close stdin immediately after spawn.
+- **Stdin piping for secrets**: When `cliproxy setup` passes an API key to `gh secret set`, use `Bun.spawn` stdin pipe instead of `--body` CLI arg. The key never appears in `ps` output.
+- **Compensating delete**: `cliproxy setup` wraps key creation in try/catch. On failure after a key was created, best-effort `DELETE /v0/management/api-keys?value=<key>` to avoid phantom keys. Error messages scrub key material.
 - **Tests**: colocated `*.test.ts`. Snapshots in `src/__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic output. Mock `fetch` and `Bun.spawn` at the boundary. Never spawn the real CLI for commands that launch browser (`keeweb open`) or SSH (`cliproxy open`) — test exported helpers and `--help` output only.
 
 ## ANTI-PATTERNS


### PR DESCRIPTION
## Summary

Update AGENTS.md hierarchy to reflect the CLI zhuzh (PR #98) and hardening PRs (#101-103), plus rewrite Fro Bot's cross-project category from outbound monitoring to inbound intelligence.

### AGENTS.md changes

| File | Key updates |
| --- | --- |
| **AGENTS.md** (root) | Added `keeweb open`, `cliproxy open/setup`, unified `status` commands to WHERE TO LOOK and COMMANDS. Added CI Node 24 pin convention. |
| **apps/cliproxy/AGENTS.md** | Fixed stale CLI path (`cliproxy-*.ts` → `cliproxy/`). Fixed management API reference path. |
| **apps/keeweb/AGENTS.md** | Added `keeweb open` command. Added CI guard convention (build.ts throws when `DROPBOX_APP_SECRET` unset in CI). |
| **packages/cli/AGENTS.md** | Added fire-and-forget open convention, stdin piping for secrets, compensating delete pattern. |

### Fro Bot autohealing changes

**Category 7 rewrite: "Cross-Project Progressive Improvement" → "Cross-Project Intelligence (Inbound)"**

Old behavior: surveyed ALL 50 active `marcusrbrown/*` repos for CI health, Fro Bot presence, AGENTS.md presence, security alerts, stale PRs, and action version drift. Generic portfolio dashboard.

New behavior: surveys a **curated list of focus repos** for patterns that could specifically improve `marcusrbrown/infra`:
- `containers` — Docker patterns
- `sparkle` — @bfra.me config versions, monorepo patterns
- `gpt` — Vitest/Playwright testing, AI patterns
- `copiloting` — @bfra.me config versions
- `renovate-config` — Renovate preset evolution
- `.github` — Shared workflows, templates

Checks are now comparative: "@bfra.me/eslint-config is ahead in sparkle (0.50.3 vs our 0.50.1)" rather than "does the repo have AGENTS.md: yes/no".

The focus repo list is explicitly designed to evolve — Fro Bot can drop repos that consistently have nothing actionable and add new ones.

**Output format**: Table changed from `| Repo | CI | Fro Bot | AGENTS.md | Alerts | Stale PRs |` to `| Repo | Finding | Actionable for infra? | Priority |` — optimized for a human to scan and delegate.
