### PR TITLE
feat(conventions): enforce root AGENTS.md rules pre-merge

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -136,15 +136,11 @@ env:
        - Scan for stale TODO/FIXME/HACK annotations older than 90 days
          (use git blame). Collect them into a single issue or update an
          existing "Stale TODOs" issue.
-       - Verify convention compliance:
-         * No `as any`, `@ts-ignore`, or `@ts-expect-error` in source
-         * GitHub Actions use .yaml extension (not .yml)
-         * All actions are SHA-pinned with version comments
-         * No `secrets: inherit` with cross-org reusable workflows
-         * Only deploy.sh is bash; all other scripts are TypeScript
-         * config/config.json template has empty dropboxSecret
        - Check that AGENTS.md files accurately reflect the current
          directory structure. If drift is found, open a PR with corrections.
+         Structural convention rules (see root AGENTS.md bullets marked
+         `(enforced)`) are mechanically gated pre-merge by ESLint and
+         `packages/cli/src/conventions.test.ts`; do not re-check them here.
        Report findings but put actual code fixes into category 4.
 
     4. DEVELOPER EXPERIENCE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,12 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 
 ## CONVENTIONS
 
-- **Only bash script**: `apps/keeweb/deploy.sh`. All other scripts are TypeScript run via `bun run`.
-- **GitHub Actions**: `.yaml` extension (not `.yml`). SHA-pin all actions with `# vX.Y.Z` version comment.
+- **Only bash script**: `apps/keeweb/deploy.sh`. All other scripts are TypeScript run via `bun run`. (enforced)
+- **GitHub Actions**: `.yaml` extension (not `.yml`). SHA-pin all actions with `# vX.Y.Z` version comment. (enforced)
 - **Shared configs**: `@bfra.me/eslint-config`, `@bfra.me/prettier-config/120-proof`, `@bfra.me/tsconfig`.
 - **Git hooks**: `simple-git-hooks` + `lint-staged` → `eslint --fix` on commit.
 - **CI install**: `bun install --frozen-lockfile --ignore-scripts` (skip simple-git-hooks postinstall).
-- **Cross-org reusable workflows**: Pass secrets explicitly (never `secrets: inherit` with `bfra-me/.github`).
+- **Cross-org reusable workflows**: Pass secrets explicitly (never `secrets: inherit` with `bfra-me/.github`). (enforced)
 - **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root.
 - **Changesets**: `@changesets/cli` for versioning. Renovate PRs get auto-generated changeset files.
 - **Tests**: Colocated `*.test.ts` alongside source. Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic snapshots. Mock at boundaries (fetch, Bun.spawn), not internals. CI runs `bun test --recursive` as a parallel job alongside lint/type-check.
@@ -60,13 +60,13 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
-- **No `as any` / `@ts-ignore` / `@ts-expect-error`** — fix the types.
-- **No secret values in tracked files** — `config/config.json` template has empty `dropboxSecret`; real value injected at build time from env var.
+- **No `as any` / `@ts-ignore` / `@ts-expect-error`** — fix the types. (enforced)
+- **No secret values in tracked files** — `config/config.json` template has empty `dropboxSecret`; real value injected at build time from env var. (enforced)
 - **Never modify `config/config.json` in CI** — secret goes into `dist/config.json` only.
 - **Never overwrite `config.yaml` on cliproxy server** — runtime API keys live there. Deploy skips upload when file exists; `--force-config` is the explicit override.
-- **Never use `ssh-keyscan`** — host keys pinned in `.github/known_hosts`.
-- **Never `secrets: inherit`** with cross-org reusable workflows.
-- **Never use `bundledDependencies`** — Bun's `.bun/` symlink layout creates `../../` paths that npm rejects with E415.
+- **Never use `ssh-keyscan` in CI workflows** — host keys are pinned in `.github/known_hosts`. Provisioning scripts may use `ssh-keyscan` locally; `apps/cliproxy/server/provision-droplet.ts` is the current example. (enforced)
+- **Never `secrets: inherit`** with cross-org reusable workflows. (enforced)
+- **Never use `bundledDependencies`** — Bun's `.bun/` symlink layout creates `../../` paths that npm rejects with E415. (enforced)
 
 ## UNIQUE STYLES
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
     },
     "packages/cli": {
       "name": "@marcusrbrown/infra",
-      "version": "0.4.1",
+      "version": "0.4.4",
       "bin": {
         "infra": "src/cli.ts",
       },
@@ -42,6 +42,9 @@
         "goke": "^6.3.2",
         "string-dedent": "^3.0.2",
         "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "yaml": "^2.8.3",
       },
     },
   },

--- a/docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md
+++ b/docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md
@@ -1,0 +1,138 @@
+---
+date: 2026-04-16
+topic: executable-conventions-tests
+source_ideation: docs/ideation/2026-04-04-cli-keeweb-testing-ideation.md
+scope: standard
+---
+
+# Executable Conventions Tests
+
+## Summary
+
+Convert the structurally-checkable subset of root `AGENTS.md` rules into mechanically-enforced CI failures. Two mechanisms: ESLint severity/config changes for code-level rules (handled by `@bfra.me/eslint-config`'s bundled plugins without new additions), and a conventions test file for content-pattern rules (YAML workflow content, JSON value invariants, filesystem shape) where the ecosystem's existing ESLint plugin rules don't reach. Custom inline ESLint AST rules are deliberately out of scope for v1 — the cost of hand-rolling YAML/JSONC AST visitors exceeds the cost of equivalent assertions in a test, with no runtime benefit for CI-only enforcement.
+
+Enforced rules in `AGENTS.md` get an in-place annotation marker so humans skimming the doc (and agents parsing it) can tell at a glance which rules are mechanical vs. judgment-based. Fro Bot autoheal category 3 stays as the post-merge safety net, trimmed to cover rules this suite doesn't mechanize.
+
+## Problem
+
+`AGENTS.md` rules decay because they're advisory. Agents violate them silently; reviewers miss violations in large diffs. Existing enforcement is advisory-by-default:
+
+- ESLint — `@typescript-eslint/no-explicit-any` is currently **off** (severity 0) and `ban-ts-comment` allows `ts-expect-error` with description. Code-level convention rules don't actually fail CI today.
+- Fro Bot autoheal category 3 — daily post-merge check, reports but doesn't gate.
+- Reviewer diligence.
+
+Concrete slipped-through examples: `bundledDependencies` added to `packages/cli/package.json` (broke publish), `apps/**` over-excluded in `renovate-changesets.yaml` (missed Docker image bump changelogs), file-naming drift. These pre-date autoheal going live; a supporting datapoint for planning is the count of category-3 violations autoheal has opened or auto-fixed in the 30–60 days since it started running, to calibrate whether the remaining drift rate justifies a pre-merge gate.
+
+## Goals
+
+- Pre-merge CI failure on violations of structurally-checkable root `AGENTS.md` rules.
+- Every enforced rule is green on `main` the day the suite ships (fix-first, not baselined).
+- Each enforced rule has a one-line link or reference to its implementation (ESLint rule name or conventions test assertion), and changing the rule updates AGENTS.md annotation and implementation in the same PR.
+- Human contributors skimming AGENTS.md can tell at a glance which rules are mechanical.
+- Agents benefit primarily from the CI failure itself — the annotation is secondary signal.
+
+## Non-Goals
+
+- Source-of-truth migration. AGENTS.md stays canonical for documentation; enforcement is additive.
+- Judgment-based rules ("prefer root cause over symptom", first-person voice in `gh` comments, run `git status` before committing).
+- Broad refactor of AGENTS.md beyond per-rule annotation markers and one factual correction (Rule 6 scope, below).
+- Replacing or rebuilding Fro Bot autoheal category 3. The suite complements it; category 3 will be trimmed to non-mechanized rules in the same PR so it doesn't double-report.
+- Baselining or allow-listing existing violations.
+- Per-app AGENTS.md rules (`apps/keeweb/AGENTS.md`, `apps/cliproxy/AGENTS.md`, `packages/cli/AGENTS.md`). Root-only v1. Per-app extension is a follow-up once the mechanics are proven.
+- New ESLint plugin additions beyond what `@bfra.me/eslint-config` already pulls in.
+- Custom inline ESLint AST rules (covered in Mechanism Policy — the ecosystem's built-in content-pattern rules are insufficient and the hand-rolled alternative has no advantage over a test).
+- Net-new regression encoding of compound-learning docs beyond what's named in the v1 rule set.
+
+## Rules in Scope (v1)
+
+9 rules. Mechanism assignments are firm (based on a feasibility audit of what `@bfra.me/eslint-config`'s bundled plugins actually ship).
+
+| # | Rule | Source | Mechanism |
+| --- | --- | --- | --- |
+| 1 | No `as any` in source | AGENTS.md | ESLint: `@typescript-eslint/no-explicit-any` → error (currently off) |
+| 2 | No `@ts-ignore` / `@ts-expect-error` in source | AGENTS.md | ESLint: `@typescript-eslint/ban-ts-comment` → error, no description carveout |
+| 3 | No `bundledDependencies` in any `package.json` | AGENTS.md anti-pattern (Bun constraint) | Conventions test: glob `**/package.json`, JSON parse, assert no `bundledDependencies` key |
+| 4 | `apps/keeweb/config/config.json` has empty `dropboxSecret` | AGENTS.md + `apps/keeweb/src/build.ts` contract | Conventions test: JSON parse, assert `.dropboxSecret === ''` |
+| 5 | No `secrets: inherit` on any job whose `uses:` points to a cross-org workflow | AGENTS.md (cross-org constraint) | Conventions test: YAML parse each workflow, walk jobs, correlate `uses:` owner with an allowed-org list (`marcusrbrown/*`, internal), fail if `secrets: inherit` appears on a cross-org job |
+| 6 | No `ssh-keyscan` under `.github/workflows/**` | `docs/solutions/` + AGENTS.md (scoped) | Conventions test: regex over workflow files |
+| 7 | Every `uses: …@<sha>` has a trailing version comment (either `# vX.Y.Z` or `# <scope>@X.Y.Z`) | AGENTS.md (SHA-pin convention) | Conventions test: YAML parse, walk `uses:` values, correlate trailing line comment via source location |
+| 8 | Files under `.github/workflows/` use `.yaml` extension (not `.yml`) | AGENTS.md | Conventions test: glob `.github/workflows/*.yml` must be empty. Explicitly scoped — `.github/settings.yml` is not a workflow and is exempt. |
+| 9 | No `.sh` files outside `apps/keeweb/deploy.sh` | AGENTS.md (TypeScript-only policy) | Conventions test: glob `**/*.sh` minus the one exempt path must be empty |
+
+**Dropped from initial draft:**
+
+- **Rule 10** (`.github/renovate.json5` exists): structurally checkable but near-zero regression risk. The file has existed since repo inception; a silent rename would break Renovate visibly within one scheduled run. Not worth the enforcement weight.
+- **Rule 11** (CLIProxyAPI management headers use `x-management-key`): confirmed covered by existing unit tests at `packages/cli/src/commands/cliproxy/config.test.ts:121,173`, and grep-style enforcement produces false positives on the legitimate Bearer usage in `setup.ts:407` (`assertProxyKeyWorks` hits `/v1/models` with a user API key — not a management call). Keep the coverage in unit tests.
+
+## Mechanism Policy
+
+1. **ESLint for code-level rules via existing built-ins.** Rules 1, 2 are severity/config changes to `@typescript-eslint/no-explicit-any` and `ban-ts-comment`. Both require a **real config change** (not just severity bump): rule 1's built-in is currently off, and rule 2's current config allows `ts-expect-error` with description — both need overriding in `eslint.config.ts` at error severity.
+2. **Conventions test for content patterns, JSON value invariants, and filesystem shape.** Rules 3-9 all go here. Justification: `eslint-plugin-jsonc@3.1.2` and `eslint-plugin-yml@3.3.1` (bundled via `@bfra.me/eslint-config`) ship no content-pattern restriction rules (no `no-restricted-keys`, no `no-restricted-syntax` on JSONC/YAML AST). A hand-rolled custom ESLint rule targeting the YAML AST is 40-80 LOC per rule plus parser type imports, and offers no advantage over the equivalent TypeScript test since these rules run only on CI and don't need editor feedback. The test is simpler, shorter, and lives in a familiar place.
+3. **Test location and path resolution.** One test file at `packages/cli/src/conventions.test.ts`. All file paths resolve via `path.resolve(import.meta.dir, '../../..')` to reach the repo root — do not use `process.cwd()`, which differs between `bun test --recursive` (CWD=repo-root) and `bun test` in `packages/cli/` (CWD=package). This pattern matches existing tests at `packages/cli/src/cli.test.ts:8` and the keeweb/cliproxy deploy tests.
+
+## Success Criteria
+
+- `bun run lint` fails on any violation of rules 1 or 2.
+- `bun test --recursive` fails on any violation of rules 3 through 9.
+- `bun run lint` and `bun test --recursive` are both green on `main` on ship day (fix-first policy).
+- Enforced rules in root `AGENTS.md` carry a single `(enforced)` marker appended inline.
+- Changes to any enforced rule update both the AGENTS.md prose and the enforcement (ESLint config entry or test assertion) in the same PR. Not mechanically enforced in v1 but stated as a working rule.
+
+## Shipping Policy
+
+- **Fix-first, ship green.** Audit each of rules 1-9 on `main` before enabling. Fix violations in the same PR if tally is small; split into audit PR + enable PR if tally is large for any single rule. Threshold for splitting is decided during planning based on the actual audit numbers, not before.
+- **Audit is a planning-phase deliverable.** Produce per-rule violation counts as the first planning step, before deciding PR structure.
+
+## AGENTS.md Annotation
+
+Each enforced rule in root `AGENTS.md` gets a single `(enforced)` marker appended inline. Unenforced rules stay unannotated. One marker variant chosen deliberately to avoid drift when a rule's mechanism changes (ESLint ↔ conventions test) — demonstrated during this brainstorm's feasibility pass, where 5 rules moved mechanism. Anyone who needs to know *which* mechanism backs a rule greps `eslint.config.ts` or `conventions.test.ts`.
+
+Plus one factual correction in the annotation pass: the current `Never use ssh-keyscan` anti-pattern in AGENTS.md should be narrowed to `Never use ssh-keyscan in CI workflows — host keys are pinned in .github/known_hosts. Provisioning scripts may use ssh-keyscan locally; apps/cliproxy/server/provision-droplet.ts is the current example.` This matches the Rule 6 scope and resolves the current discrepancy between the prose and the actual usage at `apps/cliproxy/server/provision-droplet.ts:217,219`.
+
+## Fro Bot Category 3 Coordination
+
+In the same PR as the enforcement lands, trim Fro Bot autoheal category 3's convention-check list to remove the items now mechanically gated. The prompt is at `.github/workflows/fro-bot.yaml` (category 3 of `SCHEDULE_PROMPT`). Category 3 retains:
+
+- Items the v1 suite does not cover (e.g., AGENTS.md accuracy drift — a judgment call).
+- Build + type-check + stale-TODO scans.
+- Any convention named in AGENTS.md but not in rules 1-9.
+
+This avoids double-reporting once enforcement is live.
+
+## Open Questions
+
+None. All brainstorm-phase product decisions resolved. Remaining items are planning-phase deliverables (see below).
+
+## Audit Result (done 2026-04-16 on `main`)
+
+**Zero violations across all 9 rules.** Ship-green is trivially achievable in a single PR.
+
+| # | Rule | Violations | Notes |
+| --- | --- | --- | --- |
+| 1 | No `as any` / explicit `any` | 0 | Grep for `as any`, `: any`, `<any>`, `any[]`, `Record<…, any>`, `Promise<any>` across `apps/**/*.ts` and `packages/**/*.ts` all returned empty. |
+| 2 | No `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck` | 0 | No existing comment directives. |
+| 3 | No `bundledDependencies` | 0 | No `package.json` in the tree contains the key. |
+| 4 | `apps/keeweb/config/config.json` `dropboxSecret === ''` | 0 | Confirmed `"dropboxSecret": ""` at line 26. |
+| 5 | No cross-org `secrets: inherit` | 0 | 3 grep matches in `fro-bot.yaml` are all inside prompt heredoc prose (`PR_REVIEW_PROMPT` line 48, `SCHEDULE_PROMPT` lines 143, 315), not actual YAML keys on job definitions. This confirms the mechanism choice — a regex would false-positive; the conventions test must parse YAML and inspect only job-level keys. |
+| 6 | No `ssh-keyscan` in `.github/workflows/**` | 0 | The one repo-wide occurrence is `apps/cliproxy/server/provision-droplet.ts:217,219`, outside the rule scope. |
+| 7 | Every `uses: …@<sha>` has version comment | 0 | All 37 `uses:` lines across 9 workflow files carry either `# vX.Y.Z` or `# <scope>@X.Y.Z` (e.g., `# renovate-changesets@0.2.31`). |
+| 8 | No `.yml` in `.github/workflows/` | 0 | Glob `.github/workflows/*.yml` returns empty. `.github/settings.yml` sits at `.github/` root, outside the rule scope. |
+| 9 | No `.sh` outside `apps/keeweb/deploy.sh` | 0 | The single `.sh` file in the tree is the allowed one. |
+
+Implication for planning: no per-rule PR split needed. One PR enables all rules, writes the conventions test, updates `eslint.config.ts`, annotates AGENTS.md, narrows the `ssh-keyscan` prose, and trims Fro Bot category 3.
+
+## Planning Inputs
+- Category-3 violation count from Fro Bot's issue history (last 30-60 days) to confirm the pre-merge-gate value proposition is sized right.
+- Exact `ban-ts-comment` config: verify `{ 'ts-expect-error': true, 'ts-ignore': true, 'ts-nocheck': true, 'ts-check': false, minimumDescriptionLength: 0 }` at error severity produces the desired behavior.
+- YAML parser choice for rules 5 and 7: `yaml-eslint-parser` (transitive via `eslint-plugin-yml`) vs. a direct `yaml` / `js-yaml` dep. Prefer the transitive if parsing through `Bun.file(...).text()` + `parse()` works cleanly from a test; add a direct dep only if transitive resolution is brittle under Bun's `.bun/` symlink layout.
+- Comment correlation for rule 7: match by `comment.loc.start.line === valueNode.loc.end.line`; accept version forms `# v\d+\.\d+\.\d+` OR `# [\w@/-]+@\d+\.\d+\.\d+` (e.g., `# renovate-changesets@0.2.31`).
+- Cross-org allowlist for rule 5: define as `['marcusrbrown', 'bfra-me']` or similar; finalize with the user during planning based on which reusable-workflow sources we've vetted.
+- Category-3 prompt trim: produce the diff against `fro-bot.yaml` SCHEDULE_PROMPT alongside the enforcement changes.
+- `ssh-keyscan` rule prose update in AGENTS.md: the factual correction described in the Annotation section.
+
+## Alternatives Considered
+
+- **Do-nothing + tighten ESLint severities only.** Rules 1, 2 can ship via ESLint config alone with no new test file and no annotations. This is about 20% of the proposed value for about 5% of the work. Rejected because it leaves the compound-learning and structural rules (3-9) advisory — specifically `bundledDependencies` (prior publish break), SHA-pin comments (convention drift vector), and `secrets: inherit` cross-org (audited risk).
+- **Custom inline ESLint AST rules for rules 3-7.** Gives unified lint-run reporting but adds 40-80 LOC of AST-walking code per rule, requires learning `yaml-eslint-parser` / `jsonc-eslint-parser` AST shapes, and provides zero editor-time feedback for YAML/JSON content that editors don't live-lint. Rejected: equivalent expressiveness in a test is shorter, more familiar, and has the same CI failure profile.
+- **Extend to per-app AGENTS.md in v1.** Would include the cliproxy `config.yaml`-never-overwritten rule (a high-value compound-learning invariant). Rejected for v1 to prove mechanics on root rules first; per-app is a clear follow-up.
+- **Source-of-truth migration (slim AGENTS.md, reference tests).** Higher long-term leverage but larger churn and multiple feedback cycles. Deferred — annotation is the reversible first step.

--- a/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
+++ b/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
@@ -216,7 +216,7 @@ describe('repo conventions', () => {
 - Test expectation: none — pure documentation edit, no behavior change.
 
 **Verification:**
-- `rg --hidden -F '(enforced)' AGENTS.md` returns exactly 9 matches — one per R1-R9 bullet. The ssh-keyscan narrowed bullet carries R6's single marker (the R6 marker *is* the one on the narrowed bullet, not an additional one).
+- `rg --hidden -F '(enforced)' AGENTS.md` returns exactly 8 matches. Mapping: R9, R7+R8 (one shared bullet), R5 convention side, R1+R2 (one shared bullet), R4, R6 (narrowed bullet), R5 anti-pattern side, R3. Every rule in R1-R9 is covered by at least one marker; R5 has two (stated in both Conventions and Anti-Patterns sections).
 - Visual diff review: the only changes are trailing `(enforced)` appends on the expected bullets and the ssh-keyscan prose narrowing.
 - Re-read root `AGENTS.md` end-to-end after edit to confirm the prose still reads naturally with markers appended.
 

--- a/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
+++ b/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
@@ -1,0 +1,280 @@
+---
+title: 'feat: Enforce root AGENTS.md conventions with ESLint config and conventions test'
+type: feat
+status: active
+date: 2026-04-16
+origin: docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md
+---
+
+# Enforce root AGENTS.md conventions with ESLint config and conventions test
+
+## Overview
+
+Mechanically enforce the 9 structurally-checkable rules from root `AGENTS.md` via two mechanisms: ESLint config changes in `eslint.config.ts` (rules 1-2, code-level) and a new TypeScript test at `packages/cli/src/conventions.test.ts` (rules 3-9, content-pattern and filesystem shape). Annotate each enforced rule in root `AGENTS.md` with an `(enforced)` marker and narrow the `ssh-keyscan` anti-pattern prose. Trim Fro Bot autoheal category 3 to drop items now mechanically gated so the post-merge check doesn't double-report.
+
+The brainstorm's audit confirmed zero violations on `main` across all 9 rules. Ship-green is trivial — everything lands in one PR, no cleanup commits required.
+
+## Problem Frame
+
+See origin doc for the full framing. Short version: `AGENTS.md` convention rules are advisory. Agents silently violate them, and the existing enforcement stack — ESLint with most convention-adjacent rules at warn/off severity, plus daily Fro Bot autoheal category 3 — reports but doesn't gate. Pre-merge CI failures would prevent the regressions we've already paid for (`bundledDependencies` publish break, `apps/**` over-exclusion in `renovate-changesets.yaml`, file-naming drift).
+
+## Requirements Trace
+
+From origin doc's "Rules in Scope (v1)":
+
+- **R1**: No `as any` / explicit `any` in source (ESLint `@typescript-eslint/no-explicit-any` at error)
+- **R2**: No `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck` in source (ESLint `ban-ts-comment` at error with no description carveout)
+- **R3**: No `bundledDependencies` key in any `package.json`
+- **R4**: `apps/keeweb/config/config.json` has `settings.dropboxSecret === ''` (the key is nested under `settings`)
+- **R5**: No `secrets: inherit` on any job whose `uses:` points to a cross-org workflow
+- **R6**: No `ssh-keyscan` under `.github/workflows/**`
+- **R7**: Every `uses: ...@<sha>` has a trailing version comment (`# vX.Y.Z` or `# <scope>@X.Y.Z`)
+- **R8**: Files under `.github/workflows/` use `.yaml` (not `.yml`)
+- **R9**: No `.sh` files outside `apps/keeweb/deploy.sh`
+
+Plus Rset (origin "AGENTS.md Annotation"):
+
+- **R10**: Each enforced rule in root `AGENTS.md` carries a single `(enforced)` marker
+- **R11**: The `Never use ssh-keyscan` anti-pattern prose narrows to the CI-only scope
+- **R12**: Fro Bot autoheal category 3 trims the convention checks now mechanically gated (same PR, same workflow file)
+
+## Scope Boundaries
+
+Full Non-Goals list lives in the origin doc. Plan-specific scope calls:
+
+- Dropped from v1: Rule 10 (`renovate.json5` exists — near-zero regression risk), Rule 11 (CLIProxyAPI management headers — already covered by existing unit tests at `packages/cli/src/commands/cliproxy/config.test.ts:121,173`; grep-style enforcement would false-positive on the legitimate `Bearer` usage in `setup.ts:407`)
+- Custom inline ESLint AST rules are deliberately out of scope — mechanism choice rests on what `@bfra.me/eslint-config`'s bundled plugins actually ship (see origin)
+
+### Deferred to Separate Tasks
+
+- Extending enforcement to per-app AGENTS.md rules (e.g., cliproxy `config.yaml`-never-overwritten invariant) — follow-up once root mechanics are proven
+- Drift check mechanism (parse AGENTS.md for `(enforced)` markers, assert each maps to a real ESLint rule or test assertion) — explicitly deferred in origin; nice-to-have
+- Category-3 violation count from Fro Bot's issue history (30-60 day baseline) — planning input flagged by origin's product review but not blocking
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `eslint.config.ts` — flat config using `@bfra.me/eslint-config`'s `defineConfig`. Adds overrides in named blocks. Pattern for rule severity overrides is a new named block with `rules:`.
+- `packages/cli/src/cli.test.ts:8` — canonical path-resolution pattern: `const cliDir = resolve(import.meta.dir, '..')`. Conventions test uses the same shape but with `../../..` to reach repo root.
+- `packages/cli/src/commands/keeweb/build.test.ts` and existing tests in `packages/cli/src/commands/cliproxy/` — file-reading + JSON-parsing patterns. Conventions test uses `Bun.file(path).text()` + `JSON.parse()`.
+- `.github/workflows/fro-bot.yaml` — `SCHEDULE_PROMPT` category 3 lives in the multi-line YAML block starting around line 128. Trim target is the convention-compliance bullet list under "Verify convention compliance".
+- Root `AGENTS.md` — rules live under `## Conventions` and `## Anti-Patterns (THIS PROJECT)`. Annotation pass appends `(enforced)` after the specific bullets matching R1-R9.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md` documents the `ssh-keyscan`-in-CI class of incident — the rationale for R6.
+- `docs/solutions/workflow-issues/bun-deploy-user-permissions-ci-2026-04-02.md` documents why `deploy-kw` permissions matter but is orthogonal to this plan.
+
+### External References
+
+Not needed. `yaml` package (npm) and `@typescript-eslint/ban-ts-comment` options are documented in their standard docs; no research gap.
+
+## Key Technical Decisions
+
+- **Add `yaml` package as a direct devDependency in `packages/cli/package.json`** (not root). Bun's `.bun/` symlink layout installs `yaml@2.8.3` transitively (via `eslint-plugin-yml`), but transitive deps aren't directly importable. `yaml` is a small, well-maintained package; adding it explicitly is cleaner than wrestling with transitive resolution. Devdep in the test's home package, not root workspace.
+- **Cross-org allowlist for R5 is `['marcusrbrown']`**. Origin suggested `['marcusrbrown', 'bfra-me']` as a starting value. Narrowing to `['marcusrbrown']` makes R5 also enforce the explicit-secrets-pass pattern on `bfra-me/*` reusable-workflow calls (treating them as cross-org), which matches current practice — all `bfra-me/*` jobs in this repo already pass secrets explicitly rather than via `inherit`. If we ever want to let a specific `bfra-me` workflow use `inherit`, expand the list then.
+- **R5 walker handles local reusable-workflow paths explicitly**. If `job.uses` starts with `./` or `../` (local reusable workflow), skip the cross-org check — local workflows are same-repo and `secrets: inherit` is legitimate for them. Only jobs whose `uses:` value has the `owner/repo/...@ref` shape and an owner outside `INTERNAL_ORGS` are cross-org.
+- **Rule 7 uses a regex check, not YAML AST**. The `uses:` lines in our workflows are single-line forms (`uses: owner/name@sha # version-comment`). A line-oriented regex pass is simpler than AST comment correlation and suffices for the syntax we actually use. Regex: `/@[a-f0-9]{7,}\s+#\s+(v\d+(?:\.\d+){0,2}|[\w@/-]+@\d+(?:\.\d+){0,2})\s*$/` on each `uses:` value line. The check distinguishes two violation types: **missing** (no trailing content after the SHA) and **malformed** (trailing content present but doesn't match the version-comment regex). Error messages should name the case for clearer diagnostics. If multi-line `uses:` ever shows up, escalate to AST — noted in deferred.
+- **Rule 5 uses YAML AST**. The brainstorm's audit proved naive regex false-positives on prose inside prompt heredocs (`SCHEDULE_PROMPT` / `PR_REVIEW_PROMPT` in `fro-bot.yaml`). Parse each workflow with `yaml`, walk `jobs.*` nodes, check each job's `uses:` + `secrets:` keys. Only flag `secrets: inherit` on a job whose `uses:` owner isn't in the allowlist (and isn't local — see above).
+- **`@typescript-eslint/ban-ts-comment` full shape**: `['error', { 'ts-expect-error': true, 'ts-ignore': true, 'ts-nocheck': true, 'ts-check': false }]`. `true` bans outright; `false` on `ts-check` means `@ts-check` (which *enables* checking, not suppresses it) is allowed. `minimumDescriptionLength` is irrelevant when no directive uses `'allow-with-description'`. ESLint flat config fully replaces preset rule options, so this override supersedes `@bfra.me/eslint-config`'s default (which currently allows `ts-expect-error` with description).
+- **Path resolution in conventions test**: `const REPO_ROOT = resolve(import.meta.dir, '../../..')`. Same pattern as existing tests. Avoids the `bun test` (CWD=package) vs `bun test --recursive` (CWD=repo) divergence.
+- **`Bun.Glob` must use `{ dot: true }` for `.github/` scans**. `Bun.Glob` skips dot-prefixed directories by default. Without `dot: true`, globs like `.github/workflows/*.yaml` return zero files and R5/R6/R7/R8 silently pass. Every Glob call that targets or traverses `.github/` must pass `{ dot: true }`. Add a tripwire assertion at the start of the workflow-globbing tests asserting the matched file count is >= 1, so a future refactor that drops `dot: true` fails loudly instead of silently.
+- **Conventions test is Bun-native** (`Bun.Glob`, `Bun.file`) plus `yaml` as pure JS. No Node pin needed on the `test` CI job; the existing `bun test --recursive` invocation is sufficient.
+
+## Open Questions
+
+### Resolved During Planning
+
+- YAML parser choice → `yaml` package as direct devDep in `packages/cli/package.json`.
+- `ban-ts-comment` option shape → resolved above.
+- Cross-org allowlist for R5 → `['marcusrbrown']`.
+- R7 regex form → resolved above (supports both version formats the repo actually uses).
+- Rule 7 AST vs regex → regex (single-line `uses:` syntax is universal in our workflows).
+
+### Deferred to Implementation
+
+- Exact helper function signatures in `conventions.test.ts` (e.g., whether to extract per-rule predicates or inline assertions) — let the implementation choose what reads best.
+- Fro Bot category 3 prompt diff — the exact lines to remove depend on reading the current `SCHEDULE_PROMPT` text alongside the new rule set; let implementation produce the narrowest possible trim.
+
+## Implementation Units
+
+- [ ] **Unit 1: ESLint config tightening for R1-R2**
+
+**Goal:** Flip `@typescript-eslint/no-explicit-any` from off → error and override `ban-ts-comment` to ban all three directives without description carveouts.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `eslint.config.ts`
+
+**Approach:**
+- Add a new named block to the `defineConfig(...)` call (e.g., `name: 'infra-conventions'`) with `rules:` containing the two overrides. Place it after the existing `bun-globals` block so it applies broadly across all TS files; the `files:` key stays unset to apply globally.
+- Keep the existing `cli-and-scripts` block untouched (it disables `no-console` for scripts, orthogonal concern).
+
+**Patterns to follow:**
+- Existing named blocks in `eslint.config.ts:9-21` (structure: `name`, optional `files`, `rules`).
+
+**Test scenarios:**
+- Happy path: `bun run lint` exits 0 on clean main (audit confirmed zero violations today).
+
+**Verification:**
+- `bun run lint` stays green.
+- `bunx eslint --print-config packages/cli/src/cli.ts | jq '.rules["@typescript-eslint/no-explicit-any"]'` returns `[2]` (error severity, no options).
+- `bunx eslint --print-config packages/cli/src/cli.ts | jq '.rules["@typescript-eslint/ban-ts-comment"]'` returns `[2, { "ts-expect-error": true, "ts-ignore": true, "ts-nocheck": true, "ts-check": false }]`.
+
+- [ ] **Unit 2: Conventions test for R3-R9**
+
+**Goal:** A single Bun test file that enforces R3-R9 by reading real repo files. Fails CI on any violation. All checks green on `main` at ship time.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R9
+
+**Dependencies:** Unit 1 can merge in the same PR but is not a hard prerequisite for this unit.
+
+**Files:**
+- Create: `packages/cli/src/conventions.test.ts`
+- Modify: `packages/cli/package.json` (add `yaml` to `devDependencies`)
+- Modify: `bun.lock` (regenerated by `bun install` after the dep add)
+
+**Approach:**
+- File layout: `describe('repo conventions', () => { ... })` wrapping nine `it(...)` blocks, one per rule. Each `it` is independent; failures surface per-rule with rule-specific error messages that include the offending file paths.
+- Constants at the top: `REPO_ROOT = resolve(import.meta.dir, '../../..')`, `INTERNAL_ORGS = new Set(['marcusrbrown'])`, `ALLOWED_SHELL_SCRIPTS = new Set(['apps/keeweb/deploy.sh'])`.
+- Use Bun's built-in `Glob` (`new Bun.Glob(pattern).scan({cwd, absolute, dot})`) for file discovery. Avoid `process.cwd()`. **Every `.github/`-targeting glob must pass `{ dot: true }`** — Bun.Glob skips dot-prefixed directories otherwise and the rule silently passes on an empty file set.
+- **Workflow file tripwire**: at the start of the workflow-globbing rules, compute `const workflowFiles = [...].scanSync({ cwd: REPO_ROOT, absolute: true, dot: true })` once and `expect(workflowFiles.length).toBeGreaterThan(0)`. If a future refactor drops `dot: true`, R5/R6/R7/R8 all fail together with a clear message instead of silently passing.
+- R3: glob `**/package.json` (Bun.Glob auto-excludes `node_modules/**`, no `{ dot: true }` needed — no package.json files live under dot-dirs), `JSON.parse`, assert no `bundledDependencies` key.
+- R4: `Bun.file(REPO_ROOT/'apps/keeweb/config/config.json').json()`, assert `.settings.dropboxSecret === ''`.
+- R5: glob `.github/workflows/*.yaml` with `{ dot: true }`, parse each via `yaml.parse(content, { merge: true })`. Walk `parsed.jobs[*]` — for each job that has a `uses:` value: (a) if `uses` starts with `./` or `../`, skip (local reusable workflow); (b) otherwise extract owner via `uses.split('/')[0]`, and if the owner is not in `INTERNAL_ORGS`, fail if `job.secrets === 'inherit'`. Accumulate violations into a list and `expect(violations).toEqual([])`.
+- R6: glob `.github/workflows/*.yaml` with `{ dot: true }`, read each as text, `expect(text).not.toMatch(/\bssh-keyscan\b/)`. Report offending file + line if match.
+- R7: glob `.github/workflows/*.yaml` with `{ dot: true }`, regex each line matching `^\s+-?\s*uses:\s+(\S+)@([a-f0-9]{7,})(?:\s+(.*))?$`. If capture group 3 is `undefined` (no trailing content), record violation as `"missing version comment"`. If capture group 3 is defined but doesn't match `/^#\s+(v\d+(?:\.\d+){0,2}|[\w@/-]+@\d+(?:\.\d+){0,2})\s*$/`, record as `"malformed version comment: <captured>"`. The two cases share the same assertion but produce different error messages for diagnostics.
+- R8: glob `.github/workflows/*.yml` with `{ dot: true }`, assert returned array is empty. Note: scope is *inside* `.github/workflows/` — `.github/settings.yml` is deliberately exempt.
+- R9: glob `**/*.sh` (Bun.Glob auto-excludes `node_modules/**`; additionally filter out `.cache/**`, `dist/**` explicitly), filter by `ALLOWED_SHELL_SCRIPTS`, assert unmatched list is empty.
+- Error messages: each `expect(...)` includes a message argument or uses `expect(list).toEqual([])` so the failure output names the offending files. If Bun's built-in assertion output isn't informative enough, build a `list.map(v => \`${file}:${line}: ${reason}\`).join('\n')` string and assert on that.
+
+**Technical design:** *(directional — illustrates the per-rule structure, not implementation)*
+
+```ts
+describe('repo conventions', () => {
+  it('R3: no bundledDependencies in any package.json', async () => {
+    const packageJsons = [...new Bun.Glob('**/package.json').scanSync({ cwd: REPO_ROOT, absolute: true })]
+      .filter(p => !p.includes('/node_modules/'))
+    const offenders: string[] = []
+    for (const file of packageJsons) {
+      const json = await Bun.file(file).json()
+      if ('bundledDependencies' in json) offenders.push(relative(REPO_ROOT, file))
+    }
+    expect(offenders).toEqual([])
+  })
+  // ...one `it` per rule
+})
+```
+
+**Patterns to follow:**
+- Path resolution: `packages/cli/src/cli.test.ts:8`.
+- File reading: `packages/cli/src/commands/keeweb/build.test.ts` (uses `Bun.file(...).text()` / `.json()`).
+- Test structure (describe + named `it` blocks): any existing test in `packages/cli/src/commands/`.
+
+**Test scenarios:**
+- Happy path, R3: real repo's `package.json` tree returns empty offender list. Audit confirmed 0 violations.
+- Happy path, R4: `dropboxSecret` is `""` in real file.
+- Happy path, R5: real workflows parse cleanly, cross-org check returns empty violation list.
+- Happy path, R6: no workflow contains `ssh-keyscan`.
+- Happy path, R7: all 37 `uses:` lines match the version-comment regex.
+- Happy path, R8: no `.yml` files under `.github/workflows/`.
+- Happy path, R9: only `apps/keeweb/deploy.sh` matches the `.sh` glob.
+- Edge case, R5: confirm the cross-org walker ignores `secrets: inherit` occurring inside prompt heredoc prose in `fro-bot.yaml` (3 known occurrences). If the walker flags them, the YAML parse or the jobs-only scoping is wrong.
+- Error path, R5: construct an inline synthetic workflow YAML string with a cross-org `uses:` + `secrets: inherit` job, pass through the detector function, assert exactly one violation is reported with the correct file/job identification. This is the only non-optional negative test — it's both a regression guard for the walker's core logic and our assurance that the `fro-bot.yaml` 3-prose-match ignoring isn't just luck.
+- Edge case, R5 local: inline YAML with `uses: ./.github/workflows/local.yaml` + `secrets: inherit`, assert no violation (local reusable workflows are same-repo and may inherit).
+- Edge case, R9: confirm the filter correctly allows the single permitted `.sh` path without false positives on files under excluded directories.
+
+**Verification:**
+- `bun test --recursive` passes with the new file in place.
+- `bun test packages/cli/src/conventions.test.ts` also passes (tests are independent of CWD).
+- Manual validation before merge: temporarily introduce one violation per rule (e.g., add `"bundledDependencies": ["x"]` to a `package.json`; rename one workflow file to `.yml`; remove a version comment from a `uses:` line) and confirm the corresponding test fails with a useful error message. Revert all changes before committing.
+
+- [ ] **Unit 3: Annotate root AGENTS.md**
+
+**Goal:** Append `(enforced)` to each of the 9 rules in root `AGENTS.md` that are now mechanically gated, and narrow the `ssh-keyscan` anti-pattern prose to match the CI-workflow-only scope from R6.
+
+**Requirements:** R10 (covering R1-R9 annotation), R11
+
+**Dependencies:** Soft: Units 1-2 must ship in the same PR so R10's markers remain truthful claims about work that has actually merged. Ordering within the PR: land after Units 1-2.
+
+**Files:**
+- Modify: `AGENTS.md`
+
+**Approach:**
+- For each of R1-R9, locate the corresponding bullet in root `AGENTS.md` (rules live under `## Conventions` and `## Anti-Patterns (THIS PROJECT)`). Append ` (enforced)` to the end of the bullet text. Nothing else changes.
+- Narrow the `ssh-keyscan` bullet: replace `**Never use `ssh-keyscan`** — host keys pinned in `.github/known_hosts`.` with `**Never use `ssh-keyscan` in CI workflows** — host keys are pinned in `.github/known_hosts`. Provisioning scripts may use `ssh-keyscan` locally; `apps/cliproxy/server/provision-droplet.ts` is the current example. (enforced)`.
+- No other `AGENTS.md` changes. Unenforced rules stay unannotated — this is the whole signal.
+
+**Patterns to follow:**
+- `AGENTS.md` bullet style (no terminating period on short items is inconsistent today; preserve the existing bullet's punctuation when appending).
+
+**Test scenarios:**
+- Test expectation: none — pure documentation edit, no behavior change.
+
+**Verification:**
+- `rg --hidden -F '(enforced)' AGENTS.md` returns exactly 9 matches — one per R1-R9 bullet. The ssh-keyscan narrowed bullet carries R6's single marker (the R6 marker *is* the one on the narrowed bullet, not an additional one).
+- Visual diff review: the only changes are trailing `(enforced)` appends on the expected bullets and the ssh-keyscan prose narrowing.
+- Re-read root `AGENTS.md` end-to-end after edit to confirm the prose still reads naturally with markers appended.
+
+- [ ] **Unit 4: Trim Fro Bot autoheal category 3**
+
+**Goal:** Remove the specific convention-check bullets from `SCHEDULE_PROMPT` category 3 in `.github/workflows/fro-bot.yaml` that are now mechanically gated by Units 1-2, so the daily autoheal run doesn't double-report violations the pre-merge gate already prevented.
+
+**Requirements:** R12
+
+**Dependencies:** None (ordering-only — land with Units 1-2 so the removed bullets are always backed by mechanical enforcement).
+
+**Files:**
+- Modify: `.github/workflows/fro-bot.yaml`
+
+**Approach:**
+- Locate the `SCHEDULE_PROMPT` env block. Category 3 ("CODE QUALITY & REPO HYGIENE") contains a "Verify convention compliance" bullet list. Drop the sub-bullets whose rules are now enforced by Units 1-2: no `as any` / `@ts-ignore` / `@ts-expect-error` in source (R1+R2), `.yaml` extension (R8), SHA-pin version comments (R7), no `secrets: inherit` cross-org (R5), only `deploy.sh` is bash (R9), `config/config.json` template has empty `dropboxSecret` (R4). Keep AGENTS.md-accuracy drift (judgment-based), build/type-check/stale-TODO scans, and any convention bullet not in R1-R9.
+- Also drop R3 (no `bundledDependencies`) and R6 (no `ssh-keyscan`) sub-bullets if category 3 references them explicitly — scan the prompt text and drop whichever sub-bullets match our v1 rule set.
+- Use minimal phrasing changes elsewhere. Category 3's section header, intro, build/type-check/TODO scans, and AGENTS.md-accuracy check stay.
+
+**Patterns to follow:**
+- Existing multi-line YAML block style in `fro-bot.yaml` `SCHEDULE_PROMPT`. Keep leading-space indentation consistent.
+
+**Test scenarios:**
+- Test expectation: none — workflow prompt edit, not executable code under test.
+
+**Verification:**
+- YAML parses cleanly (`docker run --rm -i mikefarah/yq '.' < .github/workflows/fro-bot.yaml > /dev/null` — or just open locally; a syntax break would be a lint-time fail).
+- Visual diff: bullets removed are exactly the ones R1-R9 cover. Surrounding prompt structure intact.
+- Post-merge, verify the next daily autoheal report (`gh issue list --search "Daily Autohealing Report" --limit 1`) doesn't flag any of the now-gated rules as convention drift.
+
+## System-Wide Impact
+
+- **Interaction graph**: `bun test --recursive` now runs one additional test file; `bun run lint` now fails on previously-warn-only patterns; `AGENTS.md` consumed by agents (they parse the new markers, but the value isn't marker-driven); `fro-bot.yaml` consumed daily by the autoheal workflow (reduced scope of category 3 work).
+- **Error propagation**: R1-R2 surface via ESLint CI failure at the `lint` job; R3-R9 surface via `bun test --recursive` at the `test` job (already parallel). Both gate the existing `ci.yaml` check on PRs.
+- **State lifecycle risks**: None — all checks are read-only against repo state.
+- **API surface parity**: No API changes. Published CLI behavior unchanged. `@marcusrbrown/infra` package shape unchanged — `files: ["src/"]` in `packages/cli/package.json` is unmodified. The new `conventions.test.ts` ships in the npm tarball alongside existing `*.test.ts` files (which already publish today); it is not runnable from an installed package because paths resolve to the monorepo root, matching the status quo for every existing test file.
+- **Integration coverage**: The conventions test *is* the integration layer. Unit-level checks on individual predicate functions (if extracted) would add nothing — the repo state the test asserts against is the integration fixture.
+- **Unchanged invariants**: All 148+ existing tests continue passing. All existing ESLint rules stay active (we're only raising severity on two rules, not disabling anything). Deploy pipeline, CLI commands, Fro Bot's PR-review path, and Renovate workflows are untouched. Category 3 autoheal prompt loses duplicate checks but keeps AGENTS.md-accuracy and build/type/TODO sweeps — the prompt's structural role is preserved.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| `yaml` package adds a new direct devDep to `packages/cli/` | Small (~50KB), actively maintained, zero runtime cost (test-only). Transitively already installed; this adds one line to `packages/cli/package.json` and regenerates `bun.lock`. |
+| ESLint rule changes surface latent `any` or `@ts-ignore` not caught by the grep audit | Audit swept for both explicit forms; zero findings. If one slips through (unlikely) the PR's CI fails before merge, and fix-first policy resolves it in the same PR. |
+| R5 YAML walker has a bug and passes silently on a crafted cross-org `secrets: inherit` | Add a small synthetic-YAML unit test as part of Unit 2's implementation (inline YAML string, assert walker flags the violation). Doubles as a regression guard. Brainstorm's audit evidence (3 prose matches in `fro-bot.yaml`) gives us a known-safe case to anti-test the walker against. |
+| R7 regex misses an unusual `uses:` form (e.g., multi-line YAML block scalar on `uses:` value) | Current 37 `uses:` lines across 9 workflows are all single-line. If multi-line forms show up later, the regex returns them as violations and the failure mode is loud (caught at PR time, not silent). Noted for potential AST upgrade in a follow-up. |
+| Fro Bot category 3 trim removes a bullet that was covering a subtle case the mechanical rule misses | Possible in theory; in practice, category 3 already only lists the same convention patterns our v1 rules cover. The few category-3 items outside R1-R9 (AGENTS.md accuracy, build pass, stale TODOs) stay. Post-merge monitor the first autoheal run after the PR lands. |
+| `bun install` after adding `yaml` dep changes `bun.lock` unrelated-ly | Use `bun install --frozen-lockfile` verification in CI (already in use). Review `bun.lock` diff before commit. |
+
+## Documentation / Operational Notes
+
+No runbook, rollout, monitoring, or README updates needed — `AGENTS.md` annotation is the full documentation delta; test failures are the monitoring.
+
+## Sources & References
+
+- **Origin document**: `docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md`
+- Related code: `eslint.config.ts`, `packages/cli/src/cli.test.ts`, `packages/cli/package.json`, `AGENTS.md`, `.github/workflows/fro-bot.yaml`
+- Related PRs: none directly; the rules mechanize conventions documented across the project's 150+ merged PRs
+- External docs: [`yaml` package](https://eemeli.org/yaml/), [`@typescript-eslint/ban-ts-comment` options](https://typescript-eslint.io/rules/ban-ts-comment/)
+- Audit evidence: origin doc's "Audit Result" section (zero violations across all 9 rules on `main` as of 2026-04-16)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,9 +15,9 @@ export default defineConfig(
   {
     name: 'infra-conventions',
     rules: {
-      // R1: Enforce no explicit `any` — AGENTS.md forbids `as any` and broader uses.
+      // AGENTS.md: forbid explicit `any` / `as any` — fix the types.
       '@typescript-eslint/no-explicit-any': 'error',
-      // R2: Ban all TS directive comments outright — no description carveouts.
+      // AGENTS.md: ban all TS directive comments — fix the types, do not suppress errors.
       '@typescript-eslint/ban-ts-comment': [
         'error',
         {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -13,6 +13,23 @@ export default defineConfig(
     },
   },
   {
+    name: 'infra-conventions',
+    rules: {
+      // R1: Enforce no explicit `any` — AGENTS.md forbids `as any` and broader uses.
+      '@typescript-eslint/no-explicit-any': 'error',
+      // R2: Ban all TS directive comments outright — no description carveouts.
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+          'ts-expect-error': true,
+          'ts-ignore': true,
+          'ts-nocheck': true,
+          'ts-check': false,
+        },
+      ],
+    },
+  },
+  {
     name: 'cli-and-scripts',
     files: ['**/cli.ts', '**/build.ts', '**/setup-*.ts'],
     rules: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,9 @@
     "string-dedent": "^3.0.2",
     "zod": "^4.3.6"
   },
+  "devDependencies": {
+    "yaml": "^2.8.3"
+  },
   "engines": {
     "bun": ">=1.0.0"
   },

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -71,13 +71,13 @@ export function findCrossOrgSecretsInherit(parsed: unknown): {jobId: string; use
   return violations
 }
 
-describe('repo conventions (v1)', () => {
+describe('repo conventions', () => {
   it('tripwire: workflow glob resolves to at least one file (catches dot-dir glob regressions)', () => {
     const workflows = listWorkflowFiles('.yaml')
     expect(workflows.length).toBeGreaterThan(0)
   })
 
-  it('R3: no `bundledDependencies` in any package.json', async () => {
+  it('no `bundledDependencies` in any package.json', async () => {
     const files = listPackageJsonFiles()
     const offenders: string[] = []
     for (const file of files) {
@@ -89,7 +89,7 @@ describe('repo conventions (v1)', () => {
     expect(offenders).toEqual([])
   })
 
-  it("R4: apps/keeweb/config/config.json has settings.dropboxSecret === ''", async () => {
+  it("apps/keeweb/config/config.json has settings.dropboxSecret === ''", async () => {
     const configPath = resolve(REPO_ROOT, 'apps/keeweb/config/config.json')
     const config = (await Bun.file(configPath).json()) as {
       settings?: {dropboxSecret?: unknown}
@@ -97,7 +97,7 @@ describe('repo conventions (v1)', () => {
     expect(config.settings?.dropboxSecret).toBe('')
   })
 
-  it('R5: no `secrets: inherit` on any job whose `uses:` points to a cross-org workflow', async () => {
+  it('no `secrets: inherit` on any job whose `uses:` points to a cross-org workflow', async () => {
     const files = listWorkflowFiles('.yaml')
     const violations: Violation[] = []
     for (const file of files) {
@@ -113,7 +113,7 @@ describe('repo conventions (v1)', () => {
     expect(violations).toEqual([])
   })
 
-  it('R6: no `ssh-keyscan` under .github/workflows/**', async () => {
+  it('no `ssh-keyscan` under .github/workflows/**', async () => {
     const files = listWorkflowFiles('.yaml')
     const violations: Violation[] = []
     for (const file of files) {
@@ -131,7 +131,7 @@ describe('repo conventions (v1)', () => {
     expect(violations).toEqual([])
   })
 
-  it('R7: every `uses: …@<sha>` has a trailing `# vX.Y.Z` or `# scope@X.Y.Z` comment', async () => {
+  it('every SHA-pinned `uses:` line has a trailing `# vX.Y.Z` or `# scope@X.Y.Z` comment', async () => {
     const files = listWorkflowFiles('.yaml')
     const violations: Violation[] = []
     for (const file of files) {
@@ -158,12 +158,12 @@ describe('repo conventions (v1)', () => {
     expect(violations).toEqual([])
   })
 
-  it('R8: no `.yml` files under .github/workflows/ (use `.yaml`)', () => {
+  it('no `.yml` files under .github/workflows/ (use `.yaml`)', () => {
     const files = listWorkflowFiles('.yml')
     expect(files.map(f => relative(REPO_ROOT, f))).toEqual([])
   })
 
-  it('R9: no `.sh` files outside `apps/keeweb/deploy.sh`', () => {
+  it('no `.sh` files outside `apps/keeweb/deploy.sh`', () => {
     const files = listShellScriptFiles()
     const offenders = files.map(f => relative(REPO_ROOT, f)).filter(f => !ALLOWED_SHELL_SCRIPTS.has(f))
     expect(offenders).toEqual([])

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1,0 +1,233 @@
+import {relative, resolve} from 'node:path'
+import {describe, expect, it} from 'bun:test'
+import {parse as parseYaml} from 'yaml'
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+const INTERNAL_ORGS = new Set(['marcusrbrown'])
+const ALLOWED_SHELL_SCRIPTS = new Set(['apps/keeweb/deploy.sh'])
+
+// Accepted version-comment forms on SHA-pinned `uses:` lines:
+//   # v6.0.2                        (semver tag)
+//   # renovate-changesets@0.2.31    (scoped release tag)
+const VERSION_COMMENT_RE = /^#\s+(?:v\d+(?:\.\d+){0,2}|[\w@/-]+@\d+(?:\.\d+){0,2})\s*$/
+
+// Match `[- ]uses: owner/repo@<sha>[ trailing]` — step-level (indented, possibly dash-prefixed) and job-level.
+// Uses [ \t] instead of \s to avoid regex backtracking ambiguity between overlapping quantifiers.
+const USES_SHA_LINE_RE = /^[ \t]+(?:-[ \t]+)?uses:[ \t]+(\S+)@([a-f0-9]{7,})(?:[ \t]+(\S.*))?$/
+
+interface Violation {
+  file: string
+  detail: string
+}
+
+// `.github/` is a dot-directory; Bun.Glob skips dot-dirs by default, so every
+// glob that traverses `.github/` must pass `{ dot: true }`. Without it, the
+// workflow rules silently pass on an empty file set. The tripwire test at the
+// top of the suite asserts the file count is >= 1 to catch this regression.
+function listWorkflowFiles(extension: '.yaml' | '.yml'): string[] {
+  const glob = new Bun.Glob(`.github/workflows/*${extension}`)
+  return [...glob.scanSync({cwd: REPO_ROOT, absolute: true, dot: true})]
+}
+
+function listPackageJsonFiles(): string[] {
+  // Bun.Glob auto-excludes node_modules/** by default; no package.json lives under dot-dirs.
+  const glob = new Bun.Glob('**/package.json')
+  return [...glob.scanSync({cwd: REPO_ROOT, absolute: true})].filter(f => !f.includes('/node_modules/'))
+}
+
+function listShellScriptFiles(): string[] {
+  const glob = new Bun.Glob('**/*.sh')
+  return [...glob.scanSync({cwd: REPO_ROOT, absolute: true})].filter(
+    f => !f.includes('/node_modules/') && !f.includes('/.cache/') && !f.includes('/dist/'),
+  )
+}
+
+/**
+ * Detect cross-org `secrets: inherit` on reusable-workflow job calls.
+ *
+ * Rules:
+ *   - Jobs without a `uses:` string are step-based and out of scope.
+ *   - `uses:` values starting with `./` or `../` are local reusable workflows; `secrets: inherit` is legitimate.
+ *   - `uses:` values whose owner (first path segment) is in INTERNAL_ORGS are same-org; `secrets: inherit` is legitimate.
+ *   - Everything else is cross-org and must not use `secrets: inherit`.
+ */
+export function findCrossOrgSecretsInherit(parsed: unknown): {jobId: string; uses: string}[] {
+  if (typeof parsed !== 'object' || parsed === null) return []
+  const jobs = (parsed as {jobs?: Record<string, unknown>}).jobs
+  if (typeof jobs !== 'object' || jobs === null) return []
+
+  const violations: {jobId: string; uses: string}[] = []
+  for (const [jobId, jobRaw] of Object.entries(jobs)) {
+    if (typeof jobRaw !== 'object' || jobRaw === null) continue
+    const job = jobRaw as {uses?: unknown; secrets?: unknown}
+    if (typeof job.uses !== 'string') continue
+    if (job.uses.startsWith('./') || job.uses.startsWith('../')) continue
+    const owner = job.uses.split('/')[0] ?? ''
+    if (INTERNAL_ORGS.has(owner)) continue
+    if (job.secrets === 'inherit') {
+      violations.push({jobId, uses: job.uses})
+    }
+  }
+  return violations
+}
+
+describe('repo conventions (v1)', () => {
+  it('tripwire: workflow glob resolves to at least one file (catches dot-dir glob regressions)', () => {
+    const workflows = listWorkflowFiles('.yaml')
+    expect(workflows.length).toBeGreaterThan(0)
+  })
+
+  it('R3: no `bundledDependencies` in any package.json', async () => {
+    const files = listPackageJsonFiles()
+    const offenders: string[] = []
+    for (const file of files) {
+      const json = (await Bun.file(file).json()) as Record<string, unknown>
+      if ('bundledDependencies' in json) {
+        offenders.push(relative(REPO_ROOT, file))
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it("R4: apps/keeweb/config/config.json has settings.dropboxSecret === ''", async () => {
+    const configPath = resolve(REPO_ROOT, 'apps/keeweb/config/config.json')
+    const config = (await Bun.file(configPath).json()) as {
+      settings?: {dropboxSecret?: unknown}
+    }
+    expect(config.settings?.dropboxSecret).toBe('')
+  })
+
+  it('R5: no `secrets: inherit` on any job whose `uses:` points to a cross-org workflow', async () => {
+    const files = listWorkflowFiles('.yaml')
+    const violations: Violation[] = []
+    for (const file of files) {
+      const text = await Bun.file(file).text()
+      const parsed = parseYaml(text, {merge: true})
+      for (const v of findCrossOrgSecretsInherit(parsed)) {
+        violations.push({
+          file: relative(REPO_ROOT, file),
+          detail: `job '${v.jobId}' uses '${v.uses}' with secrets: inherit`,
+        })
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('R6: no `ssh-keyscan` under .github/workflows/**', async () => {
+    const files = listWorkflowFiles('.yaml')
+    const violations: Violation[] = []
+    for (const file of files) {
+      const text = await Bun.file(file).text()
+      const lines = text.split(/\r?\n/)
+      for (const [index, line] of lines.entries()) {
+        if (/\bssh-keyscan\b/.test(line)) {
+          violations.push({
+            file: relative(REPO_ROOT, file),
+            detail: `line ${index + 1}: ${line.trim()}`,
+          })
+        }
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('R7: every `uses: …@<sha>` has a trailing `# vX.Y.Z` or `# scope@X.Y.Z` comment', async () => {
+    const files = listWorkflowFiles('.yaml')
+    const violations: Violation[] = []
+    for (const file of files) {
+      const text = await Bun.file(file).text()
+      const lines = text.split(/\r?\n/)
+      for (const [index, line] of lines.entries()) {
+        const match = line.match(USES_SHA_LINE_RE)
+        if (!match) continue
+        const [, ref = '', sha = '', tail] = match
+        const shortSha = sha.slice(0, 7)
+        if (tail === undefined) {
+          violations.push({
+            file: relative(REPO_ROOT, file),
+            detail: `line ${index + 1}: missing version comment on '${ref}@${shortSha}…'`,
+          })
+        } else if (!VERSION_COMMENT_RE.test(tail.trim())) {
+          violations.push({
+            file: relative(REPO_ROOT, file),
+            detail: `line ${index + 1}: malformed version comment '${tail.trim()}' on '${ref}@${shortSha}…'`,
+          })
+        }
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('R8: no `.yml` files under .github/workflows/ (use `.yaml`)', () => {
+    const files = listWorkflowFiles('.yml')
+    expect(files.map(f => relative(REPO_ROOT, f))).toEqual([])
+  })
+
+  it('R9: no `.sh` files outside `apps/keeweb/deploy.sh`', () => {
+    const files = listShellScriptFiles()
+    const offenders = files.map(f => relative(REPO_ROOT, f)).filter(f => !ALLOWED_SHELL_SCRIPTS.has(f))
+    expect(offenders).toEqual([])
+  })
+})
+
+describe('findCrossOrgSecretsInherit', () => {
+  it('flags a cross-org reusable workflow that uses `secrets: inherit`', () => {
+    const parsed = parseYaml(`
+jobs:
+  build:
+    uses: bfra-me/.github/.github/workflows/example.yaml@abc1234
+    secrets: inherit
+`)
+    const violations = findCrossOrgSecretsInherit(parsed)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.jobId).toBe('build')
+    expect(violations[0]?.uses).toContain('bfra-me/')
+  })
+
+  it('allows a same-org reusable workflow to use `secrets: inherit`', () => {
+    const parsed = parseYaml(`
+jobs:
+  release:
+    uses: marcusrbrown/infra/.github/workflows/release.yaml@sha
+    secrets: inherit
+`)
+    expect(findCrossOrgSecretsInherit(parsed)).toEqual([])
+  })
+
+  it('allows a local (./) reusable workflow to use `secrets: inherit`', () => {
+    const parsed = parseYaml(`
+jobs:
+  build:
+    uses: ./.github/workflows/local.yaml
+    secrets: inherit
+`)
+    expect(findCrossOrgSecretsInherit(parsed)).toEqual([])
+  })
+
+  it('ignores `secrets: inherit` strings appearing inside prose block scalars', () => {
+    // Mirrors fro-bot.yaml: SCHEDULE_PROMPT contains the literal string
+    // `secrets: inherit` inside a prompt heredoc, but no job-level key exists.
+    const parsed = parseYaml(`
+env:
+  SCHEDULE_PROMPT: |
+    Remember: never use secrets: inherit with cross-org workflows.
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`)
+    expect(findCrossOrgSecretsInherit(parsed)).toEqual([])
+  })
+
+  it('does not flag jobs without a `uses:` key (step-based jobs)', () => {
+    const parsed = parseYaml(`
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`)
+    expect(findCrossOrgSecretsInherit(parsed)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Convert the structurally-checkable subset of root `AGENTS.md` rules from advisory prose into mechanical CI failures. Before this PR, conventions like "no `as any`" and "never use `ssh-keyscan` in workflows" relied on ESLint warnings (mostly off), daily Fro Bot autoheal reports (post-merge only), and reviewer diligence. After this PR, the nine most violation-prone rules fail CI pre-merge.

Audit before enabling: zero existing violations on `main`. Single PR, ship-green, no cleanup commits required.

## What gets enforced

| Convention | Mechanism |
| --- | --- |
| No `as any` or explicit `any` in source | `@typescript-eslint/no-explicit-any` → error (was off) |
| No `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck` | `@typescript-eslint/ban-ts-comment` → error, no description carveout |
| No `bundledDependencies` in any `package.json` | `packages/cli/src/conventions.test.ts` |
| `apps/keeweb/config/config.json` has empty `settings.dropboxSecret` | Conventions test |
| No `secrets: inherit` on any job calling a cross-org reusable workflow | Conventions test (YAML AST walk) |
| No `ssh-keyscan` under `.github/workflows/**` | Conventions test |
| Every `uses: …@<sha>` has a trailing `# vX.Y.Z` or `# <scope>@X.Y.Z` comment | Conventions test, distinguishes missing from malformed |
| No `.yml` under `.github/workflows/` | Conventions test (`.github/settings.yml` at `.github/` root is explicitly exempt) |
| No `.sh` files outside `apps/keeweb/deploy.sh` | Conventions test |

Each enforced bullet in root `AGENTS.md` carries a single `(enforced)` marker. Unenforced bullets (judgment-based rules like "first-person voice in `gh` comments") stay unannotated.

## Mechanism choices worth flagging

- **ESLint flat config for the two `any`/directive-comment rules only.** `@bfra.me/eslint-config`'s bundled `eslint-plugin-jsonc` / `eslint-plugin-yml` don't ship content-pattern restriction rules. Writing custom JSONC/YAML AST rules would add 40-80 LOC per convention for zero benefit over a TypeScript test. The test is shorter, more familiar, and has the same CI failure profile.
- **Cross-org `secrets: inherit` detection parses YAML, not regex.** A naive regex would false-positive on three occurrences of the literal string inside prompt heredocs in `fro-bot.yaml`. The walker loads each workflow with `yaml@^2.8.3` and inspects only job-level `uses:` + `secrets:` keys, skipping local `./` reusable-workflow paths and the `marcusrbrown` allowlist.
- **SHA-pin version comments use a line-oriented regex.** Every `uses:` line in this repo is single-line `owner/name@sha # version-comment`. The regex distinguishes missing comments from malformed ones to produce better diagnostics when the test fails.
- **`Bun.Glob` + `{ dot: true }` is mandatory for `.github/` scans.** Without it, globs return zero files and four of the workflow-oriented rules silently pass. A tripwire assertion in the test file fails loudly if this ever regresses.
- **`yaml@^2.8.3` added as a direct devDep in `packages/cli/`.** Transitively installed via `eslint-plugin-yml` but Bun's `.bun/` symlink layout makes transitive deps non-importable. Adding it as a direct devDep is cleaner than wrestling with resolution.

## `ssh-keyscan` prose narrowing

One factual correction alongside the `(enforced)` annotations: the `Never use ssh-keyscan` anti-pattern is narrowed to "in CI workflows" since `apps/cliproxy/server/provision-droplet.ts` legitimately uses `ssh-keyscan` locally during one-time droplet host-key capture. The broader prose was at odds with actual practice.

## Fro Bot autoheal trim

Category 3 of `SCHEDULE_PROMPT` in `.github/workflows/fro-bot.yaml` previously listed six convention-compliance sub-bullets that map 1:1 to rules now gated pre-merge. Dropped. Without the trim, daily autoheal would re-discover the same empty violation set the pre-merge gate already prevents, eroding the category's signal over time. Everything category 3 uniquely catches (lint, tsc, build, stale TODOs, AGENTS.md accuracy) stays.

## Verification

- `bun run lint`: 0 errors, 17 pre-existing `no-console` warnings on script files (unchanged).
- `bunx tsc --noEmit`: clean.
- `bun test --recursive`: 161 pass, 0 fail (was 148; adds 13 new conventions tests — 8 repo-state checks + 1 tripwire + 4 helper-function unit tests + 1 cross-org allow case).
- Smoke-checked: temporarily removed a version comment from `ci.yaml`, confirmed the test fails with a useful error message pointing at the specific line and SHA, reverted.
- Smoke-checked: the cross-org walker's unit tests cover the flag case, same-org allow, local `./` allow, prose-inside-heredoc ignore, and step-based-job ignore.

## Docs in this PR

- `docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md` — framing, rule scope, mechanism audit, violation tally
- `docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md` — implementation plan with dependency ordering, deferred items, and per-unit verification

## Not in scope

- Per-app `AGENTS.md` rules (`apps/keeweb/`, `apps/cliproxy/`, `packages/cli/`). Prove the root mechanics first; follow-up will extend.
- Drift check mechanism (parse `AGENTS.md` for `(enforced)` markers, assert each maps to a real ESLint rule or test assertion). Nice-to-have; explicitly deferred.
- Custom inline ESLint AST rules for YAML/JSONC. The bundled plugins don't support the restrictions these rules need, and hand-rolled alternatives add complexity for no CI-behavior improvement.
