### PR TITLE
chore: expand autohealing to cliproxy, let Docker image bumps into release notes

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -155,17 +155,47 @@ env:
        branch. Group related lint/format/convention fixes into a single PR.
 
     5. DEPLOY PIPELINE HEALTH
-       Verify the deploy infrastructure is operational:
-       - Check the most recent Deploy workflow run on main. If it failed,
-         diagnose the root cause from logs and open an issue.
+       Verify deploy infrastructure for BOTH apps is operational.
+
+       KeeWeb:
+       - Check the most recent Deploy workflow run (deploy-keeweb job)
+         on main. If it failed, diagnose from logs and open an issue.
        - Verify kw.igg.ms is reachable: `curl -sf -o /dev/null -w
          "%{http_code}" https://kw.igg.ms` should return 200.
-       - Verify the keeweb environment exists and has required secrets
-         configured (DEPLOY_SSH_KEY, DROPBOX_APP_SECRET).
-       - Check that .github/known_hosts contains valid host keys for
-         box.heatvision.co.
+       - Verify the keeweb environment exists with DEPLOY_SSH_KEY and
+         DROPBOX_APP_SECRET configured.
+       - Check .github/known_hosts contains valid host keys for
+         box.heatvision.co (ed25519, ecdsa, rsa entries).
+
+       CLIProxy:
+       - Check the most recent Deploy workflow run (deploy-cliproxy job)
+         on main. If it failed, diagnose from logs and open an issue.
+         Note: if the last cliproxy deploy succeeded, the post-deploy
+         management-key health gate (PUT /v0/management/config) passed,
+         which means the management API and the OAuth token were both
+         healthy at deploy time.
+       - Verify cliproxy.fro.bot is reachable: `curl -sf -o /dev/null -w
+         "%{http_code}" https://cliproxy.fro.bot/v1/models` should
+         return 401 (auth required) or 200 — NOT a 5xx, a connection
+         error, or a timeout. A 5xx or transport failure means the
+         proxy is down. Do not interpret 401 as a failure — it confirms
+         the proxy is up and enforcing auth.
+       - Verify the cliproxy environment exists with CLIPROXY_SSH_KEY,
+         CLIPROXY_MANAGEMENT_KEY, and CLIPROXY_DOMAIN configured.
+       - Check .github/known_hosts contains host keys for
+         cliproxy.fro.bot (both domain and droplet IP entries).
+       - Indirect OAuth signal: this autoheal workflow reaches Anthropic
+         through https://cliproxy.fro.bot/v1 using OPENCODE_AUTH_JSON. If
+         this run is executing, the OAuth token is refreshing correctly
+         right now. Scan the three most recent schedule-triggered Fro Bot
+         workflow runs on main — if any failed specifically with an
+         Anthropic 401 / invalid-api-key error (as distinct from an
+         OpenCode / Bun / network failure), flag OAuth expiry and note
+         that recovery requires manual
+         `bunx @marcusrbrown/infra cliproxy login claude`.
+
        Report findings as issues only for this category. Do NOT modify
-       deploy scripts or workflow files.
+       deploy scripts, workflow files, or the CLIProxyAPI server.
 
     6. LIVE SITE REVIEW
        Use `npx agent-browser` to verify the live KeeWeb deployment at
@@ -319,12 +349,17 @@ env:
     - [list of each PR or commit-sized fix with summary link]
 
     ### Deploy Pipeline Health
