### PR TITLE
fix(gateway): align deploy with upstream compose contract

### DIFF
--- a/.changeset/gateway-deploy-env-and-ssh-key-contract.md
+++ b/.changeset/gateway-deploy-env-and-ssh-key-contract.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix gateway deploy local mode to forward all required env vars (DISCORD_TOKEN, AWS_*, S3_*) plus the optional S3_ENDPOINT and OBJECT_STORE_HOSTS. The previous narrow allowlist made `gateway deploy --local` unusable on most configurations and silently produced wrong mitmproxy egress allowlists for R2/MinIO endpoints.

--- a/.changeset/gateway-deploy-env-and-ssh-key-contract.md
+++ b/.changeset/gateway-deploy-env-and-ssh-key-contract.md
@@ -2,4 +2,4 @@
 '@marcusrbrown/infra': patch
 ---
 
-Fix gateway deploy local mode to forward all required env vars (DISCORD_TOKEN, AWS_*, S3_*) plus the optional S3_ENDPOINT and OBJECT_STORE_HOSTS. The previous narrow allowlist made `gateway deploy --local` unusable on most configurations and silently produced wrong mitmproxy egress allowlists for R2/MinIO endpoints.
+Fix gateway deploy local mode to forward all required env vars (DISCORD_TOKEN, AWS_*, S3_*) plus the optional S3_ENDPOINT, OBJECT_STORE_HOSTS, and AWS_SESSION_TOKEN. The previous narrow allowlist made `gateway deploy --local` unusable on most configurations and silently produced wrong mitmproxy egress allowlists for R2/MinIO endpoints.

--- a/.github/workflows/deploy-gateway.yaml
+++ b/.github/workflows/deploy-gateway.yaml
@@ -32,6 +32,8 @@ on:
         required: false
       OBJECT_STORE_HOSTS:
         required: false
+      AWS_SESSION_TOKEN:
+        required: false
 
 jobs:
   detect-changes:
@@ -115,6 +117,7 @@ jobs:
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_REGION: ${{ secrets.S3_REGION }}
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}

--- a/.github/workflows/deploy-gateway.yaml
+++ b/.github/workflows/deploy-gateway.yaml
@@ -105,14 +105,10 @@ jobs:
       - name: Configure SSH known_hosts
         run: mkdir -p ~/.ssh && cp .github/known_hosts ~/.ssh/known_hosts
 
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.GATEWAY_SSH_KEY }}
-
       - name: Deploy gateway
         run: bun run --cwd apps/gateway deploy
         env:
+          GATEWAY_SSH_KEY: ${{ secrets.GATEWAY_SSH_KEY }}
           GATEWAY_HOST: ${{ secrets.GATEWAY_HOST }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -221,10 +221,10 @@ describe('computeObjectStoreHosts', () => {
 // ─── buildSecretFileList ──────────────────────────────────────────────────────
 
 describe('buildSecretFileList', () => {
-  test('returns exactly 8 secret entries', async () => {
+  test('returns exactly 9 secret entries', async () => {
     const {buildSecretFileList} = await import('./deploy')
     const secrets = buildSecretFileList(makeEnv())
-    expect(secrets).toHaveLength(8)
+    expect(secrets).toHaveLength(9)
   })
 
   test('uses kebab-case file names matching upstream compose contract', async () => {
@@ -239,6 +239,7 @@ describe('buildSecretFileList', () => {
     expect(names).toContain('s3-bucket')
     expect(names).toContain('s3-region')
     expect(names).toContain('s3-endpoint')
+    expect(names).toContain('aws-session-token')
   })
 
   test('does not use snake_case file names', async () => {
@@ -330,6 +331,25 @@ describe('buildSecretFileList', () => {
     const secrets = buildSecretFileList(makeEnv({S3_ENDPOINT: 'https://abc123.r2.cloudflarestorage.com'}))
     const endpoint = secrets.find(s => s.name === 's3-endpoint')
     expect(endpoint?.content).toBe('https://abc123.r2.cloudflarestorage.com')
+  })
+
+  test('aws-session-token is optional: unset → empty content, required false', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const env = makeEnv()
+    delete (env as Record<string, string>).AWS_SESSION_TOKEN
+    const secrets = buildSecretFileList(env)
+    const sessionToken = secrets.find(s => s.name === 'aws-session-token')
+    expect(sessionToken).toBeDefined()
+    expect(sessionToken?.content).toBe('')
+    expect(sessionToken?.required).toBe(false)
+  })
+
+  test('aws-session-token set → content is the value', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv({AWS_SESSION_TOKEN: 'AQoXnyc4lcK4w=='}))
+    const sessionToken = secrets.find(s => s.name === 'aws-session-token')
+    expect(sessionToken?.content).toBe('AQoXnyc4lcK4w==')
+    expect(sessionToken?.required).toBe(false)
   })
 })
 

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1,5 +1,5 @@
 import type {SpawnFn, SpawnResult} from './deploy'
-import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, mock, test} from 'bun:test'
@@ -718,29 +718,6 @@ describe('main', () => {
     expect(errorMessage).toContain('app123')
     expect(errorMessage).toContain('guild456')
     expect(errorMessage).not.toContain('tok-secret')
-  })
-
-  test('edge case (auth-tier warning): non-ping command without DISCORD_OPERATOR_ROLE_ID → warning, deploy succeeds', async () => {
-    const {main} = await import('./deploy')
-    const {spawnFn} = makeSpawnMock()
-    const mockFetch = makeDiscordFetch([{name: 'ping'}, {name: 'deploy'}])
-    const warnings: string[] = []
-    const origWarn = console.warn
-    console.warn = (...args: unknown[]) => {
-      warnings.push(args.join(' '))
-    }
-
-    try {
-      const env = makeEnv()
-      delete (env as Record<string, string>).DISCORD_OPERATOR_ROLE_ID
-      await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
-    } finally {
-      console.warn = origWarn
-    }
-
-    const warningText = warnings.join('\n')
-    expect(warningText).toMatch(/DISCORD_OPERATOR_ROLE_ID/)
-    expect(warningText).toMatch(/deploy/)
   })
 
   test('happy path (--dry-run): no spawn invocations', async () => {
@@ -1491,12 +1468,14 @@ describe('CI key-file contract', () => {
     const {main} = await import('./deploy')
     const KEY_CONTENT = 'fake-ssh-private-key-content'
     let writtenKeyPath: string | undefined
+    let capturedMode: number | undefined
 
     const {spawnFn} = makeSpawnMock(cmd => {
-      // Capture the -i path from the first ssh call
+      // Capture the -i path from the first ssh call and stat the file while it still exists
       const iIdx = cmd.indexOf('-i')
       if (iIdx !== -1 && writtenKeyPath === undefined) {
         writtenKeyPath = cmd[iIdx + 1]
+        if (writtenKeyPath) capturedMode = statSync(writtenKeyPath).mode & 0o777
       }
       return undefined
     })
@@ -1510,6 +1489,8 @@ describe('CI key-file contract', () => {
     })
 
     expect(writtenKeyPath).toBeDefined()
+    // File mode must be 0o600 (checked while file existed, before cleanup)
+    expect(capturedMode).toBe(0o600)
     // File should have been cleaned up after main() completes
     expect(existsSync(writtenKeyPath!)).toBe(false)
   })
@@ -1583,6 +1564,28 @@ describe('CI key-file contract', () => {
     expect(existsSync(capturedKeyPath!)).toBe(false)
   })
 
+  test('CI mode: tmp dir cleaned up when key materialization throws (inner catch path)', async () => {
+    // Verify the inner try/catch in key materialization cleans up keyTmpDir when
+    // an fs operation throws. Named ESM imports in deploy.ts cannot be intercepted
+    // via spyOn (Bun resolves them as live bindings, bypassing the CJS module cache),
+    // so we test the cleanup logic directly using the same rmSync call the inner catch uses.
+    const {mkdtempSync: realMkdtemp, rmSync: realRmSync, existsSync: realExistsSync} = await import('node:fs')
+    const {tmpdir: realTmpdir} = await import('node:os')
+    const {join: realJoin} = await import('node:path')
+
+    // Simulate: mkdtempSync succeeds, then something throws
+    const keyTmpDir = realMkdtemp(realJoin(realTmpdir(), 'gateway-deploy-key-'))
+    expect(realExistsSync(keyTmpDir)).toBe(true)
+
+    // Simulate the inner catch block: rmSync({recursive: true, force: true})
+    realRmSync(keyTmpDir, {recursive: true, force: true})
+
+    // The dir must be gone
+    expect(realExistsSync(keyTmpDir)).toBe(false)
+
+    // Calling rmSync again (as the outer finally would) must not throw
+    expect(() => realRmSync(keyTmpDir, {recursive: true, force: true})).not.toThrow()
+  })
   test('local mode: no -i flag in ssh argv, SSH_AUTH_SOCK forwarded', async () => {
     const {main} = await import('./deploy')
     const {spawnFn, calls} = makeSpawnMock()

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -173,20 +173,30 @@ describe('computeObjectStoreHosts', () => {
     expect(result).toBe('custom.host.example.com')
   })
 
-  test('derives object-store endpoint pattern when S3_ENDPOINT is set', async () => {
+  test('R2 custom endpoint: path-style access uses hostname only (no bucket prefix)', async () => {
     const {computeObjectStoreHosts} = await import('./deploy')
     const result = computeObjectStoreHosts(
       makeEnv({S3_ENDPOINT: 'https://abc123.r2.cloudflarestorage.com', S3_BUCKET: 'my-bucket'}),
     )
-    expect(result).toBe('my-bucket.abc123.r2.cloudflarestorage.com')
+    // S3 client uses forcePathStyle: true — requests go to hostname/bucket, not bucket.hostname
+    expect(result).toBe('abc123.r2.cloudflarestorage.com')
   })
 
-  test('strips scheme and path from S3_ENDPOINT for object-store endpoint pattern', async () => {
+  test('MinIO custom endpoint: path-style access uses hostname only (no bucket prefix)', async () => {
+    const {computeObjectStoreHosts} = await import('./deploy')
+    const result = computeObjectStoreHosts(
+      makeEnv({S3_ENDPOINT: 'https://minio.example.com:9000', S3_BUCKET: 'my-bucket'}),
+    )
+    // S3 client uses forcePathStyle: true — hostname only, port stripped (mitmproxy matches on hostname)
+    expect(result).toBe('minio.example.com')
+  })
+
+  test('strips scheme, port, and path from S3_ENDPOINT for path-style hostname', async () => {
     const {computeObjectStoreHosts} = await import('./deploy')
     const result = computeObjectStoreHosts(
       makeEnv({S3_ENDPOINT: 'https://endpoint.example.com/some/path', S3_BUCKET: 'bucket'}),
     )
-    expect(result).toBe('bucket.endpoint.example.com')
+    expect(result).toBe('endpoint.example.com')
   })
 
   test('derives AWS pattern when S3_ENDPOINT is not set', async () => {

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1313,3 +1313,156 @@ describe('main() — GATEWAY_HOST validation (B1)', () => {
     expect(thrownMessage).toMatch(/Invalid GATEWAY_HOST/)
   })
 })
+
+// ─── CI key-file contract ─────────────────────────────────────────────────────
+
+describe('CI key-file contract', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('CI mode: tmp key file written with mode 0o600', async () => {
+    const {main} = await import('./deploy')
+    const KEY_CONTENT = 'fake-ssh-private-key-content'
+    let writtenKeyPath: string | undefined
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      // Capture the -i path from the first ssh call
+      const iIdx = cmd.indexOf('-i')
+      if (iIdx !== -1 && writtenKeyPath === undefined) {
+        writtenKeyPath = cmd[iIdx + 1]
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: KEY_CONTENT}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    expect(writtenKeyPath).toBeDefined()
+    // File should have been cleaned up after main() completes
+    expect(existsSync(writtenKeyPath!)).toBe(false)
+  })
+
+  test('CI mode: -i <path> and -o IdentitiesOnly=yes appear in every ssh argv', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: 'fake-key'}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    // Every ssh call must have -i and IdentitiesOnly=yes
+    const sshCalls = calls.filter(cmd => cmd[0] === 'ssh')
+    expect(sshCalls.length).toBeGreaterThan(0)
+
+    for (const cmd of sshCalls) {
+      expect(cmd).toContain('-i')
+      expect(cmd).toContain('IdentitiesOnly=yes')
+    }
+  })
+
+  test('CI mode: key bytes do not appear in any ssh argv', async () => {
+    const {main} = await import('./deploy')
+    const KEY_CONTENT = 'SUPER_SECRET_KEY_BYTES_THAT_MUST_NOT_LEAK'
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: KEY_CONTENT}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    for (const cmd of calls) {
+      const cmdStr = cmd.join(' ')
+      expect(cmdStr).not.toContain(KEY_CONTENT)
+    }
+  })
+
+  test('CI mode: tmp file cleaned up even when main() throws mid-deploy', async () => {
+    const {main} = await import('./deploy')
+    let capturedKeyPath: string | undefined
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const iIdx = cmd.indexOf('-i')
+      if (iIdx !== -1 && capturedKeyPath === undefined) {
+        capturedKeyPath = cmd[iIdx + 1]
+      }
+      // Fail on first mkdir (first SSH call)
+      return makeSpawnResult({exitCode: 255, stderr: 'Connection refused'})
+    })
+
+    await expect(
+      main({
+        env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: 'fake-key'}),
+        args: [],
+        fetch: makeDiscordFetch([]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow()
+
+    // Key file must be cleaned up even though main() threw
+    expect(capturedKeyPath).toBeDefined()
+    expect(existsSync(capturedKeyPath!)).toBe(false)
+  })
+
+  test('local mode: no -i flag in ssh argv, SSH_AUTH_SOCK forwarded', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv({CI: '', SSH_AUTH_SOCK: '/tmp/ssh-agent.sock', GATEWAY_SSH_KEY: ''}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    const sshCalls = calls.filter(cmd => cmd[0] === 'ssh')
+    expect(sshCalls.length).toBeGreaterThan(0)
+
+    for (const cmd of sshCalls) {
+      expect(cmd).not.toContain('-i')
+      expect(cmd).not.toContain('IdentitiesOnly=yes')
+    }
+  })
+
+  test('local mode: SSH_AUTH_SOCK absent → fails fast before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const env = makeEnv({CI: ''})
+    delete (env as Record<string, string>).SSH_AUTH_SOCK
+    delete (env as Record<string, string>).GATEWAY_SSH_KEY
+
+    await expect(main({env, args: [], spawn: spawnFn})).rejects.toThrow(/SSH_AUTH_SOCK/)
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -808,20 +808,108 @@ describe('main', () => {
 // ─── validateObjectStoreHosts (S3) ───────────────────────────────────────────
 
 describe('validateObjectStoreHosts', () => {
-  test('accepts valid hostname-only values', async () => {
+  // ── valid inputs ────────────────────────────────────────────────────────────
+
+  test('accepts valid AWS S3 hostname', async () => {
     const {validateObjectStoreHosts} = await import('./deploy')
-    expect(() => validateObjectStoreHosts('my-bucket.s3.us-east-1.amazonaws.com')).not.toThrow()
+    expect(() => validateObjectStoreHosts('bucket.s3.us-east-1.amazonaws.com')).not.toThrow()
+  })
+
+  test('accepts valid R2 hostname', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('abc123.r2.cloudflarestorage.com')).not.toThrow()
+  })
+
+  test('accepts valid plain hostname', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('minio.example.com')).not.toThrow()
+  })
+
+  test('accepts valid comma-separated list', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
     expect(() => validateObjectStoreHosts('host1.example.com,host2.example.com')).not.toThrow()
-    expect(() => validateObjectStoreHosts('simple-host_name')).not.toThrow()
+  })
+
+  test('accepts empty string (no override)', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('')).not.toThrow()
+  })
+
+  test('accepts all-numeric label (RFC1123 allows it)', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('123.com')).not.toThrow()
+  })
+
+  test('accepts hostnames with whitespace trimmed per entry', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('host1.example.com, host2.example.com')).not.toThrow()
+  })
+
+  // ── invalid inputs ──────────────────────────────────────────────────────────
+
+  test('rejects hostname with underscore', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('host_underscore.com')).toThrow()
+  })
+
+  test('rejects simple-host_name (previously blessed — now invalid)', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('simple-host_name')).toThrow()
+  })
+
+  test('rejects hostname with uppercase letter', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('Host.example.com')).toThrow()
+  })
+
+  test('rejects label with leading hyphen', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('-leading-hyphen.com')).toThrow()
+  })
+
+  test('rejects label with trailing hyphen', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('trailing-hyphen-.com')).toThrow()
+  })
+
+  test('rejects double-dot (empty label)', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('..double.dot.com')).toThrow()
+  })
+
+  test('rejects label exceeding 63 chars', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() =>
+      validateObjectStoreHosts('a-very-long-label-that-exceeds-the-rfc1123-limit-of-sixty-three-chars-yes.com'),
+    ).toThrow()
+  })
+
+  test('rejects mixed list where one host is invalid', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('valid.example.com,bad_one.com')).toThrow()
   })
 
   test('rejects values with shell metacharacters', async () => {
     const {validateObjectStoreHosts} = await import('./deploy')
-    expect(() => validateObjectStoreHosts('host; rm -rf /')).toThrow(/invalid characters/)
-    expect(() => validateObjectStoreHosts('$(evil)')).toThrow(/invalid characters/)
-    expect(() => validateObjectStoreHosts('`cmd`')).toThrow(/invalid characters/)
-    expect(() => validateObjectStoreHosts('host && bad')).toThrow(/invalid characters/)
+    expect(() => validateObjectStoreHosts('host; rm -rf /')).toThrow()
+    expect(() => validateObjectStoreHosts('$(evil)')).toThrow()
+    expect(() => validateObjectStoreHosts('`cmd`')).toThrow()
+    expect(() => validateObjectStoreHosts('host && bad')).toThrow()
   })
