### PR TITLE
chore(cliproxy): pin Caddy image to semver tag for trackable updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,14 @@
       changelogUrl: 'https://github.com/router-for-me/CLIProxyAPI/releases',
       groupName: null,
     },
+    {
+      description: ['Add changelog context for Caddy Docker image updates'],
+      matchDatasources: ['docker'],
+      matchPackageNames: ['caddy'],
+      sourceUrl: 'https://github.com/caddyserver/caddy',
+      changelogUrl: 'https://github.com/caddyserver/caddy/releases',
+      groupName: null,
+    },
   ],
   // postUpgradeTasks run after Renovate applies file changes but before the commit.
   // For github-actions manager updates (workflow SHA pins), Renovate does NOT run

--- a/apps/cliproxy/docker-compose.yaml
+++ b/apps/cliproxy/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:2-alpine@sha256:24d58e24e4231c6667677a39469a3d843a3222eadbf640f22933f24bed0939ec
+    image: caddy:2.11.2-alpine@sha256:24d58e24e4231c6667677a39469a3d843a3222eadbf640f22933f24bed0939ec
     restart: unless-stopped
     ports:
       - '80:80'


### PR DESCRIPTION
## Summary

Pin `caddy:2-alpine` → `caddy:2.11.2-alpine` so Renovate tracks per-version updates instead of digest drift. Mirrors the pattern already applied to `eceasy/cli-proxy-api`.

## Why

`2-alpine` is a **floating** Docker tag — Docker Hub rewrites it on every new Caddy 2.x release. Renovate sees the digest change, can't associate it with a specific version, and produces sparse digest-only update PRs like #128 ("update caddy:2-alpine Docker digest to 24d58e2") with no changelog context.

Pinning to `2.11.2-alpine`:

- Same digest as the current `2-alpine` pointer (`sha256:24d58e24…`) → bit-identical, no-op deploy
- Renovate can now track `2.11.2` → `2.11.3` → `2.12.0` as real version bumps
- Combined with the new `packageRules` entry, future PRs include release notes from [caddyserver/caddy](https://github.com/caddyserver/caddy/releases)
- `groupName: null` keeps Caddy out of the `group:allNonMajor` batch — each release gets its own reviewable PR

## Changes

| File | Change |
| --- | --- |
| `apps/cliproxy/docker-compose.yaml` | `caddy:2-alpine@sha256:24d58e2…` → `caddy:2.11.2-alpine@sha256:24d58e2…` (same digest) |
| `.github/renovate.json5` | Added `packageRules` entry for `caddy` with `sourceUrl` + `changelogUrl` |

## Verification

- Current digest ↔ version lookup via Docker Hub tags API: `2-alpine`, `2.11-alpine`, `2.11.2-alpine`, and `alpine` all share `sha256:24d58e24e4231c6667677a39469a3d843a3222eadbf640f22933f24bed0939ec`
- `docker compose -f apps/cliproxy/docker-compose.yaml config` → valid
- `bun run lint` → 0 errors

## Deployment impact

None. Same digest means the running container image is identical; nothing pulls or restarts. This is purely a metadata change for Renovate's benefit. Next Caddy release will produce a proper versioned PR instead of a digest-only one.

No changeset — this is deployment infrastructure, not published CLI behavior.
