### PR TITLE
fix(ci): pin Node 24 in Fro Bot workflow

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -394,6 +394,15 @@ jobs:
             }}
           token: ${{ secrets.FRO_BOT_PAT }}
 
+      # Pin Node.js because Fro Bot runs `bun run lint` / `bunx tsc` which
+      # spawn eslint/tsc via #!/usr/bin/env node shebang. ubuntu-latest
+      # ships Node 20 which lacks ES2024 APIs (Object.groupBy) used by
+      # eslint-flat-config-utils 3.1.0+.
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 


### PR DESCRIPTION
## Summary

Pin Node 24 in the Fro Bot workflow — the same fix already applied to `ci.yaml` (#89) and `copilot-setup-steps.yaml` (#104).

### Problem

The Fro Bot autohealing report (#108) flagged this as a recurring issue: `bun run lint` spawns `eslint` via `#!/usr/bin/env node` shebang, which picks up Node 20 from the ubuntu-latest runner. `eslint-flat-config-utils@3.1.0` calls `Object.groupBy` — an ES2024 API unavailable in Node 20.

Actual CI passes because `ci.yaml` already pins Node 24. But Fro Bot runs the same commands without the pin, so its lint check reports a misleading environment error.

### Fix

Add `actions/setup-node@v6.3.0` with `node-version: 24` before `setup-bun`, matching the pattern in all other workflows.

Resolves the "Fro Bot runner Node version" recurring item in the autohealing report.
