### PR TITLE
fix(keeweb): add security headers via nginx snippet

### DIFF
--- a/apps/keeweb/config/kw-security-headers.conf
+++ b/apps/keeweb/config/kw-security-headers.conf
@@ -1,0 +1,10 @@
+# Security headers for kw.igg.ms
+# Include this snippet in every location block that uses add_header,
+# because nginx's add_header in a location block replaces (not supplements)
+# server-level add_header directives.
+
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer" always;
+add_header Strict-Transport-Security "max-age=15768000" always;
+add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https://api.dropboxapi.com https://content.dropboxapi.com https://www.dropbox.com; connect-src 'self' https://api.dropboxapi.com https://content.dropboxapi.com https://www.dropbox.com https://notify.dropboxapi.com;" always;

--- a/apps/keeweb/config/kw.igg.ms.conf
+++ b/apps/keeweb/config/kw.igg.ms.conf
@@ -1,15 +1,14 @@
 # KeeWeb nginx config for kw.igg.ms
 # Updated for KeeWeb v1.18.7
 
-# Security headers
-add_header X-Frame-Options "DENY" always;
-add_header X-Content-Type-Options "nosniff" always;
-add_header Referrer-Policy "no-referrer" always;
-add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https://api.dropboxapi.com https://content.dropboxapi.com https://www.dropbox.com; connect-src 'self' https://api.dropboxapi.com https://content.dropboxapi.com https://www.dropbox.com https://notify.dropboxapi.com;" always;
+# Security headers at server level — applies to locations without their
+# own add_header directives (e.g., the SPA catch-all).
+include snippets/kw-security-headers.conf;
 
 # OAuth result callback pages — must be served exactly
 location /oauth-result/ {
     try_files $uri =404;
+    include snippets/kw-security-headers.conf;
     add_header Cache-Control "no-store";
 }
 
