### PR TITLE
docs(plans): reconcile cliproxy deployment and conventions-test plans to completed

### DIFF
--- a/docs/plans/2026-04-03-002-feat-cliproxy-deployment-plan.md
+++ b/docs/plans/2026-04-03-002-feat-cliproxy-deployment-plan.md
@@ -1,13 +1,17 @@
 ---
 title: "feat: Add CLIProxyAPI deployment and management"
 type: feat
-status: active
+status: completed
 date: 2026-04-03
 deepened: 2026-04-03
+completed: 2026-04-06
 origin: docs/brainstorms/2026-04-03-cliproxy-deployment-requirements.md
 ---
 
 # feat: Add CLIProxyAPI deployment and management
+
+> **Status note (reconciled 2026-05-18):** All 8 units shipped through PR #23 (initial 8-unit implementation) followed by remediation PRs #37 (CLIPROXY_HOST → CLIPROXY_DOMAIN), #38 (pinned host keys), #39 (auth-dir config). First successful deploy on 2026-04-06; documented in `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md`. Subsequent stability/feature work is tracked in `docs/plans/2026-04-07-001-fix-cliproxy-stability-hardening-plan.md` and the CLI zhuzh plan; do not extend this plan further.
+
 
 ## Overview
 

--- a/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
+++ b/docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md
@@ -1,12 +1,16 @@
 ---
 title: 'feat: Enforce root AGENTS.md conventions with ESLint config and conventions test'
 type: feat
-status: active
+status: completed
 date: 2026-04-16
+completed: 2026-04-20
 origin: docs/brainstorms/2026-04-16-executable-conventions-tests-requirements.md
 ---
 
 # Enforce root AGENTS.md conventions with ESLint config and conventions test
+
+> **Status note (reconciled 2026-05-18):** Shipped via PR #161 (ESLint enforcement + 7 structural rules in `packages/cli/src/conventions.test.ts` + `(enforced)` markers in `AGENTS.md` + Fro Bot category 3 trim). Follow-up PR #167 added `(enforced)` marker drift detection and per-app invariants. Live state: 175 tests pass, ESLint `no-explicit-any` and `ban-ts-comment` at error severity. A known follow-up — guard `dorny/paths-filter` for `predicate-quantifier: every` whenever `!` negations are used — is tracked in project memory ID 2388 but not yet shipped; that work is out of scope for this plan.
+
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Two plan documents in `docs/plans/` still showed `status: active` despite being shipped weeks ago. This PR reconciles the frontmatter and adds a status note above the Overview pointing to the actual merge PRs and follow-up artifacts. No plan body content was modified.

## What changed

- `docs/plans/2026-04-03-002-feat-cliproxy-deployment-plan.md`: `active` → `completed`, completion date `2026-04-06`. Shipped via PR #23 (8-unit implementation) followed by PR #37 (`CLIPROXY_HOST` → `CLIPROXY_DOMAIN`), PR #38 (pinned host keys), PR #39 (auth-dir config). Cascade documented in `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md`. Subsequent stability/feature work tracks in `docs/plans/2026-04-07-001-fix-cliproxy-stability-hardening-plan.md` and the CLI zhuzh plan.
- `docs/plans/2026-04-16-001-feat-executable-conventions-tests-plan.md`: `active` → `completed`, completion date `2026-04-20`. Shipped via PR #161 (initial ESLint + 7 structural rules + AGENTS.md markers + Fro Bot category 3 trim) and PR #167 (drift detection + per-app invariants). 175 tests pass. One known follow-up (`dorny/paths-filter` quantifier guard) is out of scope here and tracked separately.

## Why

Plan status drift makes it harder to assess what's outstanding when picking up work. Both plans were verified shipped against live code and merged PRs before flipping status.

## Verification

- `git diff --stat` shows 2 files, 10 insertions, 2 deletions — frontmatter and inserted status notes only.
- All 7 plans in `docs/plans/` now consistently show `status: completed`.
- No body content modified in either plan.

No changeset — docs-only change to internal planning artifacts.
