### PR TITLE
feat(fro-bot): add Upstream Modernization Watch category

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -277,6 +277,75 @@ env:
        - All findings go into the summary issue in THIS repository only.
        - If `gh` queries fail for a repo, skip it and note why.
 
+    8. UPSTREAM MODERNIZATION WATCH
+       Track release notes of pinned upstream dependencies and identify
+       config or feature opportunities we have not yet adopted. The goal
+       is to keep our deployment current with upstream evolution without
+       chasing every release.
+
+       Cadence: run this category fully on Sundays UTC, and whenever
+       manually dispatched via workflow_dispatch with empty or omitted
+       prompt. On other days, skip with no output and omit the
+       corresponding section from the daily summary.
+
+       Pinned upstreams to review:
+       - `eceasy/cli-proxy-api` in apps/cliproxy/docker-compose.yaml
+         → upstream repo: router-for-me/CLIProxyAPI
+       - `caddy` in apps/cliproxy/docker-compose.yaml
+         → upstream repo: caddyserver/caddy
+       - `fro-bot/agent` in .github/workflows/fro-bot.yaml
+       - `bfra-me/.github` action set referenced from
+         renovate.yaml, renovate-changesets.yaml,
+         update-repo-settings.yaml
+
+       For each upstream, in order:
+       a. Parse the workflow or compose file to extract the currently
+          pinned version (semver tag preferred; fall back to digest).
+       b. List GitHub releases newer than the pinned version via
+          `gh api repos/<owner>/<repo>/releases`.
+       c. Read each release body. Filter for changes that touch:
+          - new config keys we could enable
+          - new endpoints, healthchecks, or operational hooks
+          - new sidecars or services that materially improve operations
+          - security or hardening features with config knobs
+          - default behavior changes that affect us
+       d. Skip provider-specific changes for products we do not use.
+          For CLIProxyAPI specifically, skip Codex, Gemini, OpenAI,
+          Vertex, Antigravity, Kimi, Qwen, and GPT-5.x changes — we use
+          Claude only.
+
+       Output: file findings under a single tracking issue titled
+       "Upstream Modernization Watch — YYYY-MM-DD" (using the most
+       recent Sunday UTC date as YYYY-MM-DD). If an open issue with the
+       prefix "Upstream Modernization Watch —" already exists, update
+       its body in place rather than creating a new issue. Close the
+       prior issue only if the new scan finds no actionable items and
+       the prior issue's recommendations were all merged (verify via
+       commit history, not issue comments).
+
+       Action policy:
+       - For mechanical, low-risk changes that touch only
+         apps/<app>/docker-compose.yaml, apps/<app>/config/*, or
+         AGENTS.md files (NOT workflow or build-config files), open a
+         draft PR titled "feat(<app>): adopt <feature> from <upstream>
+         <version>". Link the PR from the tracking issue.
+       - For changes that would touch .github/workflows/, lint/test/
+         build config, or any file gated by the global hard boundary,
+         document in the tracking issue only — never open a PR.
+       - For subjective or multi-option changes (sidecar adoption,
+         model selection, optional config tradeoffs), document in the
+         tracking issue only.
+       - At most one draft PR per scan. Batch multiple low-risk
+         mechanical changes into the single PR.
+
+       Hard boundaries:
+       - NEVER bump pinned versions in this category. Renovate owns
+         version bumps. Adopt new config or features only at the
+         version we are already on or above.
+       - NEVER modify upstream repositories.
+       - If a release-notes API call fails for an upstream, skip it
+         and note "release notes unreachable" in the tracking issue.
+
     Hard boundaries:
     - Never force-push, rewrite history, or delete branches.
     - Never push directly to the default branch. Direct pushes are allowed
@@ -372,6 +441,11 @@ env:
     | Repo | Finding | Actionable for infra? | Priority |
     | --- | --- | --- | --- |
     | [repo] | [what they do that we don't] | [specific action or "monitor"] | High/Med/Low |
+
+    ### Upstream Modernization Watch
+    [Sunday-only section. On Sundays UTC, link to the tracking issue
+    if findings exist, or write "Scan clean" if no actionable items.
+    On other days, omit this entire section from the daily summary.]
 
     ### Needs Human Attention
     - [items that could not be auto-fixed, with context]

--- a/apps/cliproxy/AGENTS.md
+++ b/apps/cliproxy/AGENTS.md
@@ -7,7 +7,7 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 | Task | Location | Notes |
 | --- | --- | --- |
 | Config templates | `config/config.yaml`, `config/Caddyfile` | Server template — runtime keys live on the droplet |
-| Docker stack | `docker-compose.yaml` | Caddy + cli-proxy-api, restart: unless-stopped, healthcheck on root |
+| Docker stack | `docker-compose.yaml` | Caddy + cli-proxy-api, restart: unless-stopped, healthcheck on `/healthz` |
 | Provision droplet | `server/provision-droplet.ts` | One-time. Refuses re-run on existing droplet without `--force` |
 | Deploy updates | `src/deploy.ts` | Preserves `config.yaml`, preflight management key check |
 | CLI commands | `packages/cli/src/commands/cliproxy/` | See packages/cli/AGENTS.md for command pattern |
@@ -24,7 +24,7 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 ## DOCKER STACK
 
 - **Caddy**: HTTPS termination, auto Let's Encrypt. `restart: unless-stopped`.
-- **cli-proxy-api**: `eceasy/cli-proxy-api` (pinned digest, Renovate-managed). Alpine 3.22 base. `restart: unless-stopped`. Healthcheck: `wget --spider -q http://localhost:8317/` (root `/` returns 200; `wget` is available, `curl` is not).
+- **cli-proxy-api**: `eceasy/cli-proxy-api` (pinned digest, Renovate-managed). Alpine 3.22 base. `restart: unless-stopped`. Healthcheck: `wget --spider -q http://localhost:8317/healthz` (purpose-built liveness endpoint, available since v6.9.31; `wget` is in the base, `curl` is not).
 - **Volumes**: `caddy_data`, `caddy_config`, `cliproxy_auth` (OAuth tokens persist here across container recreates).
 - **Env file**: `MANAGEMENT_PASSWORD` injected from host `.env` into the container.
 


### PR DESCRIPTION
## Summary

Adds a weekly Upstream Modernization Watch category to the Fro Bot autohealing schedule, so the agent surfaces config and feature opportunities that land in pinned upstream dependencies between version bumps.

Also fixes stale healthcheck path references in `apps/cliproxy/AGENTS.md` left over from #181 (Fro Bot's non-blocking concern there).

## Why

Renovate keeps pinned versions current, but it cannot know which new config keys, endpoints, sidecars, or hardening features in those releases are worth adopting in our deployment. The two-week CLIProxyAPI release window (v6.9.23 → v6.9.38) had **one** mechanical opportunity (the `/healthz` endpoint, shipped as #181). A weekly automated scan would have surfaced that the same week it shipped upstream.

## Behavior

- **Cadence**: full scan on Sundays UTC and on manual `workflow_dispatch` runs with empty/omitted prompt. Skipped silently on other days.
- **Scope**: `eceasy/cli-proxy-api`, `caddy`, `fro-bot/agent`, and the `bfra-me/.github` action set.
- **Filtering**: provider-specific changes for products we don't use (Codex, Gemini, OpenAI, Vertex, Antigravity, Kimi, Qwen, GPT-5.x) are skipped — we use Claude only.
- **Output**:
  - Single tracking issue titled `Upstream Modernization Watch — YYYY-MM-DD` (most recent Sunday UTC), updated in place across runs.
  - At most one draft PR per scan, only for mechanical low-risk changes that touch `apps/<app>/docker-compose.yaml`, `apps/<app>/config/*`, or AGENTS.md files.
  - Workflow files, lint/test/build config, and other guardrail-gated paths are documented in the tracking issue only — never auto-modified.
- **Hard boundary**: never bumps pinned versions. Renovate retains exclusive ownership of versions.

## Diff shape

- `.github/workflows/fro-bot.yaml`: new category 8 in `SCHEDULE_PROMPT` + new `### Upstream Modernization Watch` section in the daily report template (Sunday-only, omitted otherwise).
- `apps/cliproxy/AGENTS.md`: two stale `wget --spider … /` references updated to `/healthz`.

## Verification

- `bun test --recursive` — 175 pass, 0 fail
- `bun run lint` — 0 errors
- `bunx tsc --noEmit` — clean
- YAML parses correctly with all 8 categories present in `SCHEDULE_PROMPT`

Test plan post-merge: trigger a manual `workflow_dispatch` run with empty prompt to validate category 8 produces a tracking issue (or "Scan clean" output) without errors.
