### PR TITLE
chore(release): remove changeset target normalization workaround

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,32 +61,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Workaround for bfra-me/.github#2012: renovate-changesets action's
-      # getRootPackageName() returns the workspace root package name
-      # (@marcusrbrown/infra-workspace) for github-actions updates because those
-      # files don't belong to any workspace member. The root package is private
-      # and not in manypkg's workspace list, so `changeset version` fails with
-      # "package not in the workspace". Rewrite any such entries to target the
-      # published CLI package before running changesets/action. Remove this step
-      # when bfra-me/.github#2012 is fixed upstream.
-      - name: Normalize changeset targets
-        run: |
-          shopt -s nullglob
-          # Match the package name at the start of a line (YAML frontmatter key),
-          # tolerating single-quoted, double-quoted, or unquoted forms so the
-          # workaround survives if upstream changes its serialization style. The
-          # line-start anchor and trailing colon scope the match to frontmatter
-          # keys, leaving prose in the changeset body untouched. We don't back-
-          # reference the opening quote because BSD sed doesn't support \1 in
-          # ERE; mismatched quotes (e.g. '"...) don't occur in valid YAML.
-          pattern="^['\"]?@marcusrbrown/infra-workspace['\"]?:"
-          for file in .changeset/*.md; do
-            if grep -Eq "$pattern" "$file"; then
-              sed -i -E "s|$pattern|'@marcusrbrown/infra':|" "$file"
-              echo "Rewrote changeset target in $file"
-            fi
-          done
-
       - id: changesets
         name: Create Release Pull Request or Publish
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0


### PR DESCRIPTION
## Summary

Remove the "Normalize changeset targets" workaround from the Release workflow. The upstream fix in `bfra-me/.github` v4.16.4 ([PR #2016](https://github.com/bfra-me/.github/pull/2016)) makes `getRootPackageName()` skip private workspace roots and fall back to the first non-private workspace member — exactly what we need.

Closes the last of three reusable-workflow fixes for external callers:
- ~~`bfra-me/.github#1990`~~ — `workflow_call` event name check (fixed in v4.16.1)
- ~~`bfra-me/.github#2003`~~ — hardcoded author allowlist (fixed in v4.16.2)
- ~~`bfra-me/.github#2012`~~ — private workspace root targeting (fixed in v4.16.4) ← **this PR**

All three reusable workflows are already pinned to `bfra-me/.github@v4.16.4` (SHA `8a9d25468e`).

## What changed

Deleted 26 lines: the `Normalize changeset targets` step that used `sed` to rewrite `@marcusrbrown/infra-workspace` → `@marcusrbrown/infra` in changeset frontmatter files before `changesets/action` ran.

## Remaining local workaround

One workaround remains: `apps/cliproxy/docker-compose.yaml` pins `eceasy/cli-proxy-api` to a semver tag instead of `:latest` to sidestep a changeset formatting bug ([bfra-me/.github#2018](https://github.com/bfra-me/.github/issues/2018)). This is actually the right thing to do regardless (gives us release notes), so it's more of a best practice than a workaround.
