### PR TITLE
fix(cli): parse docker compose ps NDJSON output in gateway status

### DIFF
--- a/.changeset/gateway-status-ndjson-parsing.md
+++ b/.changeset/gateway-status-ndjson-parsing.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix `gateway status` crash on NDJSON output from docker compose ps v2.21+

--- a/packages/cli/src/commands/gateway/status.test.ts
+++ b/packages/cli/src/commands/gateway/status.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
-import {parseComposePs, type ComposePsEntry, type ServiceRow} from './status'
+import {parseComposePs, parseComposePsOutput, type ComposePsEntry, type ServiceRow} from './status'
 
 // ─── parseComposePs ──────────────────────────────────────────────────────────
 
@@ -255,5 +255,100 @@ describe('getGatewayComposeStatus', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error).toContain('SSH')
+  })
+})
+
+// ─── parseComposePsOutput ─────────────────────────────────────────────────────
+
+// Realistic fixture shape matching live droplet output
+const ndjsonFixture = [
+  String.raw`{"Command":"\"docker-entrypoint.sh\"","CreatedAt":"2026-05-20 08:20:18 +0000 UTC","ExitCode":0,"Health":"healthy","ID":"01e1a16f5752","Image":"fro-bot-gateway","Labels":"","LocalVolumes":"0","Mounts":"","Name":"fro-bot-gateway-1","Names":"fro-bot-gateway-1","Networks":"gateway_default","Ports":"","Project":"gateway","Publishers":null,"RunningFor":"2 hours ago","Service":"gateway","Size":"0B","State":"running","Status":"Up 2 hours (healthy)"}`,
+  String.raw`{"Command":"\"mitmproxy\"","CreatedAt":"2026-05-20 08:20:18 +0000 UTC","ExitCode":0,"Health":"healthy","ID":"02b2c27f6863","Image":"fro-bot-mitmproxy","Labels":"","LocalVolumes":"0","Mounts":"","Name":"fro-bot-mitmproxy-1","Names":"fro-bot-mitmproxy-1","Networks":"gateway_default","Ports":"","Project":"gateway","Publishers":null,"RunningFor":"2 hours ago","Service":"mitmproxy","Size":"0B","State":"running","Status":"Up 2 hours (healthy)"}`,
+  String.raw`{"Command":"\"sleep infinity\"","CreatedAt":"2026-05-20 08:20:18 +0000 UTC","ExitCode":0,"Health":"","ID":"03c3d38g7974","Image":"fro-bot-workspace","Labels":"","LocalVolumes":"0","Mounts":"","Name":"fro-bot-workspace-1","Names":"fro-bot-workspace-1","Networks":"gateway_default","Ports":"","Project":"gateway","Publishers":null,"RunningFor":"2 hours ago","Service":"workspace","Size":"0B","State":"running","Status":"Up 2 hours"}`,
+]
+
+describe('parseComposePsOutput', () => {
+  it('parses NDJSON with 3 lines into 3 entries with correct Name/State/Health', () => {
+    const raw = ndjsonFixture.join('\n')
+    const entries = parseComposePsOutput(raw)
+
+    expect(entries).toHaveLength(3)
+    expect(entries[0]?.Name).toBe('fro-bot-gateway-1')
+    expect(entries[0]?.State).toBe('running')
+    expect(entries[0]?.Health).toBe('healthy')
+    expect(entries[1]?.Name).toBe('fro-bot-mitmproxy-1')
+    expect(entries[1]?.State).toBe('running')
+    expect(entries[1]?.Health).toBe('healthy')
+    expect(entries[2]?.Name).toBe('fro-bot-workspace-1')
+    expect(entries[2]?.State).toBe('running')
+    expect(entries[2]?.Health).toBe('')
+  })
+
+  it('parses legacy single JSON array format', () => {
+    const raw = JSON.stringify([
+      {Name: 'fro-bot-gateway-1', State: 'running', Health: 'healthy'},
+      {Name: 'fro-bot-mitmproxy-1', State: 'running', Health: 'healthy'},
+    ])
+    const entries = parseComposePsOutput(raw)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]?.Name).toBe('fro-bot-gateway-1')
+    expect(entries[1]?.Name).toBe('fro-bot-mitmproxy-1')
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseComposePsOutput('')).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only input', () => {
+    expect(parseComposePsOutput('   \n  \n  ')).toEqual([])
+  })
+
+  it('parses a single NDJSON line', () => {
+    const raw = ndjsonFixture.at(0) ?? ''
+    const entries = parseComposePsOutput(raw)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.Name).toBe('fro-bot-gateway-1')
+  })
+
+  it('handles trailing newline correctly', () => {
+    const raw = `${ndjsonFixture.join('\n')}\n`
+    const entries = parseComposePsOutput(raw)
+
+    expect(entries).toHaveLength(3)
+  })
+
+  it('throws on a malformed NDJSON line', () => {
+    const raw = `${ndjsonFixture[0]}\nnot-valid-json\n${ndjsonFixture[2]}`
+
+    expect(() => parseComposePsOutput(raw)).toThrow()
+  })
+})
+
+// ─── getGatewayComposeStatus — NDJSON integration ────────────────────────────
+
+describe('getGatewayComposeStatus — NDJSON stdout', () => {
+  it('parses NDJSON docker compose ps output and returns correct services', async () => {
+    const {getGatewayComposeStatus} = await import('./status')
+
+    const ndjsonOutput = ndjsonFixture.join('\n')
+    const result = await getGatewayComposeStatus('gateway.example.com', makeSpawnOk(ndjsonOutput))
+
+    expect(result.ok).toBe(true)
+    expect(result.services).toHaveLength(3)
+    expect(result.services[0]).toEqual({service: 'fro-bot-gateway-1', state: 'running', health: 'healthy'})
+    expect(result.services[1]).toEqual({service: 'fro-bot-mitmproxy-1', state: 'running', health: 'healthy'})
+    expect(result.services[2]).toEqual({service: 'fro-bot-workspace-1', state: 'running', health: 'n-a'})
+  })
+
+  it('returns ok=false with error message when NDJSON contains a malformed line', async () => {
+    const {getGatewayComposeStatus} = await import('./status')
+
+    const badOutput = `${ndjsonFixture[0]}\nnot-valid-json`
+    const result = await getGatewayComposeStatus('gateway.example.com', makeSpawnOk(badOutput))
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Failed to parse docker compose ps output')
   })
 })

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -45,6 +45,24 @@ export type SpawnFn = (
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
+export function parseComposePsOutput(stdoutText: string): ComposePsEntry[] {
+  const trimmed = stdoutText.trim()
+  if (trimmed.length === 0) return []
+
+  // Legacy compose may emit a single JSON array; current versions emit NDJSON.
+  if (trimmed.startsWith('[')) {
+    const parsed: unknown = JSON.parse(trimmed)
+    return Array.isArray(parsed) ? (parsed as ComposePsEntry[]) : []
+  }
+
+  // NDJSON: one JSON object per non-empty line.
+  return trimmed
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => JSON.parse(line) as ComposePsEntry)
+}
+
 function normalizeHealth(raw: string): HealthStatus {
   if (raw === 'healthy' || raw === 'unhealthy' || raw === 'starting') {
     return raw
@@ -117,8 +135,7 @@ export async function getGatewayComposeStatus(
   let entries: ComposePsEntry[]
 
   try {
-    const parsed: unknown = JSON.parse(stdoutText)
-    entries = Array.isArray(parsed) ? (parsed as ComposePsEntry[]) : []
+    entries = parseComposePsOutput(stdoutText)
   } catch {
     return {ok: false, services: [], error: `Failed to parse docker compose ps output: ${stdoutText.slice(0, 200)}`}
   }


### PR DESCRIPTION
Fix a production bug surfaced after v0.4.10: `bunx @marcusrbrown/infra gateway status` crashes with `Failed to parse docker compose ps output: {"Command":"...` against any current Docker Compose installation.

## Root cause

`docker compose ps --format json` emits NDJSON (one JSON object per line) since Docker Compose v2.21. The parser called bare `JSON.parse` on the whole stdout, which only handles a single array or single object — not multiple line-delimited objects.

## Fix

New `parseComposePsOutput` function that:

- Returns `[]` for empty/whitespace-only input
- Falls through to the existing single-array parse for legacy compose (`stdout.startsWith('[')`) — keeps back-compat
- Otherwise splits on newlines and parses each non-empty line as a separate object

The caller's existing try/catch around the parse step is unchanged — malformed JSON still surfaces as `{ok: false, error: "Failed to parse..."}` with the first 200 chars for diagnostics.

## Why the existing tests didn't catch this

`parseComposePs` (an internal helper) was tested with pre-parsed `ComposePsEntry[]` arrays — never with raw stdout. The JSON-parse step itself had no coverage. Added:

- 7 unit tests for `parseComposePsOutput` covering NDJSON, legacy array, empty input, single line, trailing newline, malformed lines, single-object back-compat
- 2 integration tests for `getGatewayComposeStatus` using the spawn-mock pattern with realistic NDJSON fixtures mirroring live droplet output

## Verification

- 418 tests pass, 0 fail (+9 from 409 baseline)
- Red→green proven: new tests import `parseComposePsOutput` which doesn't exist on main → unresolved import → red. Pass after fix → green.
- Lint clean (47 warnings, same as main), tsc clean
- **End-to-end verified against live gateway droplet**: `bun packages/cli/src/cli.ts gateway status` now correctly reports all 3 services (gateway healthy, mitmproxy healthy, workspace n-a) with Status: OK.
