### PR TITLE
chore(gateway): add provision script to package.json

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "deploy": "bun run src/deploy.ts",
+    "provision": "bun run server/provision-droplet.ts",
     "test": "bun test"
   }
 }


### PR DESCRIPTION
## Why

`apps/gateway/AGENTS.md` references `bun run --cwd apps/gateway provision` twice as the canonical command to run the one-time droplet provisioner. The script was never added to `apps/gateway/package.json` — calling it fails with `Script not found "provision"`.

I hit this preparing to provision the gateway droplet.

## What

Add the missing `provision` script to `apps/gateway/package.json`, mirroring the cliproxy wiring:

```jsonc
"provision": "bun run server/provision-droplet.ts"
```

## Verification

```
$ bun run --cwd apps/gateway provision --check-exists
{"name":"gateway","exists":false}
```

`--check-exists` is the non-mutating probe, so this confirms the script resolves correctly without creating anything.

361 tests pass, lint clean, tsc clean.
