### PR TITLE
fix: revert droplet image slug to docker-20-04

### DIFF
--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -5,7 +5,7 @@ import {appendFileSync, readFileSync} from 'node:fs'
 import {resolve} from 'node:path'
 
 const DROPLET_NAME = 'cliproxy'
-const DROPLET_IMAGE = 'docker-24-04'
+const DROPLET_IMAGE = 'docker-20-04'
 const DROPLET_SIZE = 's-1vcpu-1gb'
 const DROPLET_REGION = 'nyc1'
 const CLIPROXY_DOMAIN = process.env.CLIPROXY_DOMAIN ?? 'cliproxy.fro.bot'

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -4,7 +4,7 @@ import {appendFileSync, readFileSync} from 'node:fs'
 import {join, resolve} from 'node:path'
 
 const DROPLET_NAME = 'gateway'
-const DROPLET_IMAGE = 'docker-24-04'
+const DROPLET_IMAGE = 'docker-20-04'
 const DROPLET_SIZE = 's-1vcpu-2gb'
 const DROPLET_REGION = 'nyc1'
 const REMOTE_USER = process.env.REMOTE_USER ?? 'root'


### PR DESCRIPTION
## Why

Both provisioners were set to `docker-24-04`, but that slug doesn't exist as a public DigitalOcean marketplace image — `doctl compute droplet create` returns HTTP 422 "invalid image". I hit this trying to provision the gateway droplet for the first time.

The legacy `docker-20-04` slug is misleadingly named — despite the version in the name, it actually provisions Ubuntu 22.04 + Docker. Confirmed against the live cliproxy droplet (provisioned April 4, 2026 with the same slug, currently running Ubuntu 22.04 LTS with standard support through April 2027) and via:

```
doctl compute image list --public --format Slug,Name,Distribution --no-header | grep ^docker
```

Only `docker-20-04` is currently available. The previous bump introduced a slug that doesn't exist anywhere in DO's marketplace.

## What

Revert both provisioners (gateway + cliproxy) to `docker-20-04`. Pure single-line change in each file.

The cliproxy droplet is already running and unaffected by this revert — it lives on the existing Ubuntu 22.04 box. The change matters only at the next re-provision, which is hypothetical for cliproxy and imminent for gateway.

## Verification

```
361 pass, 0 fail (full suite)
0 lint errors
tsc clean
```

## Follow-up

If Ubuntu 24.04 is desired down the road, the path is `ubuntu-24-04-x64` + cloud-init userdata to install Docker — that's a separate, larger change that should land in its own PR.
