### PR TITLE
refactor(cliproxy): discriminated union + per-step reporting for workflow check

### DIFF
--- a/.changeset/cliproxy-setup-workflow-check-follow-up.md
+++ b/.changeset/cliproxy-setup-workflow-check-follow-up.md
@@ -1,0 +1,15 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+`cliproxy setup --harness opencode` workflow check now handles workflows
+with multiple `fro-bot/agent` steps, reports per-step gaps with a step
+ordinal, renders the paste snippet at the canonical 10-space indent
+(drop-in under the `with:` key), and distinguishes four workflow states
+via a discriminated union (`missing` / `unreachable` / `no-agent-step` /
+`analyzed`) so the caller can't forget a case. A workflow that exists
+but has no `fro-bot/agent` step now surfaces a dedicated warning
+("exists but has no `fro-bot/agent` step") instead of the generic
+missing-input list. Observation-only — the target repo workflow is
+never modified. Addresses Fro Bot's non-blocking concerns from the
+PR #125 follow-up review.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -5,7 +5,9 @@ import {goke} from 'goke'
 
 import {
   analyzeFroBotWorkflow,
+  formatWorkflowSnippet,
   getHarnessTemplate,
+  interpretGhContentResult,
   registerCliproxySetup,
   validateSetupOptions,
   type SecretAssignment,
@@ -62,6 +64,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo hello
+`
+
+// Follow-up from PR #125 second review: the matchAll refactor must report gaps
+// in any fro-bot/agent step, not just the first. Step #1 is complete, step #2 is
+// missing opencode-config and model — the analyzer should flag only step #2.
+const TWO_AGENT_STEPS_SECOND_BROKEN = `name: fro-bot
+on: [pull_request, schedule]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Fro Bot review
+        uses: fro-bot/agent@abc123
+        with:
+          auth-json: \${{ secrets.OPENCODE_AUTH_JSON }}
+          opencode-config: \${{ secrets.OPENCODE_CONFIG }}
+          omo-providers: \${{ secrets.OMO_PROVIDERS }}
+          model: \${{ vars.FRO_BOT_MODEL }}
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Fro Bot dispatch
+        uses: fro-bot/agent@abc123
+        with:
+          auth-json: \${{ secrets.OPENCODE_AUTH_JSON }}
+          omo-providers: \${{ secrets.OMO_PROVIDERS }}
 `
 
 describe('cliproxy setup helpers', () => {
@@ -129,39 +157,112 @@ describe('cliproxy setup helpers', () => {
   })
 
   describe('analyzeFroBotWorkflow', () => {
-    it('returns no missing inputs when all four are wired', () => {
+    it('returns empty stepsWithGaps when all four inputs are wired', () => {
       const result = analyzeFroBotWorkflow(COMPLETE_WORKFLOW)
 
-      expect(result.exists).toBe(true)
-      expect(result.missingInputs).toEqual([])
+      expect(result.kind).toBe('analyzed')
+      if (result.kind !== 'analyzed') throw new Error('unreachable')
+      expect(result.stepsWithGaps).toEqual([])
     })
 
-    it('detects a missing opencode-config input', () => {
+    it('detects a missing opencode-config input on step #1', () => {
       const result = analyzeFroBotWorkflow(MISSING_OPENCODE_CONFIG_WORKFLOW)
 
-      expect(result.exists).toBe(true)
-      expect(result.missingInputs).toEqual(['opencode-config'])
-    })
-
-    it('returns all four inputs as missing for empty content', () => {
-      const result = analyzeFroBotWorkflow('')
-
-      expect(result.exists).toBe(true)
-      expect(result.missingInputs).toEqual(['auth-json', 'opencode-config', 'omo-providers', 'model'])
+      expect(result.kind).toBe('analyzed')
+      if (result.kind !== 'analyzed') throw new Error('unreachable')
+      expect(result.stepsWithGaps).toHaveLength(1)
+      expect(result.stepsWithGaps[0]?.stepOrdinal).toBe(1)
+      expect([...(result.stepsWithGaps[0]?.missingInputs ?? [])]).toEqual(['opencode-config'])
     })
 
     it('flags model as missing even when a sibling step uses model: as an input', () => {
       const result = analyzeFroBotWorkflow(SIBLING_STEP_SHADOWS_MODEL_INPUT)
 
-      expect(result.exists).toBe(true)
-      expect(result.missingInputs).toEqual(['model'])
+      expect(result.kind).toBe('analyzed')
+      if (result.kind !== 'analyzed') throw new Error('unreachable')
+      expect(result.stepsWithGaps).toHaveLength(1)
+      expect(result.stepsWithGaps[0]?.stepOrdinal).toBe(1)
+      expect([...(result.stepsWithGaps[0]?.missingInputs ?? [])]).toEqual(['model'])
     })
 
-    it('returns all inputs as missing when the workflow has no fro-bot/agent step', () => {
+    it('returns kind no-agent-step when the workflow has no fro-bot/agent step', () => {
       const result = analyzeFroBotWorkflow(WORKFLOW_WITHOUT_FRO_BOT_AGENT)
 
-      expect(result.exists).toBe(true)
-      expect(result.missingInputs).toEqual(['auth-json', 'opencode-config', 'omo-providers', 'model'])
+      expect(result.kind).toBe('no-agent-step')
+    })
+
+    it('returns kind no-agent-step for empty content', () => {
+      const result = analyzeFroBotWorkflow('')
+
+      expect(result.kind).toBe('no-agent-step')
+    })
+
+    it('reports only the broken step when a workflow has two fro-bot/agent steps and one is complete', () => {
+      const result = analyzeFroBotWorkflow(TWO_AGENT_STEPS_SECOND_BROKEN)
+
+      expect(result.kind).toBe('analyzed')
+      if (result.kind !== 'analyzed') throw new Error('unreachable')
+      expect(result.stepsWithGaps).toHaveLength(1)
+      expect(result.stepsWithGaps[0]?.stepOrdinal).toBe(2)
+      expect([...(result.stepsWithGaps[0]?.missingInputs ?? [])]).toEqual(['opencode-config', 'model'])
+    })
+  })
+
+  describe('interpretGhContentResult', () => {
+    it('returns kind missing when stderr contains HTTP 404', () => {
+      const result = interpretGhContentResult({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'gh: Not Found (HTTP 404)',
+      })
+
+      expect(result.kind).toBe('missing')
+    })
+
+    it('returns kind unreachable with the stderr reason on non-404 failures', () => {
+      const result = interpretGhContentResult({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'gh: API rate limit exceeded',
+      })
+
+      expect(result.kind).toBe('unreachable')
+      if (result.kind !== 'unreachable') throw new Error('unreachable')
+      expect(result.reason).toBe('gh: API rate limit exceeded')
+    })
+
+    it('falls back to the exit code when stderr is empty on a non-404 failure', () => {
+      const result = interpretGhContentResult({exitCode: 2, stdout: '', stderr: ''})
+
+      expect(result.kind).toBe('unreachable')
+      if (result.kind !== 'unreachable') throw new Error('unreachable')
+      expect(result.reason).toBe('gh api exited with code 2')
+    })
+
+    it('delegates to analyzeFroBotWorkflow on a successful response', () => {
+      const result = interpretGhContentResult({
+        exitCode: 0,
+        stdout: COMPLETE_WORKFLOW,
+        stderr: '',
+      })
+
+      expect(result.kind).toBe('analyzed')
+      if (result.kind !== 'analyzed') throw new Error('unreachable')
+      expect(result.stepsWithGaps).toEqual([])
+    })
+  })
+
+  describe('formatWorkflowSnippet', () => {
+    it('renders snippet lines at 10-space indent so they can be pasted directly under with:', () => {
+      const snippet = formatWorkflowSnippet(['opencode-config', 'model'])
+
+      /* eslint-disable no-template-curly-in-string -- GitHub Actions expression syntax, not JS template literals */
+      const expected = [
+        '          opencode-config: ${{ secrets.OPENCODE_CONFIG }}',
+        '          model: ${{ vars.FRO_BOT_MODEL }}',
+      ].join('\n')
+      /* eslint-enable no-template-curly-in-string */
+      expect(snippet).toBe(expected)
     })
   })
 

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -263,61 +263,98 @@ async function listExistingGhNames(repo: string, kind: 'secret' | 'variable'): P
   return ghNameListSchema.parse(JSON.parse(result.stdout)).map(entry => entry.name)
 }
 
-export interface FroBotWorkflowCheck {
-  exists: boolean
-  /** Populated when exists is false AND the cause was not a 404 (e.g. auth, rate limit, 5xx). */
-  unreachableReason?: string
-  missingInputs: string[]
-}
+export type FroBotWorkflowCheck =
+  | {kind: 'missing'}
+  | {kind: 'unreachable'; reason: string}
+  | {kind: 'no-agent-step'}
+  | {
+      kind: 'analyzed'
+      stepsWithGaps: readonly {stepOrdinal: number; missingInputs: readonly string[]}[]
+    }
 
+// github-token and prompt are intentionally excluded from this check:
+// github-token is harness-agnostic (PAT wiring, not secret-routing) and prompt is
+// workflow-defined (the user's prompt body, not a harness default).
 const REQUIRED_OPENCODE_INPUTS = ['auth-json', 'opencode-config', 'omo-providers', 'model'] as const
 
 /**
- * Slice the workflow content down to just the body of the step whose `uses:`
- * starts with `fro-bot/agent@`. Handles both the `- name:\n  uses: ...` and
- * `- uses: ...` step shapes. Returns null if no fro-bot/agent step is present.
+ * Slice the workflow content into one entry per `fro-bot/agent` step. Handles
+ * both the `- name:\n  uses: ...` and `- uses: ...` step shapes. Returns an
+ * empty array if no fro-bot/agent step is present.
  *
- * We scope the input-key scan to this slice so a same-named key in a different
- * step (strategy matrix, custom action, reusable workflow with: block) can't
- * mask a genuine gap in fro-bot/agent's inputs.
+ * Step-scoped slicing prevents false-passes where a same-named input key in a
+ * sibling step (strategy.matrix, custom actions, reusable workflow with:
+ * blocks) could mask a genuine gap in fro-bot/agent's wiring.
  */
-function findFroBotAgentStepBody(content: string): string | null {
-  const match = content.match(/^(\s*(?:-\s+)?)uses:\s*fro-bot\/agent@/m)
-  if (!match || match.index === undefined || match[1] === undefined) return null
+function findFroBotAgentStepBodies(content: string): {stepOrdinal: number; body: string}[] {
+  const bodies: {stepOrdinal: number; body: string}[] = []
+  const pattern = /^(\s*(?:-\s+)?)uses:\s*fro-bot\/agent@/gm
 
-  const stepBodyIndent = match[1].length
-  const dashIndent = Math.max(0, stepBodyIndent - 2)
-  const lines = content.slice(match.index).split('\n')
-  const stepLines: string[] = [lines[0] ?? '']
+  for (const match of content.matchAll(pattern)) {
+    if (match.index === undefined || match[1] === undefined) continue
 
-  for (let index = 1; index < lines.length; index += 1) {
-    const line = lines[index] ?? ''
-    if (!line.trim()) {
+    const stepBodyIndent = match[1].length
+    const dashIndent = Math.max(0, stepBodyIndent - 2)
+    const lines = content.slice(match.index).split('\n')
+    const stepLines: string[] = [lines[0] ?? '']
+
+    for (let index = 1; index < lines.length; index += 1) {
+      const line = lines[index] ?? ''
+      if (!line.trim()) {
+        stepLines.push(line)
+        continue
+      }
+      const firstNonSpace = line.search(/\S/)
+      if (firstNonSpace === dashIndent && line.trimStart().startsWith('-')) break
+      if (firstNonSpace < dashIndent) break
       stepLines.push(line)
-      continue
     }
-    const firstNonSpace = line.search(/\S/)
-    if (firstNonSpace === dashIndent && line.trimStart().startsWith('-')) break
-    if (firstNonSpace < dashIndent) break
-    stepLines.push(line)
+
+    bodies.push({stepOrdinal: bodies.length + 1, body: stepLines.join('\n')})
   }
 
-  return stepLines.join('\n')
+  return bodies
 }
 
 export function analyzeFroBotWorkflow(workflowContent: string): FroBotWorkflowCheck {
-  const stepBody = findFroBotAgentStepBody(workflowContent)
+  const steps = findFroBotAgentStepBodies(workflowContent)
 
-  if (stepBody === null) {
-    return {exists: true, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
+  if (steps.length === 0) {
+    return {kind: 'no-agent-step'}
   }
 
-  const missingInputs = REQUIRED_OPENCODE_INPUTS.filter(input => {
-    const pattern = new RegExp(String.raw`^\s+${input}:`, 'm')
-    return !pattern.test(stepBody)
-  })
+  const stepsWithGaps = steps
+    .map(step => ({
+      stepOrdinal: step.stepOrdinal,
+      missingInputs: REQUIRED_OPENCODE_INPUTS.filter(input => {
+        const inputPattern = new RegExp(String.raw`^\s+${input}:`, 'm')
+        return !inputPattern.test(step.body)
+      }),
+    }))
+    .filter(step => step.missingInputs.length > 0)
 
-  return {exists: true, missingInputs}
+  return {kind: 'analyzed', stepsWithGaps}
+}
+
+/**
+ * Extracted pure helper: turn a `gh api /repos/.../contents/<file>` result into
+ * a FroBotWorkflowCheck. Separated from checkFroBotWorkflow so tests can exercise
+ * the 404-vs-transport-error logic without mocking Bun.spawn.
+ */
+export function interpretGhContentResult(result: CommandResult): FroBotWorkflowCheck {
+  if (result.exitCode === 0) {
+    return analyzeFroBotWorkflow(result.stdout)
+  }
+
+  // gh prints `gh: Not Found (HTTP 404)` on 404; anything else is auth/network/5xx.
+  if (/HTTP 404/.test(result.stderr)) {
+    return {kind: 'missing'}
+  }
+
+  return {
+    kind: 'unreachable',
+    reason: result.stderr.trim() || `gh api exited with code ${result.exitCode}`,
+  }
 }
 
 async function checkFroBotWorkflow(repo: string): Promise<FroBotWorkflowCheck> {
@@ -328,23 +365,13 @@ async function checkFroBotWorkflow(repo: string): Promise<FroBotWorkflowCheck> {
     `/repos/${repo}/contents/.github/workflows/fro-bot.yaml`,
   ])
 
-  if (result.exitCode !== 0) {
-    // gh prints `gh: Not Found (HTTP 404)` on 404; anything else is auth/network/5xx.
-    const is404 = /HTTP 404/.test(result.stderr)
-    if (is404) {
-      return {exists: false, missingInputs: [...REQUIRED_OPENCODE_INPUTS]}
-    }
-    return {
-      exists: false,
-      unreachableReason: result.stderr.trim() || `gh api exited with code ${result.exitCode}`,
-      missingInputs: [...REQUIRED_OPENCODE_INPUTS],
-    }
-  }
-
-  return analyzeFroBotWorkflow(result.stdout)
+  return interpretGhContentResult(result)
 }
 
-function formatWorkflowSnippet(missingInputs: string[]): string {
+// Snippet uses 10-space indent to match the canonical `with:` block depth
+// in marcusrbrown/infra/.github/workflows/fro-bot.yaml, so users can paste
+// directly under their step's `with:` key without re-indenting.
+export function formatWorkflowSnippet(missingInputs: readonly string[]): string {
   /* eslint-disable no-template-curly-in-string -- GitHub Actions expression syntax, not JS template literals */
   const inputMap: Record<string, string> = {
     'auth-json': 'auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}',
@@ -353,7 +380,7 @@ function formatWorkflowSnippet(missingInputs: string[]): string {
     model: 'model: ${{ vars.FRO_BOT_MODEL }}',
   }
   /* eslint-enable no-template-curly-in-string */
-  return missingInputs.map(input => `  ${inputMap[input]}`).join('\n')
+  return missingInputs.map(input => `          ${inputMap[input]}`).join('\n')
 }
 
 async function assertProxyReachable(baseUrl: string): Promise<void> {
@@ -790,28 +817,46 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
               return checkFroBotWorkflow(plan.repo)
             })
 
-            if (!workflow.exists) {
-              if (workflow.unreachableReason) {
-                log.warn(
-                  `Could not check .github/workflows/fro-bot.yaml in ${plan.repo}: ${workflow.unreachableReason}. The secrets and variables are set, but the workflow wiring was not verified. Re-run 'infra cliproxy setup' later to confirm, or inspect the file directly.`,
-                )
-              } else {
+            switch (workflow.kind) {
+              case 'missing': {
                 log.warn(
                   `No .github/workflows/fro-bot.yaml found in ${plan.repo}. The secrets and variables are set, but Fro Bot won't run until the workflow exists and passes them as inputs. See marcusrbrown/infra/.github/workflows/fro-bot.yaml for a reference.`,
                 )
