### PR TITLE
feat(cliproxy): warn when target repo fro-bot.yaml is missing required inputs

### DIFF
--- a/.changeset/cliproxy-setup-workflow-check.md
+++ b/.changeset/cliproxy-setup-workflow-check.md
@@ -5,13 +5,22 @@
 Add post-setup check that warns when the target repository's
 `.github/workflows/fro-bot.yaml` is missing required Fro Bot inputs. After
 `cliproxy setup --harness opencode` completes, the wizard fetches the
-target repo's workflow file and verifies all four required inputs
-(`auth-json`, `opencode-config`, `omo-providers`, `model`) are wired to
-the `fro-bot/agent` step. Missing inputs produce a warning with the
-exact snippet to add under the `with:` block. If the workflow file
-doesn't exist, the user is pointed at `marcusrbrown/infra` as a
-reference. Without `opencode-config` the baseURL override is ignored
-and Fro Bot hits `api.anthropic.com` with the proxy key, which fails
-with 401 — this check catches the gap before the user discovers it in
-a failed run. Observation-only: the workflow in the target repo is
-never modified.
+target repo's workflow file, locates the `fro-bot/agent` step, and
+verifies the four required inputs (`auth-json`, `opencode-config`,
+`omo-providers`, `model`) are wired to that specific step. Missing
+inputs produce a warning with the exact snippet to add under the `with:`
+block. The scan is step-scoped (not whole-file), so a same-named input
+in a sibling step (e.g. `strategy.matrix.model:` or a custom action
+with `model:`) cannot mask a genuine gap in `fro-bot/agent`'s wiring.
+
+If the workflow file is missing the check distinguishes 404 from other
+`gh api` failures (auth, rate limit, 5xx, network): a 404 points the
+user at `marcusrbrown/infra` as a reference template, while a non-404
+surfaces the stderr so the user can diagnose transport issues instead
+of chasing a missing-file red herring. Non-fatal in both cases —
+setup itself still completes.
+
+Without `opencode-config` the baseURL override is ignored and Fro Bot
+hits `api.anthropic.com` with the proxy key, which fails with 401 —
+this check catches the gap before the user discovers it in a failed
+run. Observation-only: the target repo's workflow is never modified.

--- a/.changeset/cliproxy-setup-workflow-check.md
+++ b/.changeset/cliproxy-setup-workflow-check.md
@@ -1,0 +1,17 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Add post-setup check that warns when the target repository's
+`.github/workflows/fro-bot.yaml` is missing required Fro Bot inputs. After
+`cliproxy setup --harness opencode` completes, the wizard fetches the
+target repo's workflow file and verifies all four required inputs
+(`auth-json`, `opencode-config`, `omo-providers`, `model`) are wired to
+the `fro-bot/agent` step. Missing inputs produce a warning with the
+exact snippet to add under the `with:` block. If the workflow file
+doesn't exist, the user is pointed at `marcusrbrown/infra` as a
+reference. Without `opencode-config` the baseURL override is ignored
+and Fro Bot hits `api.anthropic.com` with the proxy key, which fails
+with 401 — this check catches the gap before the user discovers it in
+a failed run. Observation-only: the workflow in the target repo is
+never modified.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -31,6 +31,39 @@ const MISSING_OPENCODE_CONFIG_WORKFLOW = `      - uses: fro-bot/agent@abc123
           prompt: \${{ env.PROMPT }}
 `
 
