### PR TITLE
test(conventions): enforce predicate-quantifier:every on dorny/paths-filter with negations

### DIFF
--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -469,6 +469,42 @@ jobs:
 `
     expect(findPathsFilterQuantifierViolations(yaml)).toEqual([])
   })
+
+  it('bare-string negation filter without predicate-quantifier → 1 violation', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            cliproxy: '!apps/cliproxy/**/*.md'
+`
+    const violations = findPathsFilterQuantifierViolations(yaml)
+    expect(violations).toEqual([
+      {
+        jobId: 'detect',
+        stepIndex: 0,
+        reason: `job 'detect' step 0 uses dorny/paths-filter with negation patterns but is missing predicate-quantifier: every`,
+      },
+    ])
+  })
+
+  it('bare-string negation filter with predicate-quantifier: every → 0 violations', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: every
+          filters: |
+            cliproxy: '!apps/cliproxy/**/*.md'
+`
+    expect(findPathsFilterQuantifierViolations(yaml)).toEqual([])
+  })
 })
 
 describe('dorny/paths-filter quantifier guard', () => {
@@ -480,8 +516,7 @@ describe('dorny/paths-filter quantifier guard', () => {
   })
 
   it('all workflow files using dorny/paths-filter with negations declare predicate-quantifier: every', async () => {
-    const glob = new Bun.Glob('.github/workflows/**')
-    const files = [...glob.scanSync({cwd: REPO_ROOT, absolute: true, dot: true})].filter(f => f.endsWith('.yaml'))
+    const files = listWorkflowFiles('.yaml')
     expect(files.length).toBeGreaterThan(0)
 
     const violations: PathsFilterQuantifierViolation[] = []

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -71,6 +71,80 @@ export function findCrossOrgSecretsInherit(parsed: unknown): {jobId: string; use
   return violations
 }
 
+/**
+ * Detect dorny/paths-filter steps that use negation patterns without declaring
+ * `predicate-quantifier: every`. The default quantifier (`some`) applies OR-logic
+ * across patterns, which silently makes negations truthy whenever any other file
+ * matches — the opposite of the intended behaviour.
+ *
+ * Rule: any step using dorny/paths-filter that contains a filter pattern starting
+ * with `!` MUST also set `predicate-quantifier: every` in the same step's `with:` block.
+ */
+export interface PathsFilterQuantifierViolation {
+  file?: string
+  jobId: string
+  stepIndex: number
+  reason: string
+}
+
+export function findPathsFilterQuantifierViolations(workflowText: string): PathsFilterQuantifierViolation[] {
+  const parsed = parseYaml(workflowText, {merge: true}) as unknown
+  if (typeof parsed !== 'object' || parsed === null) return []
+  const jobs = (parsed as {jobs?: Record<string, unknown>}).jobs
+  if (typeof jobs !== 'object' || jobs === null) return []
+
+  const violations: PathsFilterQuantifierViolation[] = []
+
+  for (const [jobId, jobRaw] of Object.entries(jobs)) {
+    if (typeof jobRaw !== 'object' || jobRaw === null) continue
+    const job = jobRaw as {steps?: unknown[]}
+    if (!Array.isArray(job.steps)) continue
+
+    for (const [index, stepRaw] of job.steps.entries()) {
+      if (typeof stepRaw !== 'object' || stepRaw === null) continue
+      const step = stepRaw as {uses?: unknown; with?: Record<string, unknown>}
+      if (typeof step.uses !== 'string') continue
+      if (!step.uses.startsWith('dorny/paths-filter')) continue
+
+      const withBlock = step.with ?? {}
+      const filtersRaw = withBlock.filters
+      if (typeof filtersRaw !== 'string') continue
+
+      // Parse the inner YAML of the filters block to inspect pattern lists
+      const filters = parseYaml(filtersRaw, {merge: true}) as unknown
+      if (typeof filters !== 'object' || filters === null) continue
+
+      let hasNegation = false
+      for (const patternsRaw of Object.values(filters as Record<string, unknown>)) {
+        const patterns = Array.isArray(patternsRaw) ? patternsRaw : [patternsRaw]
+        for (const p of patterns) {
+          if (typeof p === 'string' && p.startsWith('!')) {
+            hasNegation = true
+            break
+          }
+        }
+        if (hasNegation) break
+      }
+
+      if (!hasNegation) continue
+
+      const quantifier = withBlock['predicate-quantifier']
+      if (quantifier !== 'every') {
+        violations.push({
+          jobId,
+          stepIndex: index,
+          reason:
+            quantifier === undefined
+              ? `job '${jobId}' step ${index} uses dorny/paths-filter with negation patterns but is missing predicate-quantifier: every`
+              : `job '${jobId}' step ${index} uses dorny/paths-filter with negation patterns but predicate-quantifier is '${String(quantifier)}' (must be 'every')`,
+        })
+      }
+    }
+  }
+
+  return violations
+}
+
 describe('repo conventions', () => {
   it('tripwire: workflow glob resolves to at least one file (catches dot-dir glob regressions)', () => {
     const workflows = listWorkflowFiles('.yaml')
@@ -312,5 +386,111 @@ jobs:
       - run: echo hi
 `)
     expect(findCrossOrgSecretsInherit(parsed)).toEqual([])
