### PR TITLE
fix(cliproxy): default FRO_BOT_MODEL to anthropic/claude-sonnet-4-6

### DIFF
--- a/.changeset/fix-cliproxy-setup-fro-bot-model-prefix.md
+++ b/.changeset/fix-cliproxy-setup-fro-bot-model-prefix.md
@@ -1,0 +1,9 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix `cliproxy setup` wizard to default `FRO_BOT_MODEL` to `anthropic/claude-sonnet-4-6`
+instead of the unprefixed `claude-sonnet-4-6`. OpenCode requires provider-qualified model
+identifiers. Added regression tests that lock in the provider prefix, the `OMO_PROVIDERS`
+value, the `OPENCODE_CONFIG` baseURL `/v1` suffix, and the `OPENCODE_AUTH_JSON` shape so
+the same default drift cannot recur silently.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -43,6 +43,36 @@ describe('cliproxy setup helpers', () => {
       ])
       expect(template.variables.map((entry: VariableAssignment) => entry.name)).toEqual(['FRO_BOT_MODEL'])
     })
+
+    it('uses a provider-prefixed FRO_BOT_MODEL default value', () => {
+      const template = getHarnessTemplate('opencode', {keyValue: 'sk-test'})
+      const modelEntry = template.variables.find((entry: VariableAssignment) => entry.name === 'FRO_BOT_MODEL')
+
+      expect(modelEntry?.value).toMatch(/^anthropic\//)
+    })
+
+    it('uses the expected OMO_PROVIDERS default value', () => {
+      const template = getHarnessTemplate('opencode', {keyValue: 'sk-test'})
+      const providersEntry = template.secrets.find((entry: SecretAssignment) => entry.name === 'OMO_PROVIDERS')
+
+      expect(providersEntry?.value).toBe('claude-max20')
+    })
+
+    it('writes an OPENCODE_CONFIG baseURL with the /v1 suffix', () => {
+      const template = getHarnessTemplate('opencode', {keyValue: 'sk-test'})
+      const configEntry = template.secrets.find((entry: SecretAssignment) => entry.name === 'OPENCODE_CONFIG')
+      const parsed = JSON.parse(configEntry?.value ?? '{}')
+
+      expect(parsed.provider.anthropic.options.baseURL).toMatch(/\/v1$/)
+    })
+
+    it('writes OPENCODE_AUTH_JSON with type=api and the supplied key', () => {
+      const template = getHarnessTemplate('opencode', {keyValue: 'sk-test-key'})
+      const authEntry = template.secrets.find((entry: SecretAssignment) => entry.name === 'OPENCODE_AUTH_JSON')
+      const parsed = JSON.parse(authEntry?.value ?? '{}')
+
+      expect(parsed.anthropic).toEqual({type: 'api', key: 'sk-test-key'})
+    })
   })
 
   describe('help output', () => {

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -12,7 +12,7 @@ import {toStringArray} from './keys'
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
 const HTTP_TIMEOUT_MS = 10_000
 const DEFAULT_OMO_PROVIDERS = 'claude-max20'
-const DEFAULT_FRO_BOT_MODEL = 'claude-sonnet-4-6'
+const DEFAULT_FRO_BOT_MODEL = 'anthropic/claude-sonnet-4-6'
 
 const harnessSchema = z.enum(['opencode', 'claude-code', 'generic'])
 const ghRepoViewSchema = z.object({


### PR DESCRIPTION
## What

Fixes the `cliproxy setup` wizard's `FRO_BOT_MODEL` default from `claude-sonnet-4-6` to `anthropic/claude-sonnet-4-6`. OpenCode requires provider-qualified model identifiers — the unprefixed value caused Fro Bot runs to fail in newly onboarded repos.

## Why it shipped broken

The old `getHarnessTemplate` test only asserted the variable **name** was `FRO_BOT_MODEL`, not the **value**. Configuration defaults had no coverage, so the missing prefix went through CI, review, release, and production without flagging.

## Regression tests

Added four assertions to lock in the onboarding defaults:

| Default            | Asserted                                  |
| ------------------ | ----------------------------------------- |
| `FRO_BOT_MODEL`      | Starts with `anthropic/` (provider prefix)  |
| `OMO_PROVIDERS`      | Equals `claude-max20`                       |
| `OPENCODE_CONFIG`    | `baseURL` ends with `/v1`                     |
| `OPENCODE_AUTH_JSON` | Has `{type: 'api', key: <supplied>}` shape  |

The last two are historical foot-guns: Anthropic SDK appends `/messages` to `baseURL` so `/v1` is required, and the auth shape must be `type: 'api'` for OpenCode to accept the credential. Locking them in prevents silent drift.

## User impact

After this patch (0.4.3), `infra cliproxy setup --harness opencode` produces correct defaults out of the box. Existing onboarded repos need their `FRO_BOT_MODEL` variable updated manually with `gh variable set FRO_BOT_MODEL --body 'anthropic/claude-sonnet-4-6' --repo <owner>/<repo>`.

## Verification

- `bun test --recursive` → 137 pass (was 133, added 4 assertions)
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors
