### PR TITLE
fix(cli): update workflow names to match split deploy pipeline

### DIFF
--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -14,7 +14,7 @@ Commands:
     --verbose                          Enable verbose output for all commands
 
 
-  keeweb deploy                        Trigger KeeWeb deployment. Default mode dispatches the GitHub Deploy workflow. Use --local to run apps/keeweb/deploy.sh directly from this repo.
+  keeweb deploy                        Trigger KeeWeb deployment. Default mode dispatches the GitHub Deploy KeeWeb workflow. Use --local to run apps/keeweb/deploy.sh directly from this repo.
 
     --local                            Run local deployment using apps/keeweb/deploy.sh instead of triggering GitHub Actions. (default: false)
     --nginx                            Include nginx config deployment. Valid only with --local and passed through to deploy.sh as --nginx. (default: false)
@@ -31,7 +31,7 @@ Commands:
     --verbose                          Enable verbose output for all commands
 
 
-  cliproxy deploy                      Deploy CLIProxyAPI. Default mode triggers the GitHub Deploy workflow, while --local runs apps/cliproxy/src/deploy.ts directly with Bun.
+  cliproxy deploy                      Deploy CLIProxyAPI. Default mode triggers the GitHub Deploy CLIProxy workflow, while --local runs apps/cliproxy/src/deploy.ts directly with Bun.
 
     --local                            Run local deployment with Bun using apps/cliproxy/src/deploy.ts instead of triggering GitHub Actions. (default: false)
     --force-config                     Force upload config.yaml even if it exists on the server. WARNING: overwrites runtime API keys and settings. (default: false)

--- a/packages/cli/src/commands/cliproxy/deploy.ts
+++ b/packages/cli/src/commands/cliproxy/deploy.ts
@@ -5,8 +5,8 @@ import {resolve} from 'node:path'
 import {z} from 'zod'
 
 const REPO = 'marcusrbrown/infra'
-const WORKFLOW_NAME = 'Deploy'
-const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy.yaml'
+const WORKFLOW_NAME = 'Deploy CLIProxy'
+const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy-cliproxy.yaml'
 
 type CliInstance = ReturnType<typeof goke>
 
@@ -66,7 +66,7 @@ export function registerCliproxyDeploy(cli: CliInstance): void {
   cli
     .command(
       'cliproxy deploy',
-      'Deploy CLIProxyAPI. Default mode triggers the GitHub Deploy workflow, while --local runs apps/cliproxy/src/deploy.ts directly with Bun.',
+      'Deploy CLIProxyAPI. Default mode triggers the GitHub Deploy CLIProxy workflow, while --local runs apps/cliproxy/src/deploy.ts directly with Bun.',
     )
     .option(
       '--local',

--- a/packages/cli/src/commands/keeweb/deploy.ts
+++ b/packages/cli/src/commands/keeweb/deploy.ts
@@ -4,8 +4,8 @@ import {resolve} from 'node:path'
 import {z} from 'zod'
 
 const REPO = 'marcusrbrown/infra'
-const WORKFLOW_NAME = 'Deploy'
-const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy.yaml'
+const WORKFLOW_NAME = 'Deploy KeeWeb'
+const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy-keeweb.yaml'
 
 const DEFAULT_HOST = 'box.heatvision.co'
 const DEFAULT_REMOTE_USER = 'deploy-kw'
@@ -87,7 +87,7 @@ export function registerKeewebDeploy(cli: CliInstance): void {
   cli
     .command(
       'keeweb deploy',
-      'Trigger KeeWeb deployment. Default mode dispatches the GitHub Deploy workflow. Use --local to run apps/keeweb/deploy.sh directly from this repo.',
+      'Trigger KeeWeb deployment. Default mode dispatches the GitHub Deploy KeeWeb workflow. Use --local to run apps/keeweb/deploy.sh directly from this repo.',
     )
     .option(
       '--local',
@@ -114,7 +114,7 @@ export function registerKeewebDeploy(cli: CliInstance): void {
           'Print planned actions without validating preconditions, executing deploy.sh, or triggering GitHub Actions.',
         ),
     )
-    .example('# Trigger GitHub Deploy workflow (default mode)')
+    .example('# Trigger GitHub Deploy KeeWeb workflow (default mode)')
     .example('infra keeweb deploy')
     .example('# Preview local deploy plan without side effects')
     .example('infra keeweb deploy --local --dry-run')
@@ -170,7 +170,9 @@ export function registerKeewebDeploy(cli: CliInstance): void {
 
       validateRemotePreconditions()
 
-      console.warn('Warning: the Deploy workflow includes nginx config deployment as part of workflow_dispatch logic.')
+      console.warn(
+        'Warning: the Deploy KeeWeb workflow includes nginx config deployment as part of workflow_dispatch logic.',
+      )
       console.warn('Warning: the workflow requires keeweb environment approval before jobs execute.')
 
       const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
@@ -180,7 +182,7 @@ export function registerKeewebDeploy(cli: CliInstance): void {
 
       const exitCode = await child.exited
       if (exitCode !== 0) {
-        throw new Error(`Failed to trigger Deploy workflow (exit code ${exitCode})`)
+        throw new Error(`Failed to trigger Deploy KeeWeb workflow (exit code ${exitCode})`)
       }
 
       console.log(`Workflow triggered: ${WORKFLOW_URL}`)

--- a/packages/cli/src/commands/keeweb/status.ts
+++ b/packages/cli/src/commands/keeweb/status.ts
@@ -116,7 +116,7 @@ export async function checkLastDeploy(verbose: boolean): Promise<CheckResult> {
         'gh',
         'run',
         'list',
-        '--workflow=Deploy',
+        '--workflow=Deploy KeeWeb',
         '--status=success',
         '--limit=1',
         '--json',
@@ -164,7 +164,7 @@ export async function checkLastDeploy(verbose: boolean): Promise<CheckResult> {
       return {
         title: 'Last successful deploy',
         level: 'warning',
-        summary: 'No successful Deploy workflow runs found',
+        summary: 'No successful Deploy KeeWeb workflow runs found',
       }
     }
 


### PR DESCRIPTION
PR #165 split `deploy.yaml` into `deploy-keeweb.yaml` and `deploy-cliproxy.yaml`. The CLI still referenced the old workflow name (`Deploy`) in three places — update them to match the new split names.

**Changes:**
- `keeweb deploy`: `WORKFLOW_NAME` → `Deploy KeeWeb`, `WORKFLOW_URL` → `deploy-keeweb.yaml`
- `keeweb status`: `--workflow=Deploy KeeWeb` gh CLI flag + matching summary string
- `cliproxy deploy`: `WORKFLOW_NAME` → `Deploy CLIProxy`, `WORKFLOW_URL` → `deploy-cliproxy.yaml`
- Snapshot updated to match revised command descriptions

All 161 tests pass, lint clean, tsc clean. No changeset — no user-facing behavior change, only internal workflow name strings.