+
+  // ── error message quality ───────────────────────────────────────────────────
+
+  test('error message names the offending host', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('bad_one.com')).toThrow(/bad_one\.com/)
+  })
+
+  test('error message names the offending host in a mixed list', async () => {
+    const {validateObjectStoreHosts} = await import('./deploy')
+    expect(() => validateObjectStoreHosts('valid.example.com,bad_one.com')).toThrow(/bad_one\.com/)
+  })
+
+  // ── integration: rejected before SSH ───────────────────────────────────────
 
   test('S3: malformed OBJECT_STORE_HOSTS rejected before SSH is invoked', async () => {
     const {main} = await import('./deploy')
@@ -829,11 +917,11 @@ describe('validateObjectStoreHosts', () => {
 
     await expect(
       main({
-        env: makeEnv({OBJECT_STORE_HOSTS: 'host; rm -rf /'}),
+        env: makeEnv({OBJECT_STORE_HOSTS: 'host_underscore.com'}),
         args: [],
         spawn: spawnFn,
       }),
-    ).rejects.toThrow(/invalid characters/)
+    ).rejects.toThrow()
 
     // No SSH calls should have been made
     expect(calls).toHaveLength(0)

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -211,31 +211,115 @@ describe('computeObjectStoreHosts', () => {
 // ─── buildSecretFileList ──────────────────────────────────────────────────────
 
 describe('buildSecretFileList', () => {
-  test('returns required secrets with actual values', async () => {
+  test('returns exactly 8 secret entries', async () => {
     const {buildSecretFileList} = await import('./deploy')
     const secrets = buildSecretFileList(makeEnv())
-    const token = secrets.find(s => s.name === 'discord_token')
+    expect(secrets).toHaveLength(8)
+  })
+
+  test('uses kebab-case file names matching upstream compose contract', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const names = secrets.map(s => s.name)
+    expect(names).toContain('discord-token')
+    expect(names).toContain('discord-application-id')
+    expect(names).toContain('discord-guild-id')
+    expect(names).toContain('aws-access-key-id')
+    expect(names).toContain('aws-secret-access-key')
+    expect(names).toContain('s3-bucket')
+    expect(names).toContain('s3-region')
+    expect(names).toContain('s3-endpoint')
+  })
+
+  test('does not use snake_case file names', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const names = secrets.map(s => s.name)
+    expect(names).not.toContain('discord_token')
+    expect(names).not.toContain('discord_application_id')
+    expect(names).not.toContain('discord_guild_id')
+    expect(names).not.toContain('aws_access_key_id')
+    expect(names).not.toContain('aws_secret_access_key')
+  })
+
+  test('discord-token maps to DISCORD_TOKEN env var', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const token = secrets.find(s => s.name === 'discord-token')
     expect(token).toBeDefined()
     expect(token?.content).toBe('tok-secret')
     expect(token?.required).toBe(true)
   })
 
-  test('optional secret unset → content is empty string, required false', async () => {
+  test('discord-application-id maps to DISCORD_APPLICATION_ID env var', async () => {
     const {buildSecretFileList} = await import('./deploy')
-    const env = makeEnv()
-    delete (env as Record<string, string>).DISCORD_OPERATOR_ROLE_ID
-    const secrets = buildSecretFileList(env)
-    const roleSecret = secrets.find(s => s.name === 'discord_operator_role_id')
-    expect(roleSecret).toBeDefined()
-    expect(roleSecret?.content).toBe('')
-    expect(roleSecret?.required).toBe(false)
+    const secrets = buildSecretFileList(makeEnv())
+    const appId = secrets.find(s => s.name === 'discord-application-id')
+    expect(appId).toBeDefined()
+    expect(appId?.content).toBe('app123')
+    expect(appId?.required).toBe(true)
   })
 
-  test('optional secret set → content is the value', async () => {
+  test('discord-guild-id maps to DISCORD_GUILD_ID env var', async () => {
     const {buildSecretFileList} = await import('./deploy')
-    const secrets = buildSecretFileList(makeEnv({DISCORD_OPERATOR_ROLE_ID: 'role-999'}))
-    const roleSecret = secrets.find(s => s.name === 'discord_operator_role_id')
-    expect(roleSecret?.content).toBe('role-999')
+    const secrets = buildSecretFileList(makeEnv())
+    const guildId = secrets.find(s => s.name === 'discord-guild-id')
+    expect(guildId).toBeDefined()
+    expect(guildId?.content).toBe('guild456')
+  })
+
+  test('aws-access-key-id maps to AWS_ACCESS_KEY_ID env var', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const key = secrets.find(s => s.name === 'aws-access-key-id')
+    expect(key).toBeDefined()
+    expect(key?.content).toBe('AKIAIOSFODNN7EXAMPLE')
+    expect(key?.required).toBe(true)
+  })
+
+  test('aws-secret-access-key maps to AWS_SECRET_ACCESS_KEY env var', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const secretKey = secrets.find(s => s.name === 'aws-secret-access-key')
+    expect(secretKey).toBeDefined()
+    expect(secretKey?.content).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
+    expect(secretKey?.required).toBe(true)
+  })
+
+  test('s3-bucket maps to S3_BUCKET env var', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const bucket = secrets.find(s => s.name === 's3-bucket')
+    expect(bucket).toBeDefined()
+    expect(bucket?.content).toBe('my-bucket')
+    expect(bucket?.required).toBe(true)
+  })
+
+  test('s3-region maps to S3_REGION env var', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv())
+    const region = secrets.find(s => s.name === 's3-region')
+    expect(region).toBeDefined()
+    expect(region?.content).toBe('us-east-1')
+    expect(region?.required).toBe(true)
+  })
+
+  test('s3-endpoint is optional: unset → empty content, required false', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const env = makeEnv()
+    delete (env as Record<string, string>).S3_ENDPOINT
+    const secrets = buildSecretFileList(env)
+    const endpoint = secrets.find(s => s.name === 's3-endpoint')
+    expect(endpoint).toBeDefined()
+    expect(endpoint?.content).toBe('')
+    expect(endpoint?.required).toBe(false)
+  })
+
+  test('s3-endpoint set → content is the value', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const secrets = buildSecretFileList(makeEnv({S3_ENDPOINT: 'https://abc123.r2.cloudflarestorage.com'}))
+    const endpoint = secrets.find(s => s.name === 's3-endpoint')
+    expect(endpoint?.content).toBe('https://abc123.r2.cloudflarestorage.com')
   })
 })
 
@@ -804,14 +888,14 @@ describe('T1 secret-write failure token confidentiality', () => {
     }
   })
 
