### PR TITLE
fix(release): scope renovate-changesets to published CLI package only

### DIFF
--- a/.changeset/renovate-8393f52.md
+++ b/.changeset/renovate-8393f52.md
@@ -1,5 +1,0 @@
----
-'@marcusrbrown/infra-workspace': patch
----
-
-📦 Update 6 GitHub Actions workflow dependencies

--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -4,19 +4,11 @@ name: Renovate Changesets
 on:
   pull_request_target:
 
-permissions:
-  contents: read
-
 jobs:
   renovate-changesets:
     name: Create Renovate Changeset
     runs-on: ubuntu-latest
-    if: >-
-      (github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]') &&
-      !startsWith(github.head_ref, 'chore/update-action-pins-')
-    permissions:
-      contents: write
-      pull-requests: write
+    if: github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]'
     steps:
       - id: get-app-token
         name: Get Workflow Access Token

--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -9,9 +9,43 @@ permissions:
 
 jobs:
   renovate-changesets:
-    if: github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]'
     name: Create Renovate Changeset
-    secrets:
-      APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
-      APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-    uses: bfra-me/.github/.github/workflows/renovate-changeset.yaml@06b5ae65dfda1716812439469af0729d759adedd # v4.16.5
+    runs-on: ubuntu-latest
+    if: >-
+      (github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]') &&
+      !startsWith(github.head_ref, 'chore/update-action-pins-')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - id: get-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: Setup Git user
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          GIT_USER_NAME: ${{ steps.get-app-token.outputs.app-slug }}[bot]
+        run: |
+          USER_ID=$(gh api "/users/${GIT_USER_NAME}" --jq .id)
+          git config --global user.email "${USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+          git config --global user.name "${GIT_USER_NAME}"
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.get-app-token.outputs.token }}
+
+      - name: Generate Renovate changesets
+        uses: bfra-me/.github/.github/actions/renovate-changesets@06b5ae65dfda1716812439469af0729d759adedd # renovate-changesets@0.2.31
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          commit-back: 'true'
+          max-retries: '3'
+          target-package: '@marcusrbrown/infra'
+          exclude-patterns: '.github/**,apps/**,bun.lock,package.json'


### PR DESCRIPTION
## Summary

Scopes Renovate auto-changesets to the published CLI package only. Fixes the recurring `changeset version` failure caused by changesets targeting the private workspace root.

## What changed

**Switched from reusable workflow to direct action call** — the `bfra-me/.github` reusable workflow doesn't expose `exclude-patterns` or `target-package` inputs. Calling `renovate-changesets@0.2.31` directly gives us full control.

**Two key inputs:**

- `exclude-patterns: '.github/**,apps/**,bun.lock,package.json'` — skips github-actions SHA pins, Docker digest bumps, private app changes, and root dev-dep updates. None of these ship in `@marcusrbrown/infra`.
- `target-package: '@marcusrbrown/infra'` — safety net for any remaining fallback bumps that slip through the exclude filter.

**Deleted stale changeset** — `renovate-8393f52.md` targeted `@marcusrbrown/infra-workspace` (from PR #115 before the fix landed).

## What generates changesets now

Only Renovate PRs that modify files under `packages/cli/` — the published `@marcusrbrown/infra` package. Everything else merges without a changeset, which is correct because those changes don't affect the npm release.

## Context

The upstream fix in `bfra-me/.github` v4.16.4 (PR #2016) made `getRootPackageName()` skip private workspace roots. But the fundamental issue remained: github-actions updates touch `.github/workflows/` files that don't belong to *any* workspace member, so the action still falls back to the root. `exclude-patterns` is the proper solution — it removes those files from consideration before the fallback logic runs.

Also merges PR #114 (sed workaround removal from `release.yaml`) which is now on `main`.
