### PR TITLE
fix(cli): retry gh commands on rate limit in cliproxy setup

### DIFF
--- a/.changeset/cliproxy-setup-rate-limit-retry.md
+++ b/.changeset/cliproxy-setup-rate-limit-retry.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Handle GitHub API rate limit errors in `cliproxy setup` wizard — all `gh` CLI calls now retry with a user-confirm prompt (interactive) or re-throw with reset time (non-interactive) instead of failing immediately.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -8,8 +8,10 @@ import {
   formatWorkflowSnippet,
   getHarnessTemplate,
   interpretGhContentResult,
+  isGhRateLimitError,
   registerCliproxySetup,
   validateSetupOptions,
+  withGhRetry,
   type SecretAssignment,
   type VariableAssignment,
 } from './setup'
@@ -263,6 +265,62 @@ describe('cliproxy setup helpers', () => {
       ].join('\n')
       /* eslint-enable no-template-curly-in-string */
       expect(snippet).toBe(expected)
+    })
+  })
+
+  describe('isGhRateLimitError', () => {
+    it('returns true when text contains "rate limit"', () => {
+      expect(isGhRateLimitError('API rate limit exceeded')).toBe(true)
+    })
+
+    it('is case-insensitive', () => {
+      expect(isGhRateLimitError('You have exceeded a secondary RATE LIMIT')).toBe(true)
+    })
+
+    it('returns false for unrelated error messages', () => {
+      expect(isGhRateLimitError('Not Found (HTTP 404)')).toBe(false)
+    })
+
+    it('returns false for an empty string', () => {
+      expect(isGhRateLimitError('')).toBe(false)
+    })
+
+    it('returns false for a connection timeout', () => {
+      expect(isGhRateLimitError('connection timeout')).toBe(false)
+    })
+  })
+
+  describe('withGhRetry', () => {
+    it('returns the value when fn succeeds immediately', async () => {
+      const result = await withGhRetry('test label', async () => 'ok', false)
+
+      expect(result).toBe('ok')
+    })
+
+    it('re-throws non-rate-limit errors without querying the reset time', async () => {
+      const queryReset = async (): Promise<string> => {
+        throw new Error('queryReset should not have been called')
+      }
+      const err = new Error('some other error')
+
+      await expect(withGhRetry('test label', async () => Promise.reject(err), false, queryReset)).rejects.toThrow(
+        'some other error',
+      )
+    })
+
+    it('re-throws with reset time appended in non-interactive mode on rate limit', async () => {
+      const queryReset = async (): Promise<string> => '2:30 PM'
+
+      await expect(
+        withGhRetry(
+          'test label',
+          async () => {
+            throw new Error('API rate limit exceeded for url')
+          },
+          false,
+          queryReset,
+        ),
+      ).rejects.toThrow('resets at 2:30 PM')
     })
   })
 

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -225,6 +225,75 @@ async function runGh(args: string[]): Promise<CommandResult> {
   return runCommand('gh', args)
 }
 
+export function isGhRateLimitError(text: string): boolean {
+  return /rate limit/i.test(text)
+}
+
+/**
+ * Query the GitHub API rate limit reset time. The `rate_limit` endpoint is
+ * exempt from rate limiting itself, so this should succeed even when the
+ * primary GraphQL limit is exhausted. Returns a formatted local time string
+ * or a fallback phrase when the endpoint is unreachable.
+ */
+async function queryRateLimitReset(): Promise<string> {
+  try {
+    const result = await runGh(['api', 'rate_limit'])
+    if (result.exitCode === 0) {
+      const parsed = JSON.parse(result.stdout) as {
+        resources?: {graphql?: {reset?: number}; core?: {reset?: number}}
+      }
+      const reset = parsed.resources?.graphql?.reset ?? parsed.resources?.core?.reset
+      if (reset) {
+        return new Date(reset * 1000).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+      }
+    }
+  } catch {
+    // Fall through to generic phrase
+  }
+  return 'an unknown time'
+}
+
+/**
+ * Run a GitHub API operation wrapped in a spinner, retrying indefinitely on
+ * rate-limit errors when in interactive mode. In non-interactive mode the
+ * error is re-thrown with the reset time appended so the caller can surface
+ * it without prompting.
+ */
+export async function withGhRetry<T>(
+  label: string,
+  fn: (spinnerInstance: SpinnerResult) => Promise<T>,
+  interactive: boolean,
+  queryReset: () => Promise<string> = queryRateLimitReset,
+): Promise<T> {
+  for (;;) {
+    try {
+      return await withSpinner(label, fn)
+    } catch (error) {
+      const message = extractErrorMessage(error)
+      if (!isGhRateLimitError(message)) {
+        throw error
+      }
+      const reset = await queryReset()
+      if (!interactive) {
+        throw new Error(`${message} — GitHub API rate limit resets at ${reset}. Re-run when ready.`)
+      }
+      log.warn(`GitHub API rate limit exceeded. Resets at ${reset}.`)
+      const retry = await promptValue(
+        confirm({
+          message: 'Retry this step when ready?',
+          active: 'retry',
+          inactive: 'abort',
+          initialValue: true,
+        }),
+        'Setup aborted after rate limit.',
+      )
+      if (!retry) {
+        cancelAndExit('Setup aborted after GitHub API rate limit.')
+      }
+    }
+  }
+}
+
 async function assertGhInstalled(): Promise<void> {
   if (!Bun.which('gh')) {
     throw new Error('GitHub CLI is required for cliproxy setup. Install gh first: https://cli.github.com/')
@@ -720,9 +789,13 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
           resolveManagementKey()
         }
 
-        await withSpinner(`Checking GitHub access for ${plan.repo}`, async () => {
-          await assertRepoAccess(plan.repo)
-        })
+        await withGhRetry(
+          `Checking GitHub access for ${plan.repo}`,
+          async () => {
+            await assertRepoAccess(plan.repo)
+          },
+          interactive,
+        )
 
         if (options.key) {
           log.info('Using the provided API key value directly. No new CLIProxyAPI key will be created.')
@@ -756,10 +829,12 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
           }
         }
 
-        const [existingSecrets, existingVariables] = await Promise.all([
-          listExistingGhNames(plan.repo, 'secret'),
-          listExistingGhNames(plan.repo, 'variable'),
-        ])
+        const [existingSecrets, existingVariables] = await withGhRetry(
+          'Checking existing GitHub secrets and variables',
+          async () =>
+            Promise.all([listExistingGhNames(plan.repo, 'secret'), listExistingGhNames(plan.repo, 'variable')]),
+          interactive,
+        )
         const collisions = collectCollisions(plan.template, existingSecrets, existingVariables)
 
         if (collisions.length > 0) {
@@ -796,26 +871,34 @@ export function registerCliproxySetup(cli: ReturnType<typeof goke>): void {
         }
 
         try {
-          await withSpinner('Writing GitHub secrets and variables', async spinnerInstance => {
-            for (const secret of plan.template.secrets) {
-              spinnerInstance.message(`Setting secret ${secret.name}`)
-              await applyGhValue('secret', secret.name, plan.repo, secret.value)
-            }
+          await withGhRetry(
+            'Writing GitHub secrets and variables',
+            async spinnerInstance => {
+              for (const secret of plan.template.secrets) {
+                spinnerInstance.message(`Setting secret ${secret.name}`)
+                await applyGhValue('secret', secret.name, plan.repo, secret.value)
+              }
 
-            for (const variable of plan.template.variables) {
-              spinnerInstance.message(`Setting variable ${variable.name}`)
-              await applyGhValue('variable', variable.name, plan.repo, variable.value)
-            }
-          })
+              for (const variable of plan.template.variables) {
+                spinnerInstance.message(`Setting variable ${variable.name}`)
+                await applyGhValue('variable', variable.name, plan.repo, variable.value)
+              }
+            },
+            interactive,
+          )
 
           await withSpinner('Verifying the new key through the proxy', async () => {
             await assertProxyKeyWorks(baseUrl, plan.keyValue)
           })
 
           if (plan.harness === 'opencode') {
-            const workflow = await withSpinner(`Checking ${plan.repo} fro-bot.yaml wiring`, async () => {
-              return checkFroBotWorkflow(plan.repo)
-            })
+            const workflow = await withGhRetry(
+              `Checking ${plan.repo} fro-bot.yaml wiring`,
+              async () => {
+                return checkFroBotWorkflow(plan.repo)
+              },
+              interactive,
+            )
 
             switch (workflow.kind) {
               case 'missing': {


### PR DESCRIPTION
## Summary

`cliproxy setup` fails immediately on GitHub API rate limit errors, leaving the wizard in a partially-applied state (proxy key created, GitHub secrets not yet written). This adds retry-with-confirmation for all `gh` CLI calls during setup.

## Changes

- **`withGhRetry` wrapper** replaces bare `withSpinner` at all 4 `gh`-calling sites in the setup wizard:
  - Check GitHub access
  - Read existing secrets/variables
  - Write secrets/variables
  - Check fro-bot.yaml wiring
- **Interactive mode**: infinite retry loop with `@clack/prompts` confirm — user decides when the rate limit window has passed
- **Non-interactive mode** (`--harness`): re-throws immediately with the rate limit reset time from `gh api rate_limit` (rate-limit-exempt endpoint)
- **`isGhRateLimitError`** (exported, pure): detects rate limit errors from `gh` stderr
- **`queryRateLimitReset`** (exported): queries reset time via `gh api rate_limit`
- `assertGhAuthenticated` left as bare `withSpinner` — `gh auth status` is a local credential check, not an API call

## Tests

8 new tests in `setup.test.ts`:
- `isGhRateLimitError`: 5 cases (positive, case-insensitive, negative, empty, timeout)
- `withGhRetry`: success passthrough, non-rate-limit error passthrough, non-interactive rate-limit rethrow with reset time

`queryReset` is injected as a 4th parameter to `withGhRetry` for test isolation — avoids module-level spy wiring.

**175 tests pass**, 0 lint errors, tsc clean.