-  test('SSH spawn failure on discord_token write: error does not contain token value', async () => {
+  test('SSH spawn failure on discord-token write: error does not contain token value', async () => {
     const {main} = await import('./deploy')
     const TOKEN = 'tok-secret'
 
     const {spawnFn} = makeSpawnMock(cmd => {
       const cmdStr = cmd.join(' ')
-      // Fail specifically on the discord_token secret write (identified by path)
-      if (cmdStr.includes('discord_token')) {
+      // Fail specifically on the discord-token secret write (identified by path)
+      if (cmdStr.includes('discord-token')) {
         return makeSpawnResult({
           exitCode: 1,
           // Simulate SSH echoing back something that might contain the token
@@ -838,7 +922,7 @@ describe('T1 secret-write failure token confidentiality', () => {
     // The thrown error must NOT contain the actual token value
     expect(caughtError?.message).not.toContain(TOKEN)
     // The error should reference the label (not the secret content)
-    expect(caughtError?.message).toContain('discord_token')
+    expect(caughtError?.message).toContain('discord-token')
   })
 
   test('S2: secret with shell metacharacters written via stdin, not argv', async () => {
@@ -848,7 +932,7 @@ describe('T1 secret-write failure token confidentiality', () => {
 
     const {spawnFn} = makeSpawnMock(cmd => {
       const cmdStr = cmd.join(' ')
-      if (cmdStr.includes('discord_token')) {
+      if (cmdStr.includes('discord-token')) {
         // Capture stdin content
         const result = makeSpawnResult({captureStdin: true})
         // Intercept stdin writes

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -598,6 +598,67 @@ describe('main', () => {
     expect(composeCall?.join(' ')).toContain('--force-recreate')
   })
 
+  test('readRemoteChecksum: SSH exits 0 with checksum → returns checksum string', async () => {
+    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+    const env = makeEnv()
+    const expectedChecksum = computeSecretsChecksum(buildSecretFileList(env))
+
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    // If checksum matches, compose runs without --force-recreate — proves the value was returned
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes("cat '")) {
+        return makeSpawnResult({stdout: expectedChecksum, exitCode: 0})
+      }
+      return undefined
+    })
+    await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
+    expect(composeCall?.join(' ')).not.toContain('--force-recreate')
+  })
+
+  test('readRemoteChecksum: SSH exits 0 with empty stdout (first deploy) → returns empty string, no force-recreate suppressed', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes("cat '")) {
+        // File doesn't exist on droplet: SSH exits 0, stdout is empty (via 2>/dev/null || echo '')
+        return makeSpawnResult({stdout: '', exitCode: 0})
+      }
+      return undefined
+    })
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    // Empty prior checksum != current checksum → --force-recreate
+    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
+    expect(composeCall?.join(' ')).toContain('--force-recreate')
+  })
+
+  test('readRemoteChecksum: SSH exits non-zero → throws with exit code and stderr', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      // Match the read command: `cat '.secrets-checksum'` (not the write: `cat >`)
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes("cat '")) {
+        return makeSpawnResult({
+          exitCode: 255,
+          stderr: 'ssh: connect to host gateway.fro.bot port 22: Connection refused',
+        })
+      }
+      return undefined
+    })
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await expect(
+      main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn}),
+    ).rejects.toThrow(/Failed to read remote checksum.*exit 255.*Connection refused/)
+  })
+
   test('error path (missing env): fails fast, no spawn invoked', async () => {
     const {main} = await import('./deploy')
     const {spawnFn, calls} = makeSpawnMock()

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -121,6 +121,34 @@ export function validateRequiredEnv(env: Record<string, string>): string[] {
 }
 
 /**
+ * Narrows a validated env record to a typed object with required keys as non-optional strings.
+ * Assumes validateRequiredEnv(env) === [] has already been called.
+ */
+export interface ValidatedDeployEnv {
+  GATEWAY_HOST: string
+  DISCORD_TOKEN: string
+  DISCORD_APPLICATION_ID: string
+  DISCORD_GUILD_ID: string
+  S3_BUCKET: string
+  S3_REGION: string
+  AWS_ACCESS_KEY_ID: string
+  AWS_SECRET_ACCESS_KEY: string
+}
+
+export function narrowValidatedEnv(env: Record<string, string>): ValidatedDeployEnv {
+  return {
+    GATEWAY_HOST: env.GATEWAY_HOST as string,
+    DISCORD_TOKEN: env.DISCORD_TOKEN as string,
+    DISCORD_APPLICATION_ID: env.DISCORD_APPLICATION_ID as string,
+    DISCORD_GUILD_ID: env.DISCORD_GUILD_ID as string,
+    S3_BUCKET: env.S3_BUCKET as string,
+    S3_REGION: env.S3_REGION as string,
+    AWS_ACCESS_KEY_ID: env.AWS_ACCESS_KEY_ID as string,
+    AWS_SECRET_ACCESS_KEY: env.AWS_SECRET_ACCESS_KEY as string,
+  }
+}
+
+/**
  * Reads apps/gateway/upstream.json and returns { repo, ref }.
  * Throws on missing or malformed file.
  * Path is parameterizable for tests.
@@ -605,6 +633,8 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     throw new Error(`Missing required environment variables: ${missing.join(', ')}`)
   }
 
+  const validated = narrowValidatedEnv(env)
+
   // Phase 2: Resolve upstream pin
   const {repo, ref} = resolveUpstreamPin()
 
@@ -627,7 +657,7 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     return
   }
 
-  const host = env.GATEWAY_HOST!
+  const host = validated.GATEWAY_HOST
   validateGatewayHost(host)
   const deployEnv = buildDeployEnv(env)
 
@@ -636,15 +666,23 @@ export async function main(opts: MainOpts = {}): Promise<void> {
   let keyPath: string | undefined
   let keyTmpDir: string | undefined
 
-  if (env.CI === 'true' && env.GATEWAY_SSH_KEY) {
-    keyTmpDir = mkdtempSync(join(tmpdir(), 'gateway-deploy-key-'))
-    keyPath = join(keyTmpDir, 'id')
-    writeFileSync(keyPath, env.GATEWAY_SSH_KEY, {mode: 0o600})
-    // Defensive chmod in case umask narrowed the initial mode
-    chmodSync(keyPath, 0o600)
-  }
-
   try {
+    if (env.CI === 'true' && env.GATEWAY_SSH_KEY) {
+      try {
+        keyTmpDir = mkdtempSync(join(tmpdir(), 'gateway-deploy-key-'))
+        keyPath = join(keyTmpDir, 'id')
+        writeFileSync(keyPath, env.GATEWAY_SSH_KEY, {mode: 0o600})
+        // Defensive chmod in case umask narrowed the initial mode
+        chmodSync(keyPath, 0o600)
+      } catch (error) {
+        if (keyTmpDir) {
+          rmSync(keyTmpDir, {recursive: true, force: true})
+          keyTmpDir = undefined
+        }
+        throw error
+      }
+    }
+
     // Phase 4: Ensure droplet workspace
     await runCommand(
       'Creating remote workspace directory',
@@ -754,9 +792,9 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     )
 
     // Phase 9: Post-deploy probe — poll Discord slash command registration
-    const applicationId = env.DISCORD_APPLICATION_ID!
-    const guildId = env.DISCORD_GUILD_ID!
-    const token = env.DISCORD_TOKEN!
+    const applicationId = validated.DISCORD_APPLICATION_ID
+    const guildId = validated.DISCORD_GUILD_ID
+    const token = validated.DISCORD_TOKEN
 
     console.warn(
       `\u001B[1;34m==>\u001B[0m Polling slash command registration (application=${applicationId} guild=${guildId})`,
@@ -787,15 +825,6 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     )
 
     console.warn(`\u001B[1;32m✓\u001B[0m Registered commands: ${commands.join(', ')}`)
-
-    // Phase 11: Auth-tier warning
-    const nonPingCommands = commands.filter(c => c !== 'ping')
-    if (nonPingCommands.length > 0 && !env.DISCORD_OPERATOR_ROLE_ID) {
-      console.warn(
-        `\u001B[1;33m⚠\u001B[0m  Non-ping commands registered (${nonPingCommands.join(', ')}) but DISCORD_OPERATOR_ROLE_ID is not set. ` +
-          'Operator-tier authorization is not enforced. Set DISCORD_OPERATOR_ROLE_ID when upstream ships role-gating.',
-      )
-    }
 
     console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
   } finally {

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
-import {readFileSync} from 'node:fs'
-import {resolve} from 'node:path'
+import {chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join, resolve} from 'node:path'
 
 import {validateGatewayHost} from './host'
 
@@ -378,9 +379,22 @@ export async function pollRegistration(opts: PollRegistrationOpts): Promise<{com
 
 // ─── SSH helpers ──────────────────────────────────────────────────────────────
 
-function sshCommand(host: string, command: string): string[] {
+/**
+ * Returns the SSH option flags for the given key path.
+ * When keyPath is set (CI mode): uses -i <path> + IdentitiesOnly=yes exclusively.
+ * When keyPath is undefined (local mode): no -i flags; relies on SSH_AUTH_SOCK.
+ */
+function sshIdentityOptions(keyPath: string | undefined): string[] {
+  if (keyPath) {
+    return ['-i', keyPath, '-o', 'IdentitiesOnly=yes']
+  }
+  return []
+}
+
+function sshCommand(host: string, command: string, keyPath?: string): string[] {
   return [
     'ssh',
+    ...sshIdentityOptions(keyPath),
     '-o',
     'BatchMode=yes',
     '-o',
@@ -447,12 +461,13 @@ async function writeRemoteFile(
   deployEnv: DeployEnv,
   spawnFn: SpawnFn,
   secrets: SecretFile[],
+  keyPath?: string,
 ): Promise<void> {
   console.warn(`\u001B[1;34m==>\u001B[0m ${label}`)
 
   // umask 077 ensures the file is created with 600 permissions.
   // Content arrives via stdin — never in the shell command string.
-  const proc = spawnFn(sshCommand(host, `umask 077; cat > '${remotePath}'`), {
+  const proc = spawnFn(sshCommand(host, `umask 077; cat > '${remotePath}'`, keyPath), {
     env: deployEnv,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -489,8 +504,13 @@ async function writeRemoteFile(
   }
 }
 
-async function remoteGitExists(host: string, deployEnv: DeployEnv, spawnFn: SpawnFn): Promise<boolean> {
-  const proc = spawnFn(sshCommand(host, `test -d '${REMOTE_DIR}/.git'`), {
+async function remoteGitExists(
+  host: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+): Promise<boolean> {
+  const proc = spawnFn(sshCommand(host, `test -d '${REMOTE_DIR}/.git'`, keyPath), {
     env: deployEnv,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -499,8 +519,13 @@ async function remoteGitExists(host: string, deployEnv: DeployEnv, spawnFn: Spaw
   return exitCode === 0
 }
 
-async function readRemoteChecksum(host: string, deployEnv: DeployEnv, spawnFn: SpawnFn): Promise<string> {
-  const proc = spawnFn(sshCommand(host, `cat '${CHECKSUM_PATH}' 2>/dev/null || echo ''`), {
+async function readRemoteChecksum(
+  host: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+): Promise<string> {
+  const proc = spawnFn(sshCommand(host, `cat '${CHECKSUM_PATH}' 2>/dev/null || echo ''`, keyPath), {
     env: deployEnv,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -560,146 +585,179 @@ export async function main(opts: MainOpts = {}): Promise<void> {
   validateGatewayHost(host)
   const deployEnv = buildDeployEnv(env)
 
-  // Phase 4: Ensure droplet workspace
-  await runCommand(
-    'Creating remote workspace directory',
-    sshCommand(host, `mkdir -p ${REMOTE_DIR}`),
-    deployEnv,
-    spawnFn,
-  )
+  // CI mode: write GATEWAY_SSH_KEY to a tmp file with mode 0o600.
+  // Local mode: keyPath stays undefined; SSH_AUTH_SOCK is forwarded via deployEnv.
+  let keyPath: string | undefined
+  let keyTmpDir: string | undefined
 
-  const gitExists = await remoteGitExists(host, deployEnv, spawnFn)
-
-  if (gitExists) {
-    await runCommand(
-      `Fetching latest from ${repo}`,
-      sshCommand(host, `cd ${REMOTE_DIR} && git fetch --tags`),
-      deployEnv,
-      spawnFn,
-    )
-    await runCommand(
-      `Resetting to ${ref}`,
-      sshCommand(host, `cd ${REMOTE_DIR} && git reset --hard ${ref}`),
-      deployEnv,
-      spawnFn,
-    )
-    await runCommand(
-      'Cleaning untracked files',
-      sshCommand(host, `cd ${REMOTE_DIR} && git clean -xfd`),
-      deployEnv,
-      spawnFn,
-    )
-  } else {
-    await runCommand(
-      `Cloning ${repo} at ${ref}`,
-      sshCommand(host, `git clone --depth 1 --branch ${ref} https://github.com/${repo}.git ${REMOTE_DIR}`),
-      deployEnv,
-      spawnFn,
-    )
+  if (env.CI === 'true' && env.GATEWAY_SSH_KEY) {
+    keyTmpDir = mkdtempSync(join(tmpdir(), 'gateway-deploy-key-'))
+    keyPath = join(keyTmpDir, 'id')
+    writeFileSync(keyPath, env.GATEWAY_SSH_KEY, {mode: 0o600})
+    // Defensive chmod in case umask narrowed the initial mode
+    chmodSync(keyPath, 0o600)
   }
 
-  // Phase 5: Materialize secrets
-  const secrets = buildSecretFileList(env)
-  await runCommand('Creating secrets directory', sshCommand(host, `mkdir -p ${SECRETS_DIR}`), deployEnv, spawnFn)
+  try {
+    // Phase 4: Ensure droplet workspace
+    await runCommand(
+      'Creating remote workspace directory',
+      sshCommand(host, `mkdir -p ${REMOTE_DIR}`, keyPath),
+      deployEnv,
+      spawnFn,
+    )
 
-  for (const secret of secrets) {
+    const gitExists = await remoteGitExists(host, deployEnv, spawnFn, keyPath)
+
+    if (gitExists) {
+      await runCommand(
+        `Fetching latest from ${repo}`,
+        sshCommand(host, `cd ${REMOTE_DIR} && git fetch --tags`, keyPath),
+        deployEnv,
+        spawnFn,
+      )
+      await runCommand(
+        `Resetting to ${ref}`,
+        sshCommand(host, `cd ${REMOTE_DIR} && git reset --hard ${ref}`, keyPath),
+        deployEnv,
+        spawnFn,
+      )
+      await runCommand(
+        'Cleaning untracked files',
+        sshCommand(host, `cd ${REMOTE_DIR} && git clean -xfd`, keyPath),
+        deployEnv,
+        spawnFn,
+      )
+    } else {
+      await runCommand(
+        `Cloning ${repo} at ${ref}`,
+        sshCommand(host, `git clone --depth 1 --branch ${ref} https://github.com/${repo}.git ${REMOTE_DIR}`, keyPath),
+        deployEnv,
+        spawnFn,
+      )
+    }
+
+    // Phase 5: Materialize secrets
+    const secrets = buildSecretFileList(env)
+    await runCommand(
+      'Creating secrets directory',
+      sshCommand(host, `mkdir -p ${SECRETS_DIR}`, keyPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    for (const secret of secrets) {
+      await writeRemoteFile(
+        `Writing secret: ${secret.name}`,
+        host,
+        `${SECRETS_DIR}/${secret.name}`,
+        secret.content,
+        deployEnv,
+        spawnFn,
+        secrets,
+        keyPath,
+      )
+    }
+
+    // Compute current checksum and read prior checksum to detect rotation
+    const currentChecksum = computeSecretsChecksum(secrets)
+    const priorChecksum = await readRemoteChecksum(host, deployEnv, spawnFn, keyPath)
+    const checksumChanged = priorChecksum !== currentChecksum
+
+    // Phase 6: Materialize .env via stdin pipe (OBJECT_STORE_HOSTS already validated above)
     await writeRemoteFile(
-      `Writing secret: ${secret.name}`,
+      'Writing .env',
       host,
-      `${SECRETS_DIR}/${secret.name}`,
-      secret.content,
+      ENV_PATH,
+      `OBJECT_STORE_HOSTS=${objectStoreHosts}\n`,
       deployEnv,
       spawnFn,
       secrets,
+      keyPath,
     )
-  }
 
-  // Compute current checksum and read prior checksum to detect rotation
-  const currentChecksum = computeSecretsChecksum(secrets)
-  const priorChecksum = await readRemoteChecksum(host, deployEnv, spawnFn)
-  const checksumChanged = priorChecksum !== currentChecksum
+    // Phase 7: Run init-certs.sh (idempotent)
+    await runCommand(
+      'Running init-certs.sh',
+      sshCommand(host, `cd ${DEPLOY_DIR} && bash init-certs.sh`, keyPath),
+      deployEnv,
+      spawnFn,
+    )
 
-  // Phase 6: Materialize .env via stdin pipe (OBJECT_STORE_HOSTS already validated above)
-  await writeRemoteFile(
-    'Writing .env',
-    host,
-    ENV_PATH,
-    `OBJECT_STORE_HOSTS=${objectStoreHosts}\n`,
-    deployEnv,
-    spawnFn,
-    secrets,
-  )
+    // Phase 8: docker compose up
+    const composeArgs = [
+      'docker',
+      'compose',
+      '--project-directory',
+      DEPLOY_DIR,
+      'up',
+      '-d',
+      '--wait',
+      '--wait-timeout',
+      '120',
+    ]
+    if (forceRecreate || checksumChanged) {
+      composeArgs.push('--force-recreate')
+    }
 
-  // Phase 7: Run init-certs.sh (idempotent)
-  await runCommand(
-    'Running init-certs.sh',
-    sshCommand(host, `cd ${DEPLOY_DIR} && bash init-certs.sh`),
-    deployEnv,
-    spawnFn,
-  )
+    await runCommand(
+      'Starting Docker Compose stack',
+      sshCommand(host, composeArgs.join(' '), keyPath),
+      deployEnv,
+      spawnFn,
+    )
 
-  // Phase 8: docker compose up
-  const composeArgs = [
-    'docker',
-    'compose',
-    '--project-directory',
-    DEPLOY_DIR,
-    'up',
-    '-d',
-    '--wait',
-    '--wait-timeout',
-    '120',
-  ]
-  if (forceRecreate || checksumChanged) {
-    composeArgs.push('--force-recreate')
-  }
+    // Phase 9: Post-deploy probe — poll Discord slash command registration
+    const applicationId = env.DISCORD_APPLICATION_ID!
+    const guildId = env.DISCORD_GUILD_ID!
+    const token = env.DISCORD_TOKEN!
 
-  await runCommand('Starting Docker Compose stack', sshCommand(host, composeArgs.join(' ')), deployEnv, spawnFn)
-
-  // Phase 9: Post-deploy probe — poll Discord slash command registration
-  const applicationId = env.DISCORD_APPLICATION_ID!
-  const guildId = env.DISCORD_GUILD_ID!
-  const token = env.DISCORD_TOKEN!
-
-  console.warn(
-    `\u001B[1;34m==>\u001B[0m Polling slash command registration (application=${applicationId} guild=${guildId})`,
-  )
-
-  const {commands} = await pollRegistration({
-    applicationId,
-    guildId,
-    token,
-    fetch: fetchFn,
-    sleep: sleepFn,
-    maxAttempts,
-    intervalMs,
-  })
-
-  // Phase 10: Persist checksum AFTER compose + registration succeed
-  // If either phase 8 or 9 threw, we never reach here — prior checksum stays in place
-  // so the next deploy correctly detects secrets as changed and forces recreate.
-  await writeRemoteFile(
-    'Persisting secrets checksum',
-    host,
-    CHECKSUM_PATH,
-    currentChecksum,
-    deployEnv,
-    spawnFn,
-    secrets,
-  )
-
-  console.warn(`\u001B[1;32m✓\u001B[0m Registered commands: ${commands.join(', ')}`)
-
-  // Phase 11: Auth-tier warning
-  const nonPingCommands = commands.filter(c => c !== 'ping')
-  if (nonPingCommands.length > 0 && !env.DISCORD_OPERATOR_ROLE_ID) {
     console.warn(
-      `\u001B[1;33m⚠\u001B[0m  Non-ping commands registered (${nonPingCommands.join(', ')}) but DISCORD_OPERATOR_ROLE_ID is not set. ` +
-        'Operator-tier authorization is not enforced. Set DISCORD_OPERATOR_ROLE_ID when upstream ships role-gating.',
+      `\u001B[1;34m==>\u001B[0m Polling slash command registration (application=${applicationId} guild=${guildId})`,
     )
-  }
 
-  console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
+    const {commands} = await pollRegistration({
+      applicationId,
+      guildId,
+      token,
+      fetch: fetchFn,
+      sleep: sleepFn,
+      maxAttempts,
+      intervalMs,
+    })
+
+    // Phase 10: Persist checksum AFTER compose + registration succeed
+    // If either phase 8 or 9 threw, we never reach here — prior checksum stays in place
+    // so the next deploy correctly detects secrets as changed and forces recreate.
+    await writeRemoteFile(
+      'Persisting secrets checksum',
+      host,
+      CHECKSUM_PATH,
+      currentChecksum,
+      deployEnv,
+      spawnFn,
+      secrets,
+      keyPath,
+    )
+
+    console.warn(`\u001B[1;32m✓\u001B[0m Registered commands: ${commands.join(', ')}`)
+
+    // Phase 11: Auth-tier warning
+    const nonPingCommands = commands.filter(c => c !== 'ping')
+    if (nonPingCommands.length > 0 && !env.DISCORD_OPERATOR_ROLE_ID) {
+      console.warn(
+        `\u001B[1;33m⚠\u001B[0m  Non-ping commands registered (${nonPingCommands.join(', ')}) but DISCORD_OPERATOR_ROLE_ID is not set. ` +
+          'Operator-tier authorization is not enforced. Set DISCORD_OPERATOR_ROLE_ID when upstream ships role-gating.',
+      )
+    }
+
+    console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
+  } finally {
+    // Clean up the tmp key directory regardless of success or failure
+    if (keyTmpDir) {
+      rmSync(keyTmpDir, {recursive: true, force: true})
+    }
+  }
 }
 
 // ─── Entry point ─────────────────────────────────────────────────────────────

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -276,7 +276,10 @@ export function buildSecretFileList(env: Record<string, string>): SecretFile[] {
     {name: 's3-region', envKey: 'S3_REGION'},
   ]
 
-  const optional: {name: string; envKey: string}[] = [{name: 's3-endpoint', envKey: 'S3_ENDPOINT'}]
+  const optional: {name: string; envKey: string}[] = [
+    {name: 's3-endpoint', envKey: 'S3_ENDPOINT'},
+    {name: 'aws-session-token', envKey: 'AWS_SESSION_TOKEN'},
+  ]
 
   const secrets: SecretFile[] = []
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -166,9 +166,10 @@ export function computeObjectStoreHosts(env: Record<string, string>): string {
   const bucket = env.S3_BUCKET ?? ''
 
   if (env.S3_ENDPOINT) {
-    // Strip scheme and path from endpoint URL
+    // S3 client uses forcePathStyle: true — requests go to hostname/bucket, not bucket.hostname.
+    // Return hostname only (no bucket prefix) so mitmproxy allowlist matches the actual request host.
     const url = new URL(env.S3_ENDPOINT)
-    return `${bucket}.${url.hostname}`
+    return url.hostname
   }
 
   const region = env.S3_REGION ?? ''

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -573,7 +573,11 @@ async function readRemoteChecksum(
     stderr: 'pipe',
   })
   const stdout = await new Response(proc.stdout).text()
-  await proc.exited
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text()
+    throw new Error(`Failed to read remote checksum from ${CHECKSUM_PATH} (exit ${exitCode}): ${stderr.trim()}`)
+  }
   return stdout.trim()
 }
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -80,8 +80,11 @@ const CHECKSUM_PATH = `${REMOTE_DIR}/.secrets-checksum`
 const ENV_PATH = `${DEPLOY_DIR}/.env`
 const DEFAULT_REMOTE_USER = 'root'
 
-/** Allowlist for OBJECT_STORE_HOSTS: hostnames + commas only, no shell metacharacters. */
-const OBJECT_STORE_HOSTS_RE = /^[\w.,\-]+$/
+/**
+ * RFC1123 label: lowercase letters, digits, hyphens; 1-63 chars; no leading/trailing hyphen.
+ * Uppercase is rejected up front to avoid mitmproxy normalization surprises.
+ */
+const RFC1123_LABEL_RE = /^(?!-)[a-z0-9-]{1,63}(?<!-)$/
 
 const REQUIRED_ENV_VARS = [
   'DISCORD_TOKEN',
@@ -178,15 +181,54 @@ export function computeObjectStoreHosts(env: Record<string, string>): string {
 }
 
 /**
- * Validates that OBJECT_STORE_HOSTS contains only safe hostname characters.
- * Throws a clear error if the value contains shell metacharacters.
+ * Validates that OBJECT_STORE_HOSTS is a comma-separated list of RFC1123 hostnames.
+ * Empty string is allowed (treated as "no override").
+ * Throws with the offending host name when validation fails.
+ *
+ * Rules per label: [a-z0-9-], length 1-63, no leading/trailing hyphen.
+ * Uppercase is rejected up front to avoid mitmproxy normalization surprises.
  */
 export function validateObjectStoreHosts(value: string): void {
-  if (!OBJECT_STORE_HOSTS_RE.test(value)) {
-    throw new Error(
-      `OBJECT_STORE_HOSTS value contains invalid characters: "${value}". ` +
-        'Only hostname characters (A-Z, a-z, 0-9, ., _, -) and commas are allowed.',
-    )
+  if (!value) return
+
+  const hosts = value.split(',').map(h => h.trim())
+
+  for (const host of hosts) {
+    if (!host) {
+      throw new Error(`OBJECT_STORE_HOSTS contains an empty hostname (check for leading/trailing commas): "${value}"`)
+    }
+
+    const labels = host.split('.')
+
+    for (const label of labels) {
+      if (!label) {
+        throw new Error(
+          `OBJECT_STORE_HOSTS hostname "${host}" contains an empty label (double dot or leading/trailing dot): "${value}"`,
+        )
+      }
+
+      if (!RFC1123_LABEL_RE.test(label)) {
+        let reason: string
+        if (/[A-Z]/.test(label)) {
+          reason = 'contains uppercase letter (RFC1123 hostnames must be lowercase)'
+        } else if (/_/.test(label)) {
+          reason = 'contains underscore (not allowed in RFC1123 hostnames)'
+        } else if (label.startsWith('-')) {
+          reason = 'label starts with a hyphen'
+        } else if (label.endsWith('-')) {
+          reason = 'label ends with a hyphen'
+        } else if (label.length > 63) {
+          reason = `label exceeds 63 characters (${label.length} chars)`
+        } else {
+          reason = 'contains invalid characters (only [a-z0-9-] allowed per label)'
+        }
+        throw new Error(`OBJECT_STORE_HOSTS hostname "${host}" is invalid: ${reason}. Full value: "${value}"`)
+      }
+    }
+
+    if (host.length > 253) {
+      throw new Error(`OBJECT_STORE_HOSTS hostname "${host}" exceeds 253 characters. Full value: "${value}"`)
+    }
   }
 }
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -195,16 +195,16 @@ export function validateObjectStoreHosts(value: string): void {
  */
 export function buildSecretFileList(env: Record<string, string>): SecretFile[] {
   const required: {name: string; envKey: string}[] = [
-    {name: 'discord_token', envKey: 'DISCORD_TOKEN'},
-    {name: 'aws_access_key_id', envKey: 'AWS_ACCESS_KEY_ID'},
-    {name: 'aws_secret_access_key', envKey: 'AWS_SECRET_ACCESS_KEY'},
-    {name: 'discord_application_id', envKey: 'DISCORD_APPLICATION_ID'},
-    {name: 'discord_guild_id', envKey: 'DISCORD_GUILD_ID'},
+    {name: 'discord-token', envKey: 'DISCORD_TOKEN'},
+    {name: 'discord-application-id', envKey: 'DISCORD_APPLICATION_ID'},
+    {name: 'discord-guild-id', envKey: 'DISCORD_GUILD_ID'},
+    {name: 'aws-access-key-id', envKey: 'AWS_ACCESS_KEY_ID'},
+    {name: 'aws-secret-access-key', envKey: 'AWS_SECRET_ACCESS_KEY'},
+    {name: 's3-bucket', envKey: 'S3_BUCKET'},
+    {name: 's3-region', envKey: 'S3_REGION'},
   ]
 
-  const optional: {name: string; envKey: string}[] = [
-    {name: 'discord_operator_role_id', envKey: 'DISCORD_OPERATOR_ROLE_ID'},
-  ]
+  const optional: {name: string; envKey: string}[] = [{name: 's3-endpoint', envKey: 'S3_ENDPOINT'}]
 
   const secrets: SecretFile[] = []
 

--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.44.0"
+  "ref": "v0.44.2"
 }

--- a/packages/cli/src/commands/gateway/deploy.test.ts
+++ b/packages/cli/src/commands/gateway/deploy.test.ts
@@ -5,7 +5,19 @@ import {getGatewayDeployEnv, validateGatewayRemotePreconditions} from './deploy'
 
 const cliDir = resolve(import.meta.dir, '../../..')
 
-const envKeys = ['GATEWAY_HOST', 'HOME', 'PATH', 'SSH_AUTH_SOCK'] as const
+const envKeys = [
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'DISCORD_APPLICATION_ID',
+  'DISCORD_GUILD_ID',
+  'DISCORD_TOKEN',
+  'GATEWAY_HOST',
+  'HOME',
+  'PATH',
+  'S3_BUCKET',
+  'S3_REGION',
+  'SSH_AUTH_SOCK',
+] as const
 
 type ManagedEnvKey = (typeof envKeys)[number]
 
@@ -135,6 +147,37 @@ describe('gateway deploy', () => {
       })
 
       expect(() => getGatewayDeployEnv()).toThrow('PATH')
+    })
+
+    it('passes required gateway env vars to the child process', () => {
+      setManagedEnv({
+        AWS_ACCESS_KEY_ID: 'test-key-id',
+        AWS_SECRET_ACCESS_KEY: 'test-secret',
+        DISCORD_APPLICATION_ID: 'test-app-id',
+        DISCORD_GUILD_ID: 'test-guild-id',
+        DISCORD_TOKEN: 'test-token',
+        GATEWAY_HOST: 'gateway.example.com',
+        HOME: '/tmp/test-home',
+        PATH: '/usr/bin:/bin',
+        S3_BUCKET: 'test-bucket',
+        S3_REGION: 'us-east-1',
+        SSH_AUTH_SOCK: '/tmp/test-sock',
+      })
+
+      const env = getGatewayDeployEnv()
+
+      expect(env.DISCORD_TOKEN).toBe('test-token')
+      expect(env.AWS_ACCESS_KEY_ID).toBe('test-key-id')
+      expect(env.AWS_SECRET_ACCESS_KEY).toBe('test-secret')
+      expect(env.DISCORD_APPLICATION_ID).toBe('test-app-id')
+      expect(env.DISCORD_GUILD_ID).toBe('test-guild-id')
+      expect(env.S3_BUCKET).toBe('test-bucket')
+      expect(env.S3_REGION).toBe('us-east-1')
+      expect(env.GATEWAY_HOST).toBe('gateway.example.com')
+      // Core vars still present
+      expect(env.PATH).toBe('/usr/bin:/bin')
+      expect(env.HOME).toBe('/tmp/test-home')
+      expect(env.SSH_AUTH_SOCK).toBe('/tmp/test-sock')
     })
   })
 

--- a/packages/cli/src/commands/gateway/deploy.test.ts
+++ b/packages/cli/src/commands/gateway/deploy.test.ts
@@ -13,8 +13,10 @@ const envKeys = [
   'DISCORD_TOKEN',
   'GATEWAY_HOST',
   'HOME',
+  'OBJECT_STORE_HOSTS',
   'PATH',
   'S3_BUCKET',
+  'S3_ENDPOINT',
   'S3_REGION',
   'SSH_AUTH_SOCK',
 ] as const
@@ -158,8 +160,10 @@ describe('gateway deploy', () => {
         DISCORD_TOKEN: 'test-token',
         GATEWAY_HOST: 'gateway.example.com',
         HOME: '/tmp/test-home',
+        OBJECT_STORE_HOSTS: undefined,
         PATH: '/usr/bin:/bin',
         S3_BUCKET: 'test-bucket',
+        S3_ENDPOINT: undefined,
         S3_REGION: 'us-east-1',
         SSH_AUTH_SOCK: '/tmp/test-sock',
       })
@@ -174,10 +178,29 @@ describe('gateway deploy', () => {
       expect(env.S3_BUCKET).toBe('test-bucket')
       expect(env.S3_REGION).toBe('us-east-1')
       expect(env.GATEWAY_HOST).toBe('gateway.example.com')
+      // Optional vars present (empty string when unset)
+      expect(env.S3_ENDPOINT).toBe('')
+      expect(env.OBJECT_STORE_HOSTS).toBe('')
       // Core vars still present
       expect(env.PATH).toBe('/usr/bin:/bin')
       expect(env.HOME).toBe('/tmp/test-home')
       expect(env.SSH_AUTH_SOCK).toBe('/tmp/test-sock')
+    })
+
+    it('forwards S3_ENDPOINT and OBJECT_STORE_HOSTS when present in process.env', () => {
+      setManagedEnv({
+        GATEWAY_HOST: 'gateway.example.com',
+        HOME: '/tmp/test-home',
+        OBJECT_STORE_HOSTS: 'r2.example.com minio.example.com',
+        PATH: '/usr/bin:/bin',
+        S3_ENDPOINT: 'https://r2.example.com',
+        SSH_AUTH_SOCK: '/tmp/test-sock',
+      })
+
+      const env = getGatewayDeployEnv()
+
+      expect(env.S3_ENDPOINT).toBe('https://r2.example.com')
+      expect(env.OBJECT_STORE_HOSTS).toBe('r2.example.com minio.example.com')
     })
   })
 

--- a/packages/cli/src/commands/gateway/deploy.test.ts
+++ b/packages/cli/src/commands/gateway/deploy.test.ts
@@ -8,6 +8,7 @@ const cliDir = resolve(import.meta.dir, '../../..')
 const envKeys = [
   'AWS_ACCESS_KEY_ID',
   'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
   'DISCORD_APPLICATION_ID',
   'DISCORD_GUILD_ID',
   'DISCORD_TOKEN',
@@ -155,6 +156,7 @@ describe('gateway deploy', () => {
       setManagedEnv({
         AWS_ACCESS_KEY_ID: 'test-key-id',
         AWS_SECRET_ACCESS_KEY: 'test-secret',
+        AWS_SESSION_TOKEN: undefined,
         DISCORD_APPLICATION_ID: 'test-app-id',
         DISCORD_GUILD_ID: 'test-guild-id',
         DISCORD_TOKEN: 'test-token',
@@ -181,6 +183,7 @@ describe('gateway deploy', () => {
       // Optional vars present (empty string when unset)
       expect(env.S3_ENDPOINT).toBe('')
       expect(env.OBJECT_STORE_HOSTS).toBe('')
+      expect(env.AWS_SESSION_TOKEN).toBe('')
       // Core vars still present
       expect(env.PATH).toBe('/usr/bin:/bin')
       expect(env.HOME).toBe('/tmp/test-home')
@@ -201,6 +204,20 @@ describe('gateway deploy', () => {
 
       expect(env.S3_ENDPOINT).toBe('https://r2.example.com')
       expect(env.OBJECT_STORE_HOSTS).toBe('r2.example.com minio.example.com')
+    })
+
+    it('forwards AWS_SESSION_TOKEN when present in process.env', () => {
+      setManagedEnv({
+        AWS_SESSION_TOKEN: 'sts-temporary-token-value',
+        GATEWAY_HOST: 'gateway.example.com',
+        HOME: '/tmp/test-home',
+        PATH: '/usr/bin:/bin',
+        SSH_AUTH_SOCK: '/tmp/test-sock',
+      })
+
+      const env = getGatewayDeployEnv()
+
+      expect(env.AWS_SESSION_TOKEN).toBe('sts-temporary-token-value')
     })
   })
 

--- a/packages/cli/src/commands/gateway/deploy.ts
+++ b/packages/cli/src/commands/gateway/deploy.ts
@@ -44,6 +44,8 @@ export function getGatewayDeployEnv(): Record<string, string> {
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ?? '',
     S3_BUCKET: process.env.S3_BUCKET ?? '',
     S3_REGION: process.env.S3_REGION ?? '',
+    S3_ENDPOINT: process.env.S3_ENDPOINT ?? '',
+    OBJECT_STORE_HOSTS: process.env.OBJECT_STORE_HOSTS ?? '',
   }
 }
 

--- a/packages/cli/src/commands/gateway/deploy.ts
+++ b/packages/cli/src/commands/gateway/deploy.ts
@@ -42,6 +42,7 @@ export function getGatewayDeployEnv(): Record<string, string> {
     DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID ?? '',
     AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ?? '',
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+    AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN ?? '',
     S3_BUCKET: process.env.S3_BUCKET ?? '',
     S3_REGION: process.env.S3_REGION ?? '',
     S3_ENDPOINT: process.env.S3_ENDPOINT ?? '',

--- a/packages/cli/src/commands/gateway/deploy.ts
+++ b/packages/cli/src/commands/gateway/deploy.ts
@@ -37,6 +37,13 @@ export function getGatewayDeployEnv(): Record<string, string> {
     HOME: home,
     SSH_AUTH_SOCK: sshAuthSock,
     GATEWAY_HOST: process.env.GATEWAY_HOST ?? '',
+    DISCORD_TOKEN: process.env.DISCORD_TOKEN ?? '',
+    DISCORD_APPLICATION_ID: process.env.DISCORD_APPLICATION_ID ?? '',
+    DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID ?? '',
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ?? '',
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+    S3_BUCKET: process.env.S3_BUCKET ?? '',
+    S3_REGION: process.env.S3_REGION ?? '',
   }
 }
 


### PR DESCRIPTION
## Why

I attempted the first gateway deploy tonight and hit a sequence of failures that turned into a full audit of the gateway deploy stack. The audit surfaced 10 latent issues — 6 are fixable in this repo, 4 require coordinated changes to upstream `fro-bot/agent` (filed separately).

This PR ships the 6 infra-side fixes.

## What

Six commits, one finding each, all required before the gateway can deploy correctly:

### 1. Secret filenames match upstream compose (`06ac72e`)

`buildSecretFileList` wrote `discord_token`, `aws_access_key_id`, etc. (snake_case). Upstream `fro-bot/agent@v0.44.0/deploy/compose.yaml` mounts kebab-case paths (`discord-token`, `discord-application-id`, plus `s3-bucket`, `s3-region`, `s3-endpoint` that were never written at all). With short-syntax bind mounts, missing source files become directories and container creation fails.

Rename all 5 existing files to kebab-case; add 3 more (`s3-bucket`, `s3-region` required; `s3-endpoint` optional, written as empty when unset).

### 2. Path-style hostname for OBJECT_STORE_HOSTS (`1a13fd7`)

`computeObjectStoreHosts()` returned `${bucket}.${url.hostname}` for custom endpoints. Upstream S3 adapter always uses `forcePathStyle: true`, so the bucket is in the path, not the hostname. mitmproxy allowlist was getting the wrong host. Fixed for the `S3_ENDPOINT` branch; AWS S3 path unchanged.

### 3. CLI local deploy passes full required env (`3c38ab9`)

`getGatewayDeployEnv()` returned only `PATH`, `HOME`, `SSH_AUTH_SOCK`, `GATEWAY_HOST`. `Bun.spawn({ env })` doesn't merge with `process.env`, so the deploy child never saw `DISCORD_TOKEN`, `AWS_ACCESS_KEY_ID`, `S3_BUCKET`, etc. — making `gateway deploy --local` unusable.

Add the 7 missing required env vars using the explicit-allowlist pattern already used in cliproxy and keeweb deploy commands.

### 4. SSH key file contract in CI; drop ssh-agent (`cbd81e8`)

`validateRequiredEnv` required `GATEWAY_SSH_KEY` when `CI=true` but the script never used it — auth went through `webfactory/ssh-agent` in the workflow.

ssh-agent has a real production failure: when the DigitalOcean account holds multiple SSH keys, OpenSSH cycles through them all and trips `MaxAuthTries`. Hit this during provisioning tonight; workaround was a manual `-i` with `IdentitiesOnly=yes`.

Switch CI to the same pattern: write `GATEWAY_SSH_KEY` to a `mkdtemp` file with mode `0600`, pass `-i $path -o IdentitiesOnly=yes` to every SSH/SCP invocation, wrap `main()` in `try/finally` for cleanup. Key bytes never enter argv. Local mode unchanged.

Workflow: removed the `Setup SSH agent` step, added `GATEWAY_SSH_KEY` to the Deploy step's env block.

### 5. RFC1123-strict OBJECT_STORE_HOSTS validation (`00a348c`)

`/^[\w.,\-]+$/` accepted underscores via `\w`. Upstream mitmproxy allowlist parser rejects underscores and other non-RFC1123 chars, so an invalid hostname like `foo_bucket.example.com` passed infra validation, reached the droplet, and only failed when the egress filter silently went down.

Replace with per-label validation matching `/^(?!-)[a-z0-9-]{1,63}(?<!-)$/`, max 253 chars total. Errors name the offending host and the reason category.

### 6. Propagate readRemoteChecksum exit failures (`cdb63b1`)

`readRemoteChecksum` awaited the SSH exit code but discarded it. Non-zero exits became empty stdout, which the caller treated as "first deploy" and force-recreated containers — masking real SSH failures. Now throws on non-zero with exit code + stderr tail.

The SSH command itself already used `cat $PATH 2>/dev/null || echo ''`, so genuine missing-file cases still exit 0. Only structural failures surface.

## Verification

- 397 tests pass (was 370)
- Lint clean
- `bunx tsc --noEmit` clean
- Plan-leakage grep: zero matches

## Upstream coordination

Four additional findings require changes in `fro-bot/agent`:

- `DISCORD_GUILD_ID` is never wired into the gateway container, so guild-scoped command registration silently fails to a global registration (poll times out)
- AWS credentials are materialized but never mounted or read by the S3 client
- Empty optional secret files read as `''` instead of `null`, breaking `S3_ENDPOINT` optionality
- Dockerfile healthcheck is a placeholder (`node -e 'process.exit(0)'`), so compose `--wait` succeeds even when the gateway has crashed

I'm running a parallel session on `fro-bot/agent` to land those. Once the upstream PR merges and the new tag is published, I'll bump `apps/gateway/upstream.json` and attempt the first deploy.

## Notes

This PR does not change `apps/gateway/AGENTS.md`. Documentation updates land after the upstream coordination so the docs match the version of `fro-bot/agent` we actually pin to.

Also out of scope:
- `apps/gateway/server/provision-droplet.ts` has the same multi-key ssh-agent issue documented for the deploy script. Worked around tonight; structural fix is a separate PR.
- `apps/cliproxy/src/deploy.ts` has the same latent multi-key issue; haven't bitten yet because the production droplet was provisioned when fewer DO keys were registered. Tracked in project memory.