+                break
               }
-            } else if (workflow.missingInputs.length > 0) {
-              log.warn(
-                [
-                  `${plan.repo} .github/workflows/fro-bot.yaml is missing ${workflow.missingInputs.length} required input${
-                    workflow.missingInputs.length > 1 ? 's' : ''
-                  } (${workflow.missingInputs.join(', ')}).`,
-                  `Without ${workflow.missingInputs.includes('opencode-config') ? 'opencode-config, the baseURL override is ignored and Fro Bot hits api.anthropic.com with the proxy key, which fails with 401' : 'these, the secrets you just wrote will not reach OpenCode'}.`,
-                  '',
-                  `Add under the 'with:' block of the 'fro-bot/agent' step:`,
-                  formatWorkflowSnippet(workflow.missingInputs),
-                ].join('\n'),
-              )
+              case 'unreachable': {
+                log.warn(
+                  `Could not check .github/workflows/fro-bot.yaml in ${plan.repo}: ${workflow.reason}. The secrets and variables are set, but the workflow wiring was not verified. Re-run 'infra cliproxy setup' later to confirm, or inspect the file directly.`,
+                )
+                break
+              }
+              case 'no-agent-step': {
+                log.warn(
+                  `${plan.repo} .github/workflows/fro-bot.yaml exists but has no 'fro-bot/agent' step. Add one that passes the secrets and variables just written. See marcusrbrown/infra/.github/workflows/fro-bot.yaml for a reference.`,
+                )
+                break
+              }
+              case 'analyzed': {
+                for (const step of workflow.stepsWithGaps) {
+                  const missing = [...step.missingInputs]
+                  log.warn(
+                    [
+                      `${plan.repo} .github/workflows/fro-bot.yaml fro-bot/agent step #${step.stepOrdinal} is missing ${missing.length} required input${
+                        missing.length > 1 ? 's' : ''
+                      } (${missing.join(', ')}).`,
+                      `Without ${missing.includes('opencode-config') ? 'opencode-config, the baseURL override is ignored and Fro Bot hits api.anthropic.com with the proxy key, which fails with 401' : 'these, the secrets you just wrote will not reach OpenCode'}.`,
+                      '',
+                      `Add under the 'with:' block of the 'fro-bot/agent' step:`,
+                      formatWorkflowSnippet(missing),
+                    ].join('\n'),
+                  )
+                }
+                break
+              }
+              default: {
+                const _exhaustive: never = workflow
+                throw new Error(`Unhandled FroBotWorkflowCheck kind: ${JSON.stringify(_exhaustive)}`)
+              }
             }
           }
         } catch (mutationError) {


### PR DESCRIPTION
Follow-up on PR #125, addressing Fro Bot's non-blocking concerns from the [second review](https://github.com/marcusrbrown/infra/pull/125#pullrequestreview-4118347688).

## What changed

| Fro Bot concern | Action |
| --- | --- |
| Multiple `fro-bot/agent` steps silently ignored after the first | `matchAll` across all steps, per-step reporting with 1-indexed `stepOrdinal`. Each step with gaps gets its own `log.warn`. Self-contained — two broken steps = two warnings, no shared preamble. |
| `FroBotWorkflowCheck.exists` vestigial | Four-variant discriminated union: `missing` / `unreachable` / `no-agent-step` / `analyzed`. Caller switch has an exhaustive `never` check so a future kind can't silently fall through. |
| Snippet indent 2 → 10 spaces | Matches canonical `with:` block depth in `marcusrbrown/infra/.github/workflows/fro-bot.yaml`, so the paste is drop-in without re-indenting. |
| No explicit comment on excluded inputs | Added a three-line note above `REQUIRED_OPENCODE_INPUTS` explaining why `github-token` and `prompt` are deliberately out of scope. |

| Fro Bot missing-test callout | Added |
| --- | --- |
| Multiple fro-bot/agent steps fixture | `TWO_AGENT_STEPS_SECOND_BROKEN` — first step is complete, second is missing `opencode-config` and `model`. Asserts the analyzer flags only step #2. |
| Non-404 `gh api` failure path | `interpretGhContentResult` extracted as a pure helper (no Bun.spawn mocking). Tests cover: 404 → `missing`, rate-limit stderr → `unreachable` with `reason`, empty stderr → `gh api exited with code N` fallback, success → delegates to `analyzeFroBotWorkflow`. |
| `formatWorkflowSnippet` output shape | Equality test against the 10-space-indented canonical output for `['opencode-config', 'model']`. |

## The silent-regression trap this avoids

A 3-variant union (`missing` / `unreachable` / `analyzed`) would silently suppress the exact scenario PR #125 was written to catch: workflow exists but has no `fro-bot/agent` step. Under `matchAll`, zero matches → empty `stepsWithGaps` → no warning. The 4th variant (`no-agent-step`) preserves the diagnostic with its own copy: `"{repo} .github/workflows/fro-bot.yaml exists but has no 'fro-bot/agent' step"`.

## Design decisions

- **`checkFroBotWorkflow` testability**: extracted `interpretGhContentResult(result: CommandResult): FroBotWorkflowCheck` as a pure helper instead of exporting the async wrapper. Tested via value, no spawn mock needed. Smaller API surface.
- **Step names**: dropped from the type. Ordinals only. YAML-aware step-name extraction requires walking backward from `uses:` through optional `env:`/`run:` blocks to find the preceding `- name:` at the correct indent — a rabbit hole that would force a YAML parser dependency for marginal UX gain.
- **Warnings**: one `log.warn` per step, each self-contained. No DRY consolidation — preserving the `opencode-config`-specific phrasing per step is worth the minor duplication.

## Explicitly deferred

- YAML parser dependency / block-scalar heuristic (the theoretical `prompt: |` false-pass Fro Bot flagged is purely theoretical; infra's own workflow uses `prompt: >-` and no colon-prefixed content inside).
- `auth-json`-specific warning copy (Fro Bot's first-review ask, dropped from the second review).
- Step-name extraction (see above).
- Consolidating `runCommand` / `runGh` / `CommandResult` (unrelated to this change).

## Verification

- `bun test --recursive` → 148 pass (was 137, net +11: 6 new in `setup.test.ts`, 5 existing updated to the new `.kind`/`.stepsWithGaps` shape)
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors (17 pre-existing `no-console` warnings unchanged)
- Exhaustive `switch (workflow.kind)` with `never` default — adding a fifth variant will force a compile error at the call site.