-    | Check | Status | Details |
-    | --- | --- | --- |
-    | Last deploy run | ✅ Pass / ❌ Fail | [run link] |
-    | kw.igg.ms reachable | ✅ 200 / ❌ Error | [HTTP status] |
-    | Keeweb env secrets | ✅ Set / ⚠️ Missing | [details] |
-    | Host keys valid | ✅ Current / ⚠️ Stale | [details] |
+    | App | Check | Status | Details |
+    | --- | --- | --- | --- |
+    | keeweb | Last deploy-keeweb run | ✅ Pass / ❌ Fail | [run link] |
+    | keeweb | kw.igg.ms reachable | ✅ 200 / ❌ Error | [HTTP status] |
+    | keeweb | Env secrets | ✅ Set / ⚠️ Missing | [details] |
+    | keeweb | Host keys | ✅ Current / ⚠️ Stale | [details] |
+    | cliproxy | Last deploy-cliproxy run | ✅ Pass / ❌ Fail / — Skipped | [run link] |
+    | cliproxy | cliproxy.fro.bot reachable | ✅ 401/200 / ❌ 5xx/timeout | [HTTP status] |
+    | cliproxy | Env secrets | ✅ Set / ⚠️ Missing | [details] |
+    | cliproxy | Host keys | ✅ Current / ⚠️ Stale | [details] |
+    | cliproxy | OAuth token (indirect) | ✅ Fresh / ⚠️ Recent 401s | [this run's status or prior run links] |
 
     ### Live Site Review
     | Check | Status | Details |

--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -40,4 +40,8 @@ jobs:
           commit-back: 'true'
           max-retries: '3'
           target-package: '@marcusrbrown/infra'
-          exclude-patterns: '.github/**,apps/**,bun.lock,package.json'
+          # Exclude repo-level tooling from triggering changesets (workflow SHA pins,
+          # root dev deps). Everything else — including apps/**/docker-compose.yaml
+          # (Docker image bumps) and apps/**/package.json (runtime dep bumps) — flows
+          # through so deployment updates show up in @marcusrbrown/infra release notes.
+          exclude-patterns: '.github/**,bun.lock,package.json'


### PR DESCRIPTION
Two operational changes bundled because they both affect how production runtime state surfaces to humans.

## 1. `renovate-changesets`: let Docker image bumps into CLI release notes

Dropped `apps/**` from `exclude-patterns`. Docker image bumps (e.g. `caddy`, `eceasy/cli-proxy-api`) and `apps/**/package.json` dep bumps now generate changesets targeting `@marcusrbrown/infra`, so the published CLI's release notes reflect what's actually running in production.

Remaining exclusions still suppress repo-level tooling drift from the changelog:

| Pattern | What it blocks |
| --- | --- |
| `.github/**` | Workflow SHA pins (no runtime impact) |
| `bun.lock` | Lockfile-only churn |
| `package.json` | Root dev-tooling bumps (eslint-config, prettier-config, tsconfig) |

## 2. `fro-bot` autohealing category 5: keeweb-only → both apps

Autohealing category 5 ("Deploy Pipeline Health") was written when keeweb was the only production deployment. cliproxy is equally production-critical — the Fro Bot agent itself depends on it for Claude access — but was never monitored.

Added cliproxy checks parallel to the keeweb set:

- **Last deploy-cliproxy run** — the post-deploy management-key health gate (`PUT /v0/management/config`) serves as an OAuth-token-was-healthy-at-deploy-time signal.
- **Proxy reachability** via `https://cliproxy.fro.bot/v1/models` — expect `401` (auth enforced) or `200`; treat `5xx` / timeout as proxy down. `401` is explicitly called out as a PASS signal in the prompt so the agent doesn't misread it.
- **Environment secrets** present: `CLIPROXY_SSH_KEY`, `CLIPROXY_MANAGEMENT_KEY`, `CLIPROXY_DOMAIN`.
- **Host keys** present for `cliproxy.fro.bot` (domain + droplet IP entries in `.github/known_hosts`).
- **Indirect OAuth freshness** — the autoheal workflow itself reaches Anthropic through `cliproxy.fro.bot/v1` using `OPENCODE_AUTH_JSON`. If the current run is executing, OAuth is refreshing correctly right now. The agent is also instructed to scan the three most recent schedule-triggered runs for Anthropic 401s (distinct from OpenCode / Bun / network failures) and surface `cliproxy login claude` as the manual recovery path if any appear.

The Deploy Pipeline Health report table changed shape to accommodate both apps:

| Before | After |
| --- | --- |
| 4 rows, keeweb-only | 9 rows, per-app column (4 keeweb + 5 cliproxy) |

## What this does NOT do

- No new secrets added to the `fro-bot` job. The management-API key stays out of the autoheal blast radius — OAuth freshness is derived from the workflow's own successful completion (which traverses cliproxy end-to-end) rather than direct management-API introspection.
- No changes to `deploy.yaml`, `deploy.ts`, or the CLIProxyAPI server. The autohealing agent remains observation-only for category 5 per the existing scope boundary.
- No changeset — this is autohealing prompt + Renovate workflow config, not published CLI runtime behavior.

## Verification

- `bun run lint` → 0 errors
- YAML parses (tree-sitter validator)
- Autohealing prompt ends with the updated per-app report table
