### PR TITLE
fix(ci): fall back to autohealing prompt on empty workflow_dispatch

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
     inputs:
       prompt:
-        description: Custom prompt for the Fro Bot agent
-        required: true
+        description: Custom prompt (leave empty to run the daily autohealing schedule)
+        required: false
 
 permissions:
   contents: read
@@ -406,8 +406,8 @@ jobs:
           OPENCODE_PROMPT_ARTIFACT: 'true'
           PROMPT: >-
             ${{
-              (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || ''))
-              || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.prompt)
+              || ((github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !github.event.inputs.prompt)) && env.SCHEDULE_PROMPT)
               || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
               || ''
             }}


### PR DESCRIPTION
## Summary

When `workflow_dispatch` fires with an empty prompt (or via `gh workflow run` without `-f prompt=...`), the Fro Bot job now falls back to `SCHEDULE_PROMPT` (the daily autohealing prompt) instead of passing an empty string.

### Before
- `workflow_dispatch` with empty prompt → Fro Bot gets `""` → default agent behavior (not autohealing)
- Testing the autohealing flow manually required copy-pasting the 350-line `SCHEDULE_PROMPT` into the dispatch input

### After
- `workflow_dispatch` with empty prompt → falls back to `SCHEDULE_PROMPT` → runs the full 7-category autohealing
- `workflow_dispatch` with custom prompt → uses the custom prompt (unchanged)
- Prompt input marked `required: false` with a description noting the fallback

### Testing
Run `gh workflow run fro-bot.yaml` (no `-f prompt=...`) and verify the job picks up the autohealing prompt.
