### PR TITLE
fix(deploy-cliproxy): add predicate-quantifier:every to paths-filter

### DIFF
--- a/.github/workflows/deploy-cliproxy.yaml
+++ b/.github/workflows/deploy-cliproxy.yaml
@@ -32,6 +32,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          predicate-quantifier: every
           filters: |
             cliproxy:
               - 'apps/cliproxy/**'

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -294,9 +294,11 @@ env:
        - `caddy` in apps/cliproxy/docker-compose.yaml
          → upstream repo: caddyserver/caddy
        - `fro-bot/agent` in .github/workflows/fro-bot.yaml
+         → upstream repo: fro-bot/agent
        - `bfra-me/.github` action set referenced from
          renovate.yaml, renovate-changesets.yaml,
          update-repo-settings.yaml
+         → upstream repo: bfra-me/.github
 
        For each upstream, in order:
        a. Parse the workflow or compose file to extract the currently
@@ -369,6 +371,8 @@ env:
     - Site review (category 6) is observation-only: create issues, never
       push fixes for visual or functional findings.
     - Cross-project monitoring (category 7) MUST NOT modify other repos.
+    - Upstream modernization watch (category 8) MUST NOT bump pinned versions
+      (Renovate-owned) or modify upstream repositories.
     - Do not create multiple summary issues.
 
     Project conventions (MUST follow for code changes):


### PR DESCRIPTION
## Summary

Three small workflow-only fixes:

1. **Fix `deploy-cliproxy.yaml` paths-filter** — add missing `predicate-quantifier: every` so negation patterns actually subtract files instead of OR-ing into truthy. Without it, the default `some` quantifier evaluates each `!apps/cliproxy/**/*.md`-style negation as `true` for any file that doesn't match the negated pattern, which means **every push to main** triggered Deploy CLIProxy regardless of what changed.
2. **Add upstream repo pointers** for `fro-bot/agent` and `bfra-me/.github` in the Upstream Modernization Watch prompt (consistency with `eceasy/cli-proxy-api` and `caddy`).
3. **Add a global hard-boundary line for category 8** in the workflow-wide `Hard boundaries:` block (consistency with the existing category 6 and category 7 lines).

## Why item 1 matters

`deploy-keeweb.yaml` has `predicate-quantifier: every` (added in PR #81 on 2026-04-10); `deploy-cliproxy.yaml` was missing it after the deploy split in PR #165. Empirical evidence from run 24945073253 (commit `cd3bb16`, only changed `.github/workflows/fro-bot.yaml`):

```
##[group]Filter cliproxy = true
Matching files:
  .github/workflows/fro-bot.yaml [modified]
predicate-quantifier: some
```

The file matched because the OR-of-negations resolves true. After the fix, all five filter patterns must be true simultaneously, so files outside `apps/cliproxy/**` correctly evaluate to false.

### Side-by-side proof for commit `938fa7c` (workflow-only):

| Workflow | `predicate-quantifier` | Filter output | Deploy job |
| --- | --- | --- | --- |
| `deploy-keeweb` | `every` | `keeweb=false` | skipped (correct) |
| `deploy-cliproxy` | `some` (default) | `cliproxy=true` | waiting on approval (bug) |

After the fix, the table normalizes — both workflows produce the same correct skip behavior for non-app changes.

## Behavior preserved

- Docker image updates (e.g., `apps/cliproxy/docker-compose.yaml` digest bumps) still match `apps/cliproxy/**` and trigger deploy ✅
- Action-only updates (`.github/workflows/*.yaml`) no longer match → deploy skipped ✅
- AGENTS.md / test / fixture / snapshot changes inside `apps/cliproxy/` still negated correctly ✅

Items 2 and 3 are pure prompt cleanups carried over from Fro Bot's non-blocking review on PR #182 — no behavioral change.

## Verification

- `bun test --recursive` — 175 pass, 0 fail
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors
- YAML parse-check on both edited workflows ✅

## Pending stuck runs

Four Deploy CLIProxy runs are currently waiting on environment approval as a result of this bug. After this PR merges:

- Cancel #185 (24956971124, fro-bot/agent v0.42.2 — workflow-only)
- Cancel #186 (24961570188, cli-proxy-api v6.9.39 — superseded by v6.9.40)
- Cancel #188 (24972111673, bfra-me/.github v4.16.9 — workflow-only)
- Approve #190 (24996439963, cli-proxy-api v6.9.40 — current latest)

The Deploy CLIProxy run for this PR's merge commit should produce `cliproxy=false` (proof point) since the only changes are under `.github/workflows/`.
