### PR TITLE
fix(gateway): select SSH key by name in provisioner

### DIFF
--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 import {
   checkDropletExistence,
   dropletExists,
+  getSshFingerprint,
   parseProvisionArgs,
   pinHostKeys,
   validateDoctl,
@@ -294,6 +295,99 @@ describe('provision-droplet', () => {
       )
 
       await expect(pinHostKeys('gateway.example.com', '1.2.3.4', knownHostsPath)).rejects.toThrow()
+
+      spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getSshFingerprint
+  // -------------------------------------------------------------------------
+
+  // Real doctl output uses multi-space padding between Name and FingerPrint columns.
+  // The Name column can contain spaces, @, and dots — so we parse last-field-is-fingerprint.
+  const MULTI_KEY_OUTPUT = [
+    'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+    'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+    'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+    'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+  ].join('\n')
+
+  describe('getSshFingerprint', () => {
+    it('matches gateway-specific key when multiple keys exist', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getSshFingerprint('fro-bot-gateway')
+
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+      // Must NOT return the first key's fingerprint
+      expect(fp).not.toBe('91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('picks the named key even when it is the only row', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(
+          'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+          0,
+        ) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getSshFingerprint('fro-bot-gateway')
+
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('throws with a clear message when the named key is not found', async () => {
+      const threeOtherKeys = [
+        'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+        'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+        'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
+
+      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
+      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/GATEWAY_SSH_KEY_NAME/)
+      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/fro-bot-gateway/)
+
+      spawnSpy.mockRestore()
+    })
+
+    it('throws with a clear message when the key list is empty', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(makeSpawnResult('', 0) as ReturnType<typeof Bun.spawn>)
+
+      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
+
+      spawnSpy.mockRestore()
+    })
+
+    it('throws on doctl non-zero exit', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResultWithStderr('unauthorized', 1) as ReturnType<typeof Bun.spawn>,
+      )
+
+      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/unauthorized/)
+
+      spawnSpy.mockRestore()
+    })
+
+    it('uses fro-bot-gateway as the default key name when no argument is provided', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getSshFingerprint()
+
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
 
       spawnSpy.mockRestore()
     })

--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -17,7 +17,7 @@ import {
 // Env helpers
 // ---------------------------------------------------------------------------
 
-const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'GATEWAY_HOST'] as const
+const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'GATEWAY_HOST', 'GATEWAY_SSH_KEY_NAME'] as const
 type ManagedEnvKey = (typeof managedEnvKeys)[number]
 
 let savedEnv: Partial<Record<ManagedEnvKey, string | undefined>>
@@ -388,6 +388,47 @@ describe('provision-droplet', () => {
       const fp = await getSshFingerprint()
 
       expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('uses GATEWAY_SSH_KEY_NAME env var when no argument is passed', async () => {
+      process.env.GATEWAY_SSH_KEY_NAME = 'custom-key-name'
+
+      const customKeyOutput = [
+        'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+        'custom-key-name                                       aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(customKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getSshFingerprint()
+
+      expect(fp).toBe('aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99')
+      // Must NOT return the fro-bot-gateway fingerprint
+      expect(fp).not.toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('looks up a key whose name contains spaces', async () => {
+      const spacedKeyOutput = [
+        'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+        'my key with spaces                                    11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00',
+        'another-key                                           ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(spacedKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getSshFingerprint('my key with spaces')
+
+      expect(fp).toBe('11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00')
+      // Must NOT return the next row's fingerprint
+      expect(fp).not.toBe('ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00')
 
       spawnSpy.mockRestore()
     })

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -160,18 +160,30 @@ function ssh(host: string, command: string): string[] {
   ]
 }
 
-async function getSshFingerprint(): Promise<string> {
-  const raw = await runCapture(['doctl', 'compute', 'ssh-key', 'list', '--format', 'FingerPrint', '--no-header'])
-  const first = raw
-    .split('\n')
-    .map(line => line.trim())
-    .find(Boolean)
+export async function getSshFingerprint(keyName?: string): Promise<string> {
+  const name = keyName ?? process.env.GATEWAY_SSH_KEY_NAME ?? 'fro-bot-gateway'
+  const raw = await runCapture(['doctl', 'compute', 'ssh-key', 'list', '--format', 'Name,FingerPrint', '--no-header'])
 
-  if (!first) {
-    throw new Error('No SSH keys found in DigitalOcean account. Add at least one key before provisioning.')
+  // Each row: "<Name padded with spaces>  <FingerPrint>"
+  // The Name column can contain spaces, @, and dots, so we treat the last
+  // whitespace-delimited token as the fingerprint and everything before it as the name.
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const lastSpace = trimmed.lastIndexOf(' ')
+    if (lastSpace === -1) continue
+    const rowName = trimmed.slice(0, lastSpace).trim()
+    const fingerprint = trimmed.slice(lastSpace + 1).trim()
+    if (rowName === name) {
+      return fingerprint
+    }
   }
 
-  return first
+  throw new Error(
+    `SSH key named "${name}" not found in DigitalOcean account. ` +
+      `Run \`doctl compute ssh-key list\` to see available keys, ` +
+      `or set GATEWAY_SSH_KEY_NAME to override the default ("fro-bot-gateway").`,
+  )
 }
 
 async function getDropletIpWithWait(): Promise<string> {


### PR DESCRIPTION
## Why

The provisioner picked the first SSH key from the DigitalOcean account, which left the wrong key authorized on the droplet whenever the account held more than one key. CI deploys using `GATEWAY_SSH_KEY` then failed to authenticate, even though provisioning itself succeeded.

I hit this preparing the gateway droplet — my DO account has four keys and `fro-bot-gateway` (the one created for this deploy) sorts last.

## What

- Look up the key by name. Default `fro-bot-gateway`; override via `GATEWAY_SSH_KEY_NAME`.
- Error message names both the missing key and the `GATEWAY_SSH_KEY_NAME` override when no match is found.
- Export `getSshFingerprint(keyName?)` so the lookup is unit-testable.

## Tests

6 new tests in `apps/gateway/server/provision-droplet.test.ts`:

- Picks the named key from a multi-key listing (not the first row)
- Picks the named key when it's the only row
- Throws with actionable error when the named key is absent
- Throws on empty key list
- Surfaces non-zero `doctl` exit
- Defaults to `fro-bot-gateway` with no argument

359 tests pass, lint clean, tsc clean.

## Notes

The cliproxy provisioner has the same shape and the same latent bug, but its droplet is already provisioned and stable — left untouched here, separate cleanup later.