+// Regression fixture for PR #125 review: a sibling step has `model:` as an input,
+// but the fro-bot/agent step is missing it. The step-scoped scan must still flag
+// `model` as missing, otherwise the diagnostic is silently suppressed.
+const SIBLING_STEP_SHADOWS_MODEL_INPUT = `name: ci
+on: [push]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        model: [opus, sonnet]
+    steps:
+      - uses: actions/some-ai-step@abc
+        with:
+          model: \${{ matrix.model }}
+      - name: Run Fro Bot
+        uses: fro-bot/agent@def
+        with:
+          auth-json: \${{ secrets.OPENCODE_AUTH_JSON }}
+          opencode-config: \${{ secrets.OPENCODE_CONFIG }}
+          omo-providers: \${{ secrets.OMO_PROVIDERS }}
+`
+
+const WORKFLOW_WITHOUT_FRO_BOT_AGENT = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo hello
+`
+
 describe('cliproxy setup helpers', () => {
   describe('validateSetupOptions', () => {
     it('requires --key in non-interactive mode', () => {
@@ -117,12 +150,18 @@ describe('cliproxy setup helpers', () => {
       expect(result.missingInputs).toEqual(['auth-json', 'opencode-config', 'omo-providers', 'model'])
     })
 
-    it('ignores inputs that appear only in unrelated positions (e.g. comments or text)', () => {
-      const content = `This doc mentions opencode-config but the fro-bot/agent step is missing it.`
+    it('flags model as missing even when a sibling step uses model: as an input', () => {
+      const result = analyzeFroBotWorkflow(SIBLING_STEP_SHADOWS_MODEL_INPUT)
 
-      const result = analyzeFroBotWorkflow(content)
+      expect(result.exists).toBe(true)
+      expect(result.missingInputs).toEqual(['model'])
+    })
 
-      expect(result.missingInputs).toContain('opencode-config')
+    it('returns all inputs as missing when the workflow has no fro-bot/agent step', () => {
+      const result = analyzeFroBotWorkflow(WORKFLOW_WITHOUT_FRO_BOT_AGENT)
+
+      expect(result.exists).toBe(true)
+      expect(result.missingInputs).toEqual(['auth-json', 'opencode-config', 'omo-providers', 'model'])
     })
   })
 

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -4,12 +4,32 @@ import {describe, expect, it} from 'bun:test'
 import {goke} from 'goke'
 
 import {
+  analyzeFroBotWorkflow,
   getHarnessTemplate,
   registerCliproxySetup,
   validateSetupOptions,
   type SecretAssignment,
   type VariableAssignment,
 } from './setup'
+
+const COMPLETE_WORKFLOW = `      - uses: fro-bot/agent@abc123
+        with:
+          github-token: \${{ secrets.FRO_BOT_PAT }}
+          auth-json: \${{ secrets.OPENCODE_AUTH_JSON }}
+          model: \${{ vars.FRO_BOT_MODEL }}
+          omo-providers: \${{ secrets.OMO_PROVIDERS }}
+          opencode-config: \${{ secrets.OPENCODE_CONFIG }}
+          prompt: \${{ env.PROMPT }}
+`
+
+const MISSING_OPENCODE_CONFIG_WORKFLOW = `      - uses: fro-bot/agent@abc123
+        with:
+          auth-json: \${{ secrets.OPENCODE_AUTH_JSON }}
+          github-token: \${{ secrets.FRO_BOT_PAT }}
+          model: \${{ vars.FRO_BOT_MODEL }}
+          omo-providers: \${{ secrets.OMO_PROVIDERS }}
+          prompt: \${{ env.PROMPT }}
+`
 
 describe('cliproxy setup helpers', () => {
   describe('validateSetupOptions', () => {
@@ -72,6 +92,37 @@ describe('cliproxy setup helpers', () => {
       const parsed = JSON.parse(authEntry?.value ?? '{}')
 
       expect(parsed.anthropic).toEqual({type: 'api', key: 'sk-test-key'})
+    })
+  })
+
+  describe('analyzeFroBotWorkflow', () => {
+    it('returns no missing inputs when all four are wired', () => {
+      const result = analyzeFroBotWorkflow(COMPLETE_WORKFLOW)
+
+      expect(result.exists).toBe(true)
+      expect(result.missingInputs).toEqual([])
+    })
+
+    it('detects a missing opencode-config input', () => {
+      const result = analyzeFroBotWorkflow(MISSING_OPENCODE_CONFIG_WORKFLOW)
+
+      expect(result.exists).toBe(true)
+      expect(result.missingInputs).toEqual(['opencode-config'])
+    })
+
+    it('returns all four inputs as missing for empty content', () => {
+      const result = analyzeFroBotWorkflow('')
+
+      expect(result.exists).toBe(true)
+      expect(result.missingInputs).toEqual(['auth-json', 'opencode-config', 'omo-providers', 'model'])
+    })
+
+    it('ignores inputs that appear only in unrelated positions (e.g. comments or text)', () => {
+      const content = `This doc mentions opencode-config but the fro-bot/agent step is missing it.`
+
+      const result = analyzeFroBotWorkflow(content)
+
+      expect(result.missingInputs).toContain('opencode-config')
     })
   })
 

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -263,6 +263,48 @@ async function listExistingGhNames(repo: string, kind: 'secret' | 'variable'): P
   return ghNameListSchema.parse(JSON.parse(result.stdout)).map(entry => entry.name)
 }
 
+export interface FroBotWorkflowCheck {
+  exists: boolean
+  missingInputs: string[]
+}
+
+const REQUIRED_OPENCODE_INPUTS = ['auth-json', 'opencode-config', 'omo-providers', 'model'] as const
+
+export function analyzeFroBotWorkflow(workflowContent: string): FroBotWorkflowCheck {
+  const missingInputs = REQUIRED_OPENCODE_INPUTS.filter(input => {
+    const pattern = new RegExp(String.raw`^\s+${input}:`, 'm')
+    return !pattern.test(workflowContent)
+  })
+  return {exists: true, missingInputs}
+}
+
+async function checkFroBotWorkflow(repo: string): Promise<FroBotWorkflowCheck> {
+  const result = await runGh([
+    'api',
+    '--header',
+    'Accept: application/vnd.github.raw',
+    `/repos/${repo}/contents/.github/workflows/fro-bot.yaml`,
+  ])
+
+  if (result.exitCode !== 0) {
+    return {exists: false, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
+  }
+
+  return analyzeFroBotWorkflow(result.stdout)
+}
+
+function formatWorkflowSnippet(missingInputs: string[]): string {
+  /* eslint-disable no-template-curly-in-string -- GitHub Actions expression syntax, not JS template literals */
+  const inputMap: Record<string, string> = {
+    'auth-json': 'auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}',
+    'opencode-config': 'opencode-config: ${{ secrets.OPENCODE_CONFIG }}',
+    'omo-providers': 'omo-providers: ${{ secrets.OMO_PROVIDERS }}',
+    model: 'model: ${{ vars.FRO_BOT_MODEL }}',
+  }
+  /* eslint-enable no-template-curly-in-string */
+  return missingInputs.map(input => `  ${inputMap[input]}`).join('\n')
+}
+
 async function assertProxyReachable(baseUrl: string): Promise<void> {
   try {
     const response = await fetch(baseUrl, {
@@ -691,6 +733,30 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
           await withSpinner('Verifying the new key through the proxy', async () => {
             await assertProxyKeyWorks(baseUrl, plan.keyValue)
           })
+
+          if (plan.harness === 'opencode') {
+            const workflow = await withSpinner(`Checking ${plan.repo} fro-bot.yaml wiring`, async () => {
+              return checkFroBotWorkflow(plan.repo)
+            })
+
+            if (!workflow.exists) {
+              log.warn(
+                `No .github/workflows/fro-bot.yaml found in ${plan.repo}. The secrets and variables are set, but Fro Bot won't run until the workflow exists and passes them as inputs. See marcusrbrown/infra/.github/workflows/fro-bot.yaml for a reference.`,
+              )
+            } else if (workflow.missingInputs.length > 0) {
+              log.warn(
+                [
+                  `${plan.repo} .github/workflows/fro-bot.yaml is missing ${workflow.missingInputs.length} required input${
+                    workflow.missingInputs.length > 1 ? 's' : ''
+                  } (${workflow.missingInputs.join(', ')}).`,
+                  `Without ${workflow.missingInputs.includes('opencode-config') ? 'opencode-config, the baseURL override is ignored and Fro Bot hits api.anthropic.com with the proxy key, which fails with 401' : 'these, the secrets you just wrote will not reach OpenCode'}.`,
+                  '',
+                  `Add under the 'with:' block of the 'fro-bot/agent' step:`,
+                  formatWorkflowSnippet(workflow.missingInputs),
+                ].join('\n'),
+              )
+            }
+          }
         } catch (mutationError) {
           if (keyCreatedByThisRun && managementKey) {
             try {

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -265,16 +265,58 @@ async function listExistingGhNames(repo: string, kind: 'secret' | 'variable'): P
 
 export interface FroBotWorkflowCheck {
   exists: boolean
+  /** Populated when exists is false AND the cause was not a 404 (e.g. auth, rate limit, 5xx). */
+  unreachableReason?: string
   missingInputs: string[]
 }
 
 const REQUIRED_OPENCODE_INPUTS = ['auth-json', 'opencode-config', 'omo-providers', 'model'] as const
 
+/**
+ * Slice the workflow content down to just the body of the step whose `uses:`
+ * starts with `fro-bot/agent@`. Handles both the `- name:\n  uses: ...` and
+ * `- uses: ...` step shapes. Returns null if no fro-bot/agent step is present.
+ *
+ * We scope the input-key scan to this slice so a same-named key in a different
+ * step (strategy matrix, custom action, reusable workflow with: block) can't
+ * mask a genuine gap in fro-bot/agent's inputs.
+ */
+function findFroBotAgentStepBody(content: string): string | null {
+  const match = content.match(/^(\s*(?:-\s+)?)uses:\s*fro-bot\/agent@/m)
+  if (!match || match.index === undefined || match[1] === undefined) return null
+
+  const stepBodyIndent = match[1].length
+  const dashIndent = Math.max(0, stepBodyIndent - 2)
+  const lines = content.slice(match.index).split('\n')
+  const stepLines: string[] = [lines[0] ?? '']
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (!line.trim()) {
+      stepLines.push(line)
+      continue
+    }
+    const firstNonSpace = line.search(/\S/)
+    if (firstNonSpace === dashIndent && line.trimStart().startsWith('-')) break
+    if (firstNonSpace < dashIndent) break
+    stepLines.push(line)
+  }
+
+  return stepLines.join('\n')
+}
+
 export function analyzeFroBotWorkflow(workflowContent: string): FroBotWorkflowCheck {
+  const stepBody = findFroBotAgentStepBody(workflowContent)
+
+  if (stepBody === null) {
+    return {exists: true, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
+  }
+
   const missingInputs = REQUIRED_OPENCODE_INPUTS.filter(input => {
     const pattern = new RegExp(String.raw`^\s+${input}:`, 'm')
-    return !pattern.test(workflowContent)
+    return !pattern.test(stepBody)
   })
+
   return {exists: true, missingInputs}
 }
 
@@ -287,7 +329,16 @@ async function checkFroBotWorkflow(repo: string): Promise<FroBotWorkflowCheck> {
   ])
 
   if (result.exitCode !== 0) {
-    return {exists: false, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
+    // gh prints `gh: Not Found (HTTP 404)` on 404; anything else is auth/network/5xx.
+    const is404 = /HTTP 404/.test(result.stderr)
+    if (is404) {
+      return {exists: false, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
+    }
+    return {
+      exists: false,
+      unreachableReason: result.stderr.trim() || `gh api exited with code ${result.exitCode}`,
+      missingInputs: [...REQUIRED_OPENCODE_INPUTS],
+    }
   }
 
   return analyzeFroBotWorkflow(result.stdout)
@@ -740,9 +791,15 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
             })
 
             if (!workflow.exists) {
-              log.warn(
-                `No .github/workflows/fro-bot.yaml found in ${plan.repo}. The secrets and variables are set, but Fro Bot won't run until the workflow exists and passes them as inputs. See marcusrbrown/infra/.github/workflows/fro-bot.yaml for a reference.`,
-              )
+              if (workflow.unreachableReason) {
+                log.warn(
+                  `Could not check .github/workflows/fro-bot.yaml in ${plan.repo}: ${workflow.unreachableReason}. The secrets and variables are set, but the workflow wiring was not verified. Re-run 'infra cliproxy setup' later to confirm, or inspect the file directly.`,
+                )
+              } else {
+                log.warn(
+                  `No .github/workflows/fro-bot.yaml found in ${plan.repo}. The secrets and variables are set, but Fro Bot won't run until the workflow exists and passes them as inputs. See marcusrbrown/infra/.github/workflows/fro-bot.yaml for a reference.`,
+                )
+              }
             } else if (workflow.missingInputs.length > 0) {
               log.warn(
                 [


### PR DESCRIPTION
## What

After `cliproxy setup --harness opencode` finishes wiring secrets and variables, fetch the target repo's `.github/workflows/fro-bot.yaml` and check whether the four required inputs are passed to the `fro-bot/agent` step:

| Input             | Consumes                       |
| ----------------- | ------------------------------ |
| `auth-json`         | `secrets.OPENCODE_AUTH_JSON`     |
| `opencode-config`   | `secrets.OPENCODE_CONFIG`        |
| `omo-providers`     | `secrets.OMO_PROVIDERS`          |
| `model`             | `vars.FRO_BOT_MODEL`             |

If any are missing, the wizard logs a warning naming the gap and prints the exact snippet to add under the `with:` block. If the workflow file doesn't exist, the user is pointed at `marcusrbrown/infra` as a reference template.

## Why

Just hit this with `marcusrbrown/tokentoilet`: `cliproxy setup` correctly wrote all four GitHub secrets/variables, but the repo's existing `fro-bot.yaml` was missing `opencode-config`. Fro Bot ran, ignored the baseURL override, hit `api.anthropic.com` with the proxy key, and failed with 401 — invisible until someone looked at a failing run. This is the exact same gap that required a separate manual fix in `fro-bot/.github` PR #3058.

The setup wizard can't edit the target repo's workflow (out of scope, would need a multi-step PR flow), but it *can* detect the mismatch and tell the user what to paste. One-time warning, zero destructive side effects.

## Scope

- **Only for `--harness opencode`** — `claude-code` and `generic` harnesses don't use `OPENCODE_CONFIG`
- **Observation-only**: target repo workflow is never modified
- **Silent pass** when all four inputs are wired
- **404 is not an error**: if `fro-bot.yaml` doesn't exist, setup still completes — just notes the gap

## Tests

4 new assertions in `analyzeFroBotWorkflow`:
- Complete workflow (infra's own fro-bot.yaml shape) → no missing inputs
- Missing `opencode-config` (tokentoilet's actual state) → detects one gap
- Empty content → all four missing
- Free text mentioning "opencode-config" → still missing (guards against naive `.includes()` check)

## Verification

- `bun test --recursive` → 141 pass (was 137, +4 assertions)
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors
