### PR TITLE
feat(cliproxy): switch container healthcheck to /healthz

### DIFF
--- a/apps/cliproxy/docker-compose.yaml
+++ b/apps/cliproxy/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     environment:
       MANAGEMENT_PASSWORD: ${MANAGEMENT_PASSWORD:-}
     healthcheck:
-      test: [CMD, wget, --spider, -q, 'http://localhost:8317/']
+      test: [CMD, wget, --spider, -q, 'http://localhost:8317/healthz']
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Switch the cli-proxy-api Docker healthcheck from the proxy root (`/`) to the dedicated `/healthz` endpoint added in CLIProxyAPI v6.9.31.

## Why

`/healthz` is a purpose-built liveness endpoint that returns immediately without exercising the proxy or model-registry logic. The previous root-path check ran the full request pipeline every 30s and could mask upstream-degradation issues as healthy if the proxy returned 200 from a partially-broken state.

Source-confirmed in `internal/api/server.go` (CLIProxyAPI) — both `GET` and `HEAD /healthz` are registered:

```go
s.engine.GET("/healthz", healthzHandler)
s.engine.HEAD("/healthz", healthzHandler)
```

## Diff

`apps/cliproxy/docker-compose.yaml`:

```diff
-      test: [CMD, wget, --spider, -q, 'http://localhost:8317/']
+      test: [CMD, wget, --spider, -q, 'http://localhost:8317/healthz']
```

No changeset — deploy infra change, no impact on `@marcusrbrown/infra` runtime behavior.

## Verification

- `docker compose -f apps/cliproxy/docker-compose.yaml config` resolves the healthcheck URL to `http://localhost:8317/healthz`
- `bun test --recursive` — 175 pass, 0 fail
- `bun run lint` — 0 errors (17 pre-existing warnings)
- `bunx tsc --noEmit` — clean

Post-merge: confirm via the deploy-cliproxy run that `cliproxy.fro.bot/v1/models` reachability still passes.