+  })
+})
+
+describe('findPathsFilterQuantifierViolations', () => {
+  it('paths-filter with negations and predicate-quantifier: every → 0 violations', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: every
+          filters: |
+            app:
+              - 'apps/myapp/**'
+              - '!apps/myapp/**/*.md'
+`
+    expect(findPathsFilterQuantifierViolations(yaml)).toEqual([])
+  })
+
+  it('paths-filter with negations and missing predicate-quantifier → 1 violation', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            app:
+              - 'apps/myapp/**'
+              - '!apps/myapp/**/*.md'
+`
+    const violations = findPathsFilterQuantifierViolations(yaml)
+    expect(violations).toEqual([
+      {
+        jobId: 'detect',
+        stepIndex: 0,
+        reason: `job 'detect' step 0 uses dorny/paths-filter with negation patterns but is missing predicate-quantifier: every`,
+      },
+    ])
+  })
+
+  it('paths-filter with negations and predicate-quantifier: some → 1 violation', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: some
+          filters: |
+            app:
+              - 'apps/myapp/**'
+              - '!apps/myapp/**/*.md'
+`
+    const violations = findPathsFilterQuantifierViolations(yaml)
+    expect(violations).toEqual([
+      {
+        jobId: 'detect',
+        stepIndex: 0,
+        reason: `job 'detect' step 0 uses dorny/paths-filter with negation patterns but predicate-quantifier is 'some' (must be 'every')`,
+      },
+    ])
+  })
+
+  it('paths-filter without negations → 0 violations regardless of quantifier', () => {
+    const yaml = `
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            app:
+              - 'apps/myapp/**'
+              - 'apps/myapp/**/*.ts'
+`
+    expect(findPathsFilterQuantifierViolations(yaml)).toEqual([])
+  })
+})
+
+describe('dorny/paths-filter quantifier guard', () => {
+  it('tripwire: workflow glob resolves to at least one file (catches dot-dir glob regressions)', () => {
+    // `.github/` is a dot-directory; Bun.Glob skips dot-dirs by default unless `dot: true` is set.
+    const glob = new Bun.Glob('.github/workflows/**')
+    const files = [...glob.scanSync({cwd: REPO_ROOT, absolute: true, dot: true})]
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('all workflow files using dorny/paths-filter with negations declare predicate-quantifier: every', async () => {
+    const glob = new Bun.Glob('.github/workflows/**')
+    const files = [...glob.scanSync({cwd: REPO_ROOT, absolute: true, dot: true})].filter(f => f.endsWith('.yaml'))
+    expect(files.length).toBeGreaterThan(0)
+
+    const violations: PathsFilterQuantifierViolation[] = []
+    for (const file of files) {
+      const text = await Bun.file(file).text()
+      for (const v of findPathsFilterQuantifierViolations(text)) {
+        violations.push({...v, file: relative(REPO_ROOT, file)})
+      }
+    }
+    expect(violations).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Add a `packages/cli/src/conventions.test.ts` check that fails CI whenever a workflow step uses `dorny/paths-filter` with `!`-negation patterns but omits `predicate-quantifier: every`.

## Why

The default `predicate-quantifier: some` is OR-logic across all patterns in a filter group. When that default is combined with `!`-prefixed exclusion patterns, every non-matching file still trips the filter as truthy — the opposite of what the negation expresses. The result is a deploy job that fires on every push instead of skipping when only excluded paths changed.

This regression has bitten this repo three times: in the initial unified `deploy.yaml`, again when the deploy pipeline was split into per-app workflows, and most recently in `deploy-cliproxy.yaml`. Each manifestation cost approval-gate noise and unnecessary container restarts. Mechanical enforcement closes the loop.

## What changed

`packages/cli/src/conventions.test.ts` (+162 lines, 0 deletions):

- Exports a pure function `findPathsFilterQuantifierViolations(workflowText: string): PathsFilterQuantifierViolation[]`. Walks every job/step in the parsed YAML, finds `dorny/paths-filter` steps, parses the inner `filters` YAML, detects negation patterns, and requires `predicate-quantifier: every` in the same `with:` block. Returns `{jobId, stepIndex, reason}` per violation so failures point at the specific job/step in real workflow files.
- Adds 4 unit tests covering correct quantifier, missing quantifier, wrong quantifier, and the no-negations case.
- Adds an integration test that iterates every `.github/workflows/**/*.yaml` file using `Bun.Glob({ dot: true })` and asserts zero violations. Includes the tripwire assertion that the glob actually resolves to at least one file — guarding against a future `{ dot: true }` regression silently making the check vacuous.

No production code changed. No new dependencies. Test count: 175 → 181.

## Verification

- Red-green proof performed: temporarily removing `predicate-quantifier: every` from `deploy-keeweb.yaml` line 40 causes the integration test to fail with a violation message naming the exact `jobId` and `stepIndex`. Restored line → green.
- `bun test --recursive` → 181 pass, 0 fail
- `bunx tsc --noEmit` → clean
- `bunx eslint packages/cli/src/conventions.test.ts` → clean

No changeset — this is internal test infrastructure with no impact on the published `@marcusrbrown/infra` runtime or CLI behavior.
