### PR TITLE
fix(gateway): append trailing newline to materialized GATEWAY_SSH_KEY

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1606,6 +1606,66 @@ describe('CI key-file contract', () => {
     // Calling rmSync again (as the outer finally would) must not throw
     expect(() => realRmSync(keyTmpDir, {recursive: true, force: true})).not.toThrow()
   })
+  test('CI mode: key file gets trailing newline appended when GH Actions strips it', async () => {
+    const {main} = await import('./deploy')
+    // Simulate GitHub Actions stripping the trailing newline from the secret
+    const KEY_WITHOUT_NEWLINE = '-----BEGIN OPENSSH PRIVATE KEY-----\nfake-key-bytes\n-----END OPENSSH PRIVATE KEY-----'
+    let writtenKeyPath: string | undefined
+    let capturedContents: string | undefined
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const iIdx = cmd.indexOf('-i')
+      if (iIdx !== -1 && writtenKeyPath === undefined) {
+        writtenKeyPath = cmd[iIdx + 1]
+        if (writtenKeyPath) capturedContents = readFileSync(writtenKeyPath, 'utf-8')
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: KEY_WITHOUT_NEWLINE}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    expect(writtenKeyPath).toBeDefined()
+    // File must end with exactly one newline
+    expect(capturedContents).toBe(`${KEY_WITHOUT_NEWLINE}\n`)
+    expect(capturedContents!.endsWith('\n')).toBe(true)
+  })
+
+  test('CI mode: key file is not double-newlined when secret already has trailing newline', async () => {
+    const {main} = await import('./deploy')
+    // Key already has a trailing newline (e.g. from a local .env file)
+    const KEY_WITH_NEWLINE = '-----BEGIN OPENSSH PRIVATE KEY-----\nfake-key-bytes\n-----END OPENSSH PRIVATE KEY-----\n'
+    let writtenKeyPath: string | undefined
+    let capturedContents: string | undefined
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const iIdx = cmd.indexOf('-i')
+      if (iIdx !== -1 && writtenKeyPath === undefined) {
+        writtenKeyPath = cmd[iIdx + 1]
+        if (writtenKeyPath) capturedContents = readFileSync(writtenKeyPath, 'utf-8')
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: KEY_WITH_NEWLINE}),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    expect(writtenKeyPath).toBeDefined()
+    // Must not double-newline — exactly one trailing newline
+    expect(capturedContents).toBe(KEY_WITH_NEWLINE)
+    expect(capturedContents!.endsWith('\n\n')).toBe(false)
+  })
+
   test('local mode: no -i flag in ssh argv, SSH_AUTH_SOCK forwarded', async () => {
     const {main} = await import('./deploy')
     const {spawnFn, calls} = makeSpawnMock()

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -674,7 +674,8 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       try {
         keyTmpDir = mkdtempSync(join(tmpdir(), 'gateway-deploy-key-'))
         keyPath = join(keyTmpDir, 'id')
-        writeFileSync(keyPath, env.GATEWAY_SSH_KEY, {mode: 0o600})
+        const keyContent = env.GATEWAY_SSH_KEY.endsWith('\n') ? env.GATEWAY_SSH_KEY : `${env.GATEWAY_SSH_KEY}\n`
+        writeFileSync(keyPath, keyContent, {mode: 0o600})
         // Defensive chmod in case umask narrowed the initial mode
         chmodSync(keyPath, 0o600)
       } catch (error) {


### PR DESCRIPTION
First-deploy follow-up: `ssh -i` was failing with `error in libcrypto` because the materialized key file was missing its trailing newline. GitHub Actions strips trailing whitespace when injecting secrets into env vars, and OpenSSH PEM keys require `\n` after `-----END OPENSSH PRIVATE KEY-----`.

## Fix

One line: append a trailing newline when the GATEWAY_SSH_KEY value doesn't already end with one. Idempotent — locally-supplied keys with their own trailing newline are unchanged.

## How this was missed

The existing CI key tests assert mode 0o600 and that the file exists during the SSH spawn, but never inspect the contents. Two new tests now cover both branches (newline missing → appended; newline present → not doubled).

## Verification

- 403 tests pass, 0 fail (+2 from 401 baseline)
- Red→green proven: new tests fail before the fix, pass after
- Lint clean, tsc clean