@@ -21,12 +20,14 @@ location / {
 # Don't cache HTML, config, manifests, or service worker
 location ~* \.(?:manifest|appcache|html?|xml|json)$ {
     expires -1;
+    include snippets/kw-security-headers.conf;
     add_header Cache-Control "no-cache, no-store, must-revalidate";
 }
 
 # Service worker must never be cached
 location = /service-worker.js {
     expires -1;
+    include snippets/kw-security-headers.conf;
     add_header Cache-Control "no-cache, no-store, must-revalidate";
 }
 
@@ -34,6 +35,7 @@ location = /service-worker.js {
 location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
     expires 30d;
     access_log off;
+    include snippets/kw-security-headers.conf;
     add_header Cache-Control "public, immutable";
 }
 
@@ -41,6 +43,7 @@ location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
 location ~* \.(?:css|js|wasm)$ {
     expires 30d;
     access_log off;
+    include snippets/kw-security-headers.conf;
     add_header Cache-Control "public, immutable";
 }
 

--- a/apps/keeweb/deploy.sh
+++ b/apps/keeweb/deploy.sh
@@ -44,6 +44,10 @@ if [ "$WITH_NGINX" = true ] && [ ! -f "$DEPLOY_DIR/kw.igg.ms.conf" ]; then
     echo "ERROR: dist directory missing kw.igg.ms.conf for --nginx deploy" >&2
     exit 1
 fi
+if [ "$WITH_NGINX" = true ] && [ ! -f "$DEPLOY_DIR/kw-security-headers.conf" ]; then
+    echo "ERROR: dist directory missing kw-security-headers.conf for --nginx deploy" >&2
+    exit 1
+fi
 
 log "Deploying KeeWeb v1.18.7 to $HOST"
 
@@ -61,12 +65,14 @@ ssh "${REMOTE_USER}@${HOST}" "
 log "Uploading site files"
 rsync -rlvz --delete --no-times --no-perms \
     --exclude='kw.igg.ms.conf' \
+    --exclude='kw-security-headers.conf' \
     --exclude='.DS_Store' \
     "$DEPLOY_DIR/" "${REMOTE_USER}@${HOST}:${SITE_DIR}/"
 
 if [ "$WITH_NGINX" = true ]; then
-    log "Staging nginx config for activation"
+    log "Staging nginx config and security headers snippet for activation"
     scp "$DEPLOY_DIR/kw.igg.ms.conf" "${REMOTE_USER}@${HOST}:${STAGING_DIR}/kw.igg.ms.conf"
+    scp "$DEPLOY_DIR/kw-security-headers.conf" "${REMOTE_USER}@${HOST}:${STAGING_DIR}/kw-security-headers.conf"
 
     log "Activating site content and nginx config"
     ssh "${REMOTE_USER}@${HOST}" "sudo '$ACTIVATE_CMD' --nginx"

--- a/apps/keeweb/server/setup-deploy-user.ts
+++ b/apps/keeweb/server/setup-deploy-user.ts
@@ -25,6 +25,7 @@ set -euo pipefail
 
 SITE_DIR="${SITE_DIR}"
 NGINX_CONF="${NGINX_CONF}"
+SNIPPETS_DIR="/etc/nginx/snippets"
 STAGING_DIR="/home/${DEPLOY_USER}/staging"
 
 log() { printf "\\033[1;34m==>\\033[0m %s\\n" "$1"; }
@@ -37,6 +38,7 @@ find "$SITE_DIR" -type d -exec chmod g+s {} +
 
 if [[ "\${1:-}" == "--nginx" ]]; then
     STAGED_CONF="$STAGING_DIR/kw.igg.ms.conf"
+    STAGED_HEADERS="$STAGING_DIR/kw-security-headers.conf"
 
     if [[ ! -f "$STAGED_CONF" ]]; then
         err "No staged nginx config at $STAGED_CONF"
@@ -50,6 +52,17 @@ if [[ "\${1:-}" == "--nginx" ]]; then
         log "Backed up current config to \${NGINX_CONF}.bak"
     fi
 
+    # Install security headers snippet if staged
+    if [[ -f "$STAGED_HEADERS" ]]; then
+        if [[ -f "$SNIPPETS_DIR/kw-security-headers.conf" ]]; then
+            cp "$SNIPPETS_DIR/kw-security-headers.conf" "$SNIPPETS_DIR/kw-security-headers.conf.bak"
+        fi
+        cp "$STAGED_HEADERS" "$SNIPPETS_DIR/kw-security-headers.conf"
+        chown root:root "$SNIPPETS_DIR/kw-security-headers.conf"
+        chmod 644 "$SNIPPETS_DIR/kw-security-headers.conf"
+        log "Installed security headers snippet"
+    fi
+
     cp "$STAGED_CONF" "$NGINX_CONF"
     chown user-data:user-data "$NGINX_CONF"
     chmod 644 "$NGINX_CONF"
@@ -58,13 +71,17 @@ if [[ "\${1:-}" == "--nginx" ]]; then
         log "nginx config valid — reloading"
         systemctl reload nginx
         log "nginx reloaded successfully"
-        rm -f "$STAGED_CONF"
+        rm -f "$STAGED_CONF" "$STAGED_HEADERS"
     else
         err "nginx config validation FAILED — rolling back"
         if [[ -f "\${NGINX_CONF}.bak" ]]; then
             cp "\${NGINX_CONF}.bak" "$NGINX_CONF"
             chown user-data:user-data "$NGINX_CONF"
-            log "Restored backup config"
+            log "Restored backup site config"
+        fi
+        if [[ -f "$SNIPPETS_DIR/kw-security-headers.conf.bak" ]]; then
+            cp "$SNIPPETS_DIR/kw-security-headers.conf.bak" "$SNIPPETS_DIR/kw-security-headers.conf"
+            log "Restored backup security headers snippet"
         fi
         exit 1
     fi

--- a/apps/keeweb/src/build.ts
+++ b/apps/keeweb/src/build.ts
@@ -14,8 +14,10 @@ const zipPath = path.join(cacheDir, ZIP_FILENAME)
 const distDir = path.join(rootDir, 'dist')
 const configTemplatePath = path.join(rootDir, 'config', 'config.json')
 const nginxTemplatePath = path.join(rootDir, 'config', 'kw.igg.ms.conf')
+const headersTemplatePath = path.join(rootDir, 'config', 'kw-security-headers.conf')
 const distConfigPath = path.join(distDir, 'config.json')
 const distNginxPath = path.join(distDir, 'kw.igg.ms.conf')
+const distHeadersPath = path.join(distDir, 'kw-security-headers.conf')
 
 const ANSI = {
   blue: '\u001B[1;34m',
@@ -169,6 +171,16 @@ export async function copyNginxConfig(
   await Bun.write(_distNginxPath, Bun.file(_nginxTemplatePath))
 }
 
+export async function copySecurityHeaders(
+  overrides: {headersTemplatePath?: string; distHeadersPath?: string} = {},
+): Promise<void> {
+  const _headersTemplatePath = overrides.headersTemplatePath ?? headersTemplatePath
+  const _distHeadersPath = overrides.distHeadersPath ?? distHeadersPath
+
+  logStep('Copying security headers snippet into dist')
+  await Bun.write(_distHeadersPath, Bun.file(_headersTemplatePath))
+}
+
 async function main(): Promise<void> {
   logStep(`Starting KeeWeb build for v${KEEWEB_VERSION}`)
 
@@ -177,6 +189,7 @@ async function main(): Promise<void> {
   await extractArchive()
   await writeConfigWithSecret()
   await copyNginxConfig()
+  await copySecurityHeaders()
 
   logSuccess(`Build complete: ${distDir}`)
 }


### PR DESCRIPTION
## Summary

Add security headers (X-Frame-Options, X-Content-Type-Options, Content-Security-Policy, Referrer-Policy, Strict-Transport-Security) to the KeeWeb nginx config via an included snippet.

Flagged as recurring by the Fro Bot autohealing report (#108): "Missing security headers — X-Frame-Options, X-Content-Type-Options, Content-Security-Policy, Strict-Transport-Security not present in response headers."

### Root cause

The existing config already had 4 security headers defined at server level (lines 5-8 of `kw.igg.ms.conf`). But nginx's `add_header` directive in a location block **completely replaces** server-level `add_header` directives — it doesn't supplement them. Every location block with its own `add_header Cache-Control` (5 of 6 locations) silently dropped the security headers.

Verified: `curl -sI https://kw.igg.ms/ | grep -i x-frame` returns nothing.

### Fix

Extract all security headers to `/etc/nginx/snippets/kw-security-headers.conf` and `include` it in every location block that has its own `add_header`. The `location /` block (SPA catch-all) has no `add_header` of its own, so it inherits the server-level include correctly.

Also adds HSTS (`Strict-Transport-Security: max-age=15768000`) matching MIAB's existing policy for other sites on the same server.

### Deploy pipeline changes

| Component | Change |
| --- | --- |
| `config/kw-security-headers.conf` | **New** — the snippet source file |
| `config/kw.igg.ms.conf` | Rewritten to use `include snippets/kw-security-headers.conf;` in all location blocks |
| `src/build.ts` | Added `copySecurityHeaders()` — copies snippet to `dist/` alongside nginx config |
| `deploy.sh` | Stages snippet via `scp` alongside nginx config; validates both exist for `--nginx` deploy; excludes from content rsync |
| `kw-deploy-activate` (on server) | Installs snippet to `/etc/nginx/snippets/` with backup + rollback on `nginx -t` failure |
| `setup-deploy-user.ts` | Embedded activation script updated to match live server version |

### Deployment

This PR updates the config files in the repo. To deploy the security headers:

1. Merge this PR
2. Run the Deploy workflow with `--nginx` (or trigger workflow_dispatch — which always includes nginx)
3. The activation script will install the snippet + config, validate with `nginx -t`, and reload

The activation script on the server was already updated to support the snippet. The first `--nginx` deploy after merge will install it.

### Verification

After deploy, verify headers are present:
```bash
curl -sI https://kw.igg.ms/ | grep -iE 'x-frame|x-content-type|content-security|strict-transport|referrer-policy'
```

Expected:
```
x-frame-options: DENY
x-content-type-options: nosniff
referrer-policy: no-referrer
strict-transport-security: max-age=15768000
content-security-policy: default-src 'self' ...
```
