### PR TITLE
fix(cliproxy): bump provisioner image to docker-24-04

### DIFF
--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -5,7 +5,7 @@ import {appendFileSync, readFileSync} from 'node:fs'
 import {resolve} from 'node:path'
 
 const DROPLET_NAME = 'cliproxy'
-const DROPLET_IMAGE = 'docker-20-04'
+const DROPLET_IMAGE = 'docker-24-04'
 const DROPLET_SIZE = 's-1vcpu-1gb'
 const DROPLET_REGION = 'nyc1'
 const CLIPROXY_DOMAIN = process.env.CLIPROXY_DOMAIN ?? 'cliproxy.fro.bot'


### PR DESCRIPTION
## Summary

Bump the cliproxy provisioner droplet image slug from `docker-20-04` to `docker-24-04`. Follow-up to PR #264 which made the same change for the gateway provisioner.

## Why

DigitalOcean's `docker-20-04` slug is a legacy name that today actually provisions Ubuntu 22.04 + Docker (DO never renamed it). The `docker-24-04` slug provisions Ubuntu 24.04 + Docker, which is current and forward-looking. The intent of the constant is now explicit.

## Scope

- One line: `apps/cliproxy/server/provision-droplet.ts:8`
- No test changes (the provisioner has no test file)
- No changeset (provisioning infra, not the published CLI package)
- The live cliproxy droplet (Ubuntu 22.04) is unaffected — this only changes what gets provisioned on next `bun run --cwd apps/cliproxy provision`

## Verification

- 353 tests pass
- Lint + type-check clean
