### PR TITLE
refactor(provisioning): extract shared droplet helpers to packages/shared

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 ├── apps/cliproxy/      CLIProxyAPI deploy package (see apps/cliproxy/AGENTS.md)
 ├── apps/gateway/       Fro Bot gateway deploy package (see apps/gateway/AGENTS.md)
 ├── packages/cli/       @marcusrbrown/infra CLI (see packages/cli/AGENTS.md)
+├── packages/shared/    Shared provisioning helpers (see packages/shared/AGENTS.md)
 ├── docs/               Brainstorms → plans → solutions (compound learning)
 ├── .changeset/         Changesets config for versioning
 ├── .agents/skills/     Agent skills (goke, etc.) — load before working with that domain
@@ -69,7 +70,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 - **No secret values in tracked files** — `config/config.json` template has empty `dropboxSecret`; real value injected at build time from env var. (enforced)
 - **Never modify `config/config.json` in CI** — secret goes into `dist/config.json` only.
 - **Never overwrite `config.yaml` on cliproxy server** — runtime API keys live there. Deploy skips upload when file exists; `--force-config` is the explicit override.
-- **Never use `ssh-keyscan` in CI workflows** — host keys are pinned in `.github/known_hosts`. Provisioning scripts may use `ssh-keyscan` locally; `apps/cliproxy/server/provision-droplet.ts` is the current example. (enforced)
+- **Never use `ssh-keyscan` in CI workflows** — host keys are pinned in `.github/known_hosts`. Provisioning scripts may use `ssh-keyscan` locally via the shared `pinHostKeys` helper in `packages/shared/server/droplet-helpers.ts`. (enforced)
 - **Never `secrets: inherit`** with cross-org reusable workflows. (enforced)
 - **Never use `bundledDependencies`** — Bun's `.bun/` symlink layout creates `../../` paths that npm rejects with E415. (enforced)
 - **Never pass gateway secret bytes via argv** — `writeRemoteFile` pipes bytes through SSH stdin only; `--body <value>` patterns are banned.

--- a/apps/cliproxy/AGENTS.md
+++ b/apps/cliproxy/AGENTS.md
@@ -56,5 +56,6 @@ Verified endpoint surface (see `apps/cliproxy/src/deploy.ts` and `packages/cli/s
 
 - **Secrets**: `CLIPROXY_SSH_KEY`, `CLIPROXY_MANAGEMENT_KEY`, `CLIPROXY_DOMAIN` scoped to GitHub environment `cliproxy`. `DIGITALOCEAN_ACCESS_TOKEN` is repo-level.
 - **Local `.env`**: `CLIPROXY_MANAGEMENT_KEY` must match the droplet's `MANAGEMENT_PASSWORD` (set during provisioning, printed once).
+- **Provisioning SSH key**: `provision-droplet.ts` looks up the DigitalOcean SSH key by name. Default is `fro-bot-cliproxy`; override with `CLIPROXY_SSH_KEY_NAME` env var. Shared helper lives in `packages/shared/server/droplet-helpers.ts`.
 - **OAuth refresh**: Claude OAuth tokens auto-refresh in `cliproxy_auth` volume. Manual refresh: `bunx @marcusrbrown/infra cliproxy login claude`.
 - **API key recovery**: There is no recovery tooling. If keys are wiped, regenerate via `cliproxy keys add` and redistribute. `cliproxy config get --output backup.json` (with `0600` perms) is the safest backup mechanism.

--- a/apps/cliproxy/package.json
+++ b/apps/cliproxy/package.json
@@ -4,5 +4,8 @@
   "scripts": {
     "deploy": "bun run src/deploy.ts",
     "provision": "bun run server/provision-droplet.ts"
+  },
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
   }
 }

--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from 'bun:test'
+
+import {validateCliproxyDomain} from './provision-droplet'
+
+// ---------------------------------------------------------------------------
+// validateCliproxyDomain
+// ---------------------------------------------------------------------------
+
+describe('validateCliproxyDomain', () => {
+  it('accepts a valid domain', () => {
+    expect(validateCliproxyDomain('cliproxy.fro.bot')).toBe('cliproxy.fro.bot')
+  })
+
+  it('accepts a plain hostname', () => {
+    expect(validateCliproxyDomain('example.com')).toBe('example.com')
+  })
+
+  it('throws on a value containing a newline (heredoc termination)', () => {
+    expect(() => validateCliproxyDomain('cliproxy.fro.bot\nENVFILE\nevil')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a dollar sign (variable expansion)', () => {
+    expect(() => validateCliproxyDomain('host$PATH')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a backtick (command substitution)', () => {
+    expect(() => validateCliproxyDomain('host`id`')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a pipe (command chaining)', () => {
+    expect(() => validateCliproxyDomain('host|cat /etc/passwd')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a semicolon (command separator)', () => {
+    expect(() => validateCliproxyDomain('host;rm -rf /')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing an ampersand (background execution)', () => {
+    expect(() => validateCliproxyDomain('host&evil')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a single quote', () => {
+    expect(() => validateCliproxyDomain("host'evil")).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a double quote', () => {
+    expect(() => validateCliproxyDomain('host"evil')).toThrow(/disallowed characters/)
+  })
+
+  it('throws on a value containing a backslash', () => {
+    expect(() => validateCliproxyDomain(String.raw`host\evil`)).toThrow(/disallowed characters/)
+  })
+})

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -20,6 +20,23 @@ const DROPLET_IMAGE = 'docker-20-04'
 const DROPLET_SIZE = 's-1vcpu-1gb'
 const DROPLET_REGION = 'nyc1'
 const CLIPROXY_DOMAIN = process.env.CLIPROXY_DOMAIN ?? 'cliproxy.fro.bot'
+
+// Disallowed characters in CLIPROXY_DOMAIN: newlines (heredoc termination),
+// shell metacharacters ($, `, |, ;, &), and quotes/backslash.
+const DOMAIN_DISALLOWED_RE = /[\n`$|;&'"\\]/
+
+/**
+ * Validates a CLIPROXY_DOMAIN value. Throws if it contains characters that
+ * could terminate a heredoc early or inject shell commands.
+ */
+export function validateCliproxyDomain(domain: string): string {
+  if (DOMAIN_DISALLOWED_RE.test(domain)) {
+    throw new Error(`CLIPROXY_DOMAIN contains disallowed characters: ${JSON.stringify(domain.slice(0, 40))}`)
+  }
+
+  return domain
+}
+
 const REMOTE_USER = process.env.REMOTE_USER ?? 'root'
 const REMOTE_DIR = '/opt/cliproxy'
 
@@ -90,10 +107,24 @@ async function writeRemoteEnvFile(host: string): Promise<string> {
   const managementPassword = randomBytes(32).toString('hex')
   const envFile = `CLIPROXY_DOMAIN=${CLIPROXY_DOMAIN}\nMANAGEMENT_PASSWORD=${managementPassword}\n`
 
-  await run(
-    'Writing remote .env file',
-    ssh(host, `cat > ${REMOTE_DIR}/.env << 'ENVFILE'\n${envFile}ENVFILE`, REMOTE_USER),
-  )
+  // Pipe contents through stdin — never embed in the command string.
+  // This prevents heredoc-termination injection if any env var contains newlines.
+  const proc = Bun.spawn(ssh(host, `cat > ${REMOTE_DIR}/.env`, REMOTE_USER), {
+    stdin: 'pipe',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+
+  proc.stdin.write(envFile)
+  proc.stdin.end()
+
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    console.error(`\u001B[1;31mFAILED:\u001B[0m Writing remote .env file (exit ${exitCode})`)
+    process.exit(1)
+  }
+
+  console.log('\u001B[1;34m==>\u001B[0m Writing remote .env file')
 
   return managementPassword
 }
@@ -137,7 +168,10 @@ async function provision(): Promise<void> {
   console.log('\nCommit the updated .github/known_hosts before triggering a CI deploy.')
 }
 
-provision().catch((error: unknown) => {
-  console.error(error)
-  process.exit(1)
-})
+if (import.meta.main) {
+  validateCliproxyDomain(CLIPROXY_DOMAIN)
+  provision().catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env bun
 
 import {randomBytes} from 'node:crypto'
-import {appendFileSync, readFileSync} from 'node:fs'
 import {resolve} from 'node:path'
+
+import {
+  dropletExists,
+  getDropletIpWithWait,
+  getSshFingerprint,
+  pinHostKeys,
+  run,
+  scp,
+  ssh,
+  validateDoctl,
+  waitForSsh,
+} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 
 const DROPLET_NAME = 'cliproxy'
 const DROPLET_IMAGE = 'docker-20-04'
@@ -12,143 +23,35 @@ const CLIPROXY_DOMAIN = process.env.CLIPROXY_DOMAIN ?? 'cliproxy.fro.bot'
 const REMOTE_USER = process.env.REMOTE_USER ?? 'root'
 const REMOTE_DIR = '/opt/cliproxy'
 
-function local(command: string[]): string[] {
-  return command
-}
-
-function ssh(host: string, command: string): string[] {
-  return [
-    'ssh',
-    '-o',
-    'BatchMode=yes',
-    '-o',
-    'StrictHostKeyChecking=accept-new',
-    '-o',
-    'ConnectTimeout=10',
-    `${REMOTE_USER}@${host}`,
-    command,
-  ]
-}
-
-function scp(host: string, source: string, target: string): string[] {
-  return [
-    'scp',
-    '-o',
-    'BatchMode=yes',
-    '-o',
-    'StrictHostKeyChecking=accept-new',
-    '-o',
-    'ConnectTimeout=10',
-    source,
-    `${REMOTE_USER}@${host}:${target}`,
-  ]
-}
-
-async function run(label: string, command: string[]) {
-  console.log(`\u001B[1;34m==>\u001B[0m ${label}`)
-  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
-  const stdout = await new Response(proc.stdout).text()
-  const stderr = await new Response(proc.stderr).text()
-  const code = await proc.exited
-  if (stdout.trim()) console.log(stdout.trim())
-  if (code !== 0) {
-    console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
-    if (stderr.trim()) console.error(stderr.trim())
-    process.exit(1)
-  }
-}
-
-async function runCapture(command: string[]): Promise<string> {
-  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
-  const stdout = await new Response(proc.stdout).text()
-  const stderr = await new Response(proc.stderr).text()
-  const code = await proc.exited
-  if (code !== 0) {
-    throw new Error(stderr.trim() || `Command failed: ${command.join(' ')}`)
-  }
-  return stdout.trim()
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise(resolvePromise => setTimeout(resolvePromise, ms))
-}
-
-async function validateDoctl(): Promise<void> {
-  if (!Bun.which('doctl')) {
-    throw new Error(
-      'doctl is required. Install it first: https://docs.digitalocean.com/reference/doctl/how-to/install/',
-    )
-  }
-
-  await run('Validating doctl authentication', local(['doctl', 'account', 'get']))
-}
-
-async function getSshFingerprint(): Promise<string> {
-  const raw = await runCapture(local(['doctl', 'compute', 'ssh-key', 'list', '--format', 'FingerPrint', '--no-header']))
-  const first = raw
-    .split('\n')
-    .map(line => line.trim())
-    .find(Boolean)
-
-  if (!first) {
-    throw new Error('No SSH keys found in DigitalOcean account. Add at least one key before provisioning.')
-  }
-
-  return first
-}
-
-async function dropletExists(): Promise<boolean> {
-  const raw = await runCapture(local(['doctl', 'compute', 'droplet', 'list', '--format', 'Name', '--no-header']))
-  const names = raw
-    .split('\n')
-    .map(line => line.trim())
-    .filter(Boolean)
-
-  return names.includes(DROPLET_NAME)
-}
-
 async function createDropletIfMissing(): Promise<boolean> {
-  const exists = await dropletExists()
+  const exists = await dropletExists(DROPLET_NAME)
   if (exists) {
     console.log(`\u001B[1;34m==>\u001B[0m Droplet ${DROPLET_NAME} already exists — skipping creation`)
     return true
   }
 
-  const fingerprint = await getSshFingerprint()
-  await run(
-    `Creating droplet ${DROPLET_NAME}`,
-    local([
-      'doctl',
-      'compute',
-      'droplet',
-      'create',
-      DROPLET_NAME,
-      '--image',
-      DROPLET_IMAGE,
-      '--size',
-      DROPLET_SIZE,
-      '--region',
-      DROPLET_REGION,
-      '--ssh-keys',
-      fingerprint,
-      '--wait',
-    ]),
-  )
+  const keyName = process.env.CLIPROXY_SSH_KEY_NAME ?? 'fro-bot-cliproxy'
+  const fingerprint = await getSshFingerprint(keyName, {
+    envVarName: 'CLIPROXY_SSH_KEY_NAME',
+    defaultKeyName: 'fro-bot-cliproxy',
+  })
+  await run(`Creating droplet ${DROPLET_NAME}`, [
+    'doctl',
+    'compute',
+    'droplet',
+    'create',
+    DROPLET_NAME,
+    '--image',
+    DROPLET_IMAGE,
+    '--size',
+    DROPLET_SIZE,
+    '--region',
+    DROPLET_REGION,
+    '--ssh-keys',
+    fingerprint,
+    '--wait',
+  ])
   return false
-}
-
-async function getDropletIpWithWait(): Promise<string> {
-  for (let attempt = 1; attempt <= 20; attempt += 1) {
-    const ip = await runCapture(
-      local(['doctl', 'compute', 'droplet', 'get', DROPLET_NAME, '--format', 'PublicIPv4', '--no-header']),
-    )
-    if (ip) {
-      return ip
-    }
-    await sleep(5_000)
-  }
-
-  throw new Error('Timed out waiting for droplet IPv4 address')
 }
 
 async function validateDns(dropletIp: string): Promise<void> {
@@ -177,68 +80,30 @@ function resolveLocalFiles(): {compose: string; config: string; caddy: string} {
 async function copyComposeFiles(host: string): Promise<void> {
   const files = resolveLocalFiles()
 
-  await run('Creating remote directories', ssh(host, `mkdir -p ${REMOTE_DIR}/config`))
-  await run('Uploading docker-compose.yaml', scp(host, files.compose, `${REMOTE_DIR}/docker-compose.yaml`))
-  await run('Uploading config/config.yaml', scp(host, files.config, `${REMOTE_DIR}/config/config.yaml`))
-  await run('Uploading config/Caddyfile', scp(host, files.caddy, `${REMOTE_DIR}/config/Caddyfile`))
+  await run('Creating remote directories', ssh(host, `mkdir -p ${REMOTE_DIR}/config`, REMOTE_USER))
+  await run('Uploading docker-compose.yaml', scp(host, files.compose, `${REMOTE_DIR}/docker-compose.yaml`, REMOTE_USER))
+  await run('Uploading config/config.yaml', scp(host, files.config, `${REMOTE_DIR}/config/config.yaml`, REMOTE_USER))
+  await run('Uploading config/Caddyfile', scp(host, files.caddy, `${REMOTE_DIR}/config/Caddyfile`, REMOTE_USER))
 }
 
 async function writeRemoteEnvFile(host: string): Promise<string> {
   const managementPassword = randomBytes(32).toString('hex')
   const envFile = `CLIPROXY_DOMAIN=${CLIPROXY_DOMAIN}\nMANAGEMENT_PASSWORD=${managementPassword}\n`
 
-  await run('Writing remote .env file', ssh(host, `cat > ${REMOTE_DIR}/.env << 'ENVFILE'\n${envFile}ENVFILE`))
+  await run(
+    'Writing remote .env file',
+    ssh(host, `cat > ${REMOTE_DIR}/.env << 'ENVFILE'\n${envFile}ENVFILE`, REMOTE_USER),
+  )
 
   return managementPassword
 }
 
 async function deployCompose(host: string): Promise<void> {
-  await run('Starting Docker Compose stack', ssh(host, `cd ${REMOTE_DIR} && docker compose up -d`))
-}
-
-async function waitForSsh(host: string): Promise<void> {
-  for (let attempt = 1; attempt <= 24; attempt += 1) {
-    const proc = Bun.spawn(ssh(host, 'echo ready'), {stdout: 'pipe', stderr: 'pipe'})
-    const code = await proc.exited
-    if (code === 0) {
-      return
-    }
-
-    await sleep(5_000)
-  }
-
-  throw new Error('Timed out waiting for SSH connectivity to droplet')
-}
-
-async function pinHostKeys(dropletIp: string): Promise<void> {
-  const knownHostsPath = resolve(import.meta.dir, '..', '..', '..', '.github', 'known_hosts')
-
-  // Pin unhashed domain-name keys (for CI, which connects by domain)
-  const domainKeys = await runCapture(local(['ssh-keyscan', CLIPROXY_DOMAIN]))
-  // Pin hashed IP keys (for local provisioning)
-  const ipKeys = await runCapture(local(['ssh-keyscan', '-H', dropletIp]))
-
-  if (!domainKeys && !ipKeys) {
-    console.warn('Warning: Could not retrieve host keys from droplet. Pin them manually before CI deploy.')
-    return
-  }
-
-  const existing = readFileSync(knownHostsPath, 'utf-8')
-  const marker = `# cliproxy droplet (${dropletIp} / ${CLIPROXY_DOMAIN})`
-
-  if (existing.includes(marker)) {
-    console.log(`\u001B[1;34m==>\u001B[0m Host keys already pinned for ${dropletIp}`)
-    return
-  }
-
-  const newBlock = `\n${marker}\n${domainKeys}\n${ipKeys}\n`
-  appendFileSync(knownHostsPath, newBlock)
-  console.log(`\u001B[1;32m✓\u001B[0m Pinned host keys for ${dropletIp} / ${CLIPROXY_DOMAIN} in .github/known_hosts`)
-  console.log('  Commit the updated .github/known_hosts before running CI deploy.')
+  await run('Starting Docker Compose stack', ssh(host, `cd ${REMOTE_DIR} && docker compose up -d`, REMOTE_USER))
 }
 
 async function provision(): Promise<void> {
-  await validateDoctl()
+  await validateDoctl({checkAuth: true})
   const dropletAlreadyExisted = await createDropletIfMissing()
 
   if (dropletAlreadyExisted && !process.argv.includes('--force')) {
@@ -250,9 +115,14 @@ async function provision(): Promise<void> {
     console.warn('⚠️  --force: Overwriting remote config and .env on existing droplet')
   }
 
-  const dropletIp = await getDropletIpWithWait()
-  await waitForSsh(dropletIp)
-  await pinHostKeys(dropletIp)
+  const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
+  await waitForSsh(dropletIp, REMOTE_USER)
+
+  const knownHostsPath = resolve(import.meta.dir, '..', '..', '..', '.github', 'known_hosts')
+  await pinHostKeys(CLIPROXY_DOMAIN, dropletIp, knownHostsPath, {
+    marker: `# cliproxy droplet (${dropletIp} / ${CLIPROXY_DOMAIN})`,
+  })
+
   await validateDns(dropletIp)
   await copyComposeFiles(dropletIp)
   const managementPassword = await writeRemoteEnvFile(dropletIp)

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -7,5 +7,8 @@
     "deploy": "bun run src/deploy.ts",
     "provision": "bun run server/provision-droplet.ts",
     "test": "bun test"
+  },
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
   }
 }

--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -1,15 +1,10 @@
-import {mkdtempSync, readFileSync, writeFileSync} from 'node:fs'
-import {tmpdir} from 'node:os'
-import {join} from 'node:path'
+import {dropletExists} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
 import {
   checkDropletExistence,
-  dropletExists,
-  getSshFingerprint,
+  getGatewaySshFingerprint,
   parseProvisionArgs,
-  pinHostKeys,
-  validateDoctl,
   validateRequiredEnv,
 } from './provision-droplet'
 
@@ -65,24 +60,6 @@ function makeSpawnResult(stdout: string, exitCode: number): SpawnResult {
   }
 }
 
-function makeSpawnResultWithStderr(stderr: string, exitCode: number): SpawnResult {
-  const enc = new TextEncoder()
-  return {
-    stdout: new ReadableStream({
-      start(controller) {
-        controller.close()
-      },
-    }),
-    stderr: new ReadableStream({
-      start(controller) {
-        controller.enqueue(enc.encode(stderr))
-        controller.close()
-      },
-    }),
-    exited: Promise.resolve(exitCode),
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -94,28 +71,6 @@ describe('provision-droplet', () => {
 
   afterEach(() => {
     restoreEnv()
-  })
-
-  // -------------------------------------------------------------------------
-  // validateDoctl
-  // -------------------------------------------------------------------------
-
-  describe('validateDoctl', () => {
-    it('throws when doctl is not on PATH', () => {
-      const whichSpy = spyOn(Bun, 'which').mockReturnValue(null)
-
-      expect(() => validateDoctl()).toThrow(/doctl is required/)
-
-      whichSpy.mockRestore()
-    })
-
-    it('does not throw when doctl is available', () => {
-      const whichSpy = spyOn(Bun, 'which').mockReturnValue('/usr/local/bin/doctl')
-
-      expect(() => validateDoctl()).not.toThrow()
-
-      whichSpy.mockRestore()
-    })
   })
 
   // -------------------------------------------------------------------------
@@ -157,7 +112,7 @@ describe('provision-droplet', () => {
   })
 
   // -------------------------------------------------------------------------
-  // dropletExists
+  // dropletExists (gateway-specific usage)
   // -------------------------------------------------------------------------
 
   describe('dropletExists', () => {
@@ -237,75 +192,9 @@ describe('provision-droplet', () => {
   })
 
   // -------------------------------------------------------------------------
-  // pinHostKeys
+  // getGatewaySshFingerprint (gateway-specific wrapper)
   // -------------------------------------------------------------------------
 
-  describe('pinHostKeys', () => {
-    let tmpDir: string
-    let knownHostsPath: string
-
-    beforeEach(() => {
-      tmpDir = mkdtempSync(join(tmpdir(), 'gateway-test-'))
-      knownHostsPath = join(tmpDir, 'known_hosts')
-      writeFileSync(knownHostsPath, '')
-    })
-
-    it('appends domain and IP host key entries to known_hosts', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn')
-        .mockReturnValueOnce(
-          makeSpawnResult('gateway.example.com ssh-ed25519 AAAA...domain', 0) as ReturnType<typeof Bun.spawn>,
-        )
-        .mockReturnValueOnce(makeSpawnResult('|1|hash== ssh-ed25519 AAAA...ip', 0) as ReturnType<typeof Bun.spawn>)
-
-      await pinHostKeys('gateway.example.com', '1.2.3.4', knownHostsPath)
-
-      const contents = readFileSync(knownHostsPath, 'utf-8')
-      expect(contents).toContain('gateway.example.com ssh-ed25519')
-      expect(contents).toContain('|1|hash==')
-
-      spawnSpy.mockRestore()
-    })
-
-    it('skips append when entries for this host already exist (idempotency)', async () => {
-      // Pre-populate with the marker
-      writeFileSync(
-        knownHostsPath,
-        '# gateway droplet (1.2.3.4 / gateway.example.com)\ngateway.example.com ssh-ed25519 AAAA...\n',
-      )
-
-      const spawnSpy = spyOn(Bun, 'spawn')
-
-      await pinHostKeys('gateway.example.com', '1.2.3.4', knownHostsPath)
-
-      // spawn should NOT have been called (no ssh-keyscan needed)
-      expect(spawnSpy).not.toHaveBeenCalled()
-
-      const contents = readFileSync(knownHostsPath, 'utf-8')
-      // File should be unchanged — only one occurrence of the marker
-      expect(contents.split('# gateway droplet').length).toBe(2) // 1 split = 2 parts
-
-      spawnSpy.mockRestore()
-    })
-
-    it('throws when ssh-keyscan fails for the domain', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
-        makeSpawnResultWithStderr('ssh-keyscan: getaddrinfo for host gateway.example.com failed', 1) as ReturnType<
-          typeof Bun.spawn
-        >,
-      )
-
-      await expect(pinHostKeys('gateway.example.com', '1.2.3.4', knownHostsPath)).rejects.toThrow()
-
-      spawnSpy.mockRestore()
-    })
-  })
-
-  // -------------------------------------------------------------------------
-  // getSshFingerprint
-  // -------------------------------------------------------------------------
-
-  // Real doctl output uses multi-space padding between Name and FingerPrint columns.
-  // The Name column can contain spaces, @, and dots — so we parse last-field-is-fingerprint.
   const MULTI_KEY_OUTPUT = [
     'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
     'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
@@ -313,79 +202,13 @@ describe('provision-droplet', () => {
     'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
   ].join('\n')
 
-  describe('getSshFingerprint', () => {
-    it('matches gateway-specific key when multiple keys exist', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
-        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
-      )
-
-      const fp = await getSshFingerprint('fro-bot-gateway')
-
-      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
-      // Must NOT return the first key's fingerprint
-      expect(fp).not.toBe('91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9')
-
-      spawnSpy.mockRestore()
-    })
-
-    it('picks the named key even when it is the only row', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
-        makeSpawnResult(
-          'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
-          0,
-        ) as ReturnType<typeof Bun.spawn>,
-      )
-
-      const fp = await getSshFingerprint('fro-bot-gateway')
-
-      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
-
-      spawnSpy.mockRestore()
-    })
-
-    it('throws with a clear message when the named key is not found', async () => {
-      const threeOtherKeys = [
-        'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
-        'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
-        'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
-      ].join('\n')
-
-      const spawnSpy = spyOn(Bun, 'spawn')
-        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
-        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
-        .mockReturnValueOnce(makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>)
-
-      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
-      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/GATEWAY_SSH_KEY_NAME/)
-      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/fro-bot-gateway/)
-
-      spawnSpy.mockRestore()
-    })
-
-    it('throws with a clear message when the key list is empty', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(makeSpawnResult('', 0) as ReturnType<typeof Bun.spawn>)
-
-      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
-
-      spawnSpy.mockRestore()
-    })
-
-    it('throws on doctl non-zero exit', async () => {
-      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
-        makeSpawnResultWithStderr('unauthorized', 1) as ReturnType<typeof Bun.spawn>,
-      )
-
-      await expect(getSshFingerprint('fro-bot-gateway')).rejects.toThrow(/unauthorized/)
-
-      spawnSpy.mockRestore()
-    })
-
+  describe('getGatewaySshFingerprint', () => {
     it('uses fro-bot-gateway as the default key name when no argument is provided', async () => {
       const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
         makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
       )
 
-      const fp = await getSshFingerprint()
+      const fp = await getGatewaySshFingerprint()
 
       expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
 
@@ -404,31 +227,39 @@ describe('provision-droplet', () => {
         makeSpawnResult(customKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
       )
 
-      const fp = await getSshFingerprint()
+      const fp = await getGatewaySshFingerprint()
 
       expect(fp).toBe('aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99')
-      // Must NOT return the fro-bot-gateway fingerprint
       expect(fp).not.toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
 
       spawnSpy.mockRestore()
     })
 
-    it('looks up a key whose name contains spaces', async () => {
-      const spacedKeyOutput = [
-        'fro-bot-gateway                                       e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
-        'my key with spaces                                    11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00',
-        'another-key                                           ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00',
-      ].join('\n')
-
+    it('matches the named key when explicitly passed', async () => {
       const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
-        makeSpawnResult(spacedKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
       )
 
-      const fp = await getSshFingerprint('my key with spaces')
+      const fp = await getGatewaySshFingerprint('fro-bot-gateway')
 
-      expect(fp).toBe('11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00')
-      // Must NOT return the next row's fingerprint
-      expect(fp).not.toBe('ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00')
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+      expect(fp).not.toBe('91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('throws when the named key is not found', async () => {
+      const threeOtherKeys = [
+        'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+        'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+        'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValueOnce(
+        makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      await expect(getGatewaySshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
 
       spawnSpy.mockRestore()
     })

--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -1,6 +1,7 @@
 import {dropletExists} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
+import {validateGatewayHost} from '../src/host'
 import {
   checkDropletExistence,
   getGatewaySshFingerprint,
@@ -262,6 +263,40 @@ describe('provision-droplet', () => {
       await expect(getGatewaySshFingerprint('fro-bot-gateway')).rejects.toThrow(/not found/)
 
       spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // validateGatewayHost — provision script must call this before pinHostKeys
+  // -------------------------------------------------------------------------
+
+  describe('validateGatewayHost (provision security invariant)', () => {
+    it('accepts a valid hostname', () => {
+      expect(validateGatewayHost('gateway.example.com')).toBe('gateway.example.com')
+    })
+
+    it('throws on empty string', () => {
+      expect(() => validateGatewayHost('')).toThrow(/empty/)
+    })
+
+    it('throws on a value starting with a dash (ssh flag injection)', () => {
+      expect(() => validateGatewayHost('-oProxyCommand=evil')).toThrow(/Invalid GATEWAY_HOST/)
+    })
+
+    it('throws on a value containing shell metacharacters (semicolon)', () => {
+      expect(() => validateGatewayHost('host;rm -rf /')).toThrow(/Invalid GATEWAY_HOST/)
+    })
+
+    it('throws on a value containing a space', () => {
+      expect(() => validateGatewayHost('host name')).toThrow(/Invalid GATEWAY_HOST/)
+    })
+
+    it('throws on a value containing backtick command substitution', () => {
+      expect(() => validateGatewayHost('host`id`')).toThrow(/Invalid GATEWAY_HOST/)
+    })
+
+    it('throws on a value containing a newline', () => {
+      expect(() => validateGatewayHost('host\nENVFILE\nevil')).toThrow(/Invalid GATEWAY_HOST/)
     })
   })
 

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -1,7 +1,16 @@
 #!/usr/bin/env bun
 
-import {appendFileSync, readFileSync} from 'node:fs'
 import {join, resolve} from 'node:path'
+
+import {
+  dropletExists,
+  getDropletIpWithWait,
+  getSshFingerprint,
+  pinHostKeys,
+  run,
+  validateDoctl,
+  waitForSsh,
+} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 
 const DROPLET_NAME = 'gateway'
 const DROPLET_IMAGE = 'docker-20-04'
@@ -20,19 +29,8 @@ export interface DropletExistenceState {
 }
 
 // ---------------------------------------------------------------------------
-// Pure-logic helpers (exported for testability)
+// Gateway-specific helpers (exported for testability)
 // ---------------------------------------------------------------------------
-
-/**
- * Checks that doctl is available on PATH. Throws with install instructions if not.
- */
-export function validateDoctl(): void {
-  if (!Bun.which('doctl')) {
-    throw new Error(
-      'doctl is required. Install it first: https://docs.digitalocean.com/reference/doctl/how-to/install/',
-    )
-  }
-}
 
 /**
  * Validates that all required environment variables are present.
@@ -41,27 +39,6 @@ export function validateDoctl(): void {
 export function validateRequiredEnv(env: Partial<Record<string, string>>): string[] {
   const required = ['DIGITALOCEAN_ACCESS_TOKEN', 'GATEWAY_HOST']
   return required.filter(key => !env[key])
-}
-
-/**
- * Checks whether a droplet with the given name exists in the DigitalOcean account.
- * Runs `doctl compute droplet list` via Bun.spawn.
- */
-export async function dropletExists(name: string): Promise<boolean> {
-  const proc = Bun.spawn(['doctl', 'compute', 'droplet', 'list', '--format', 'Name', '--no-header'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-  const stdout = await new Response(proc.stdout).text()
-  const code = await proc.exited
-  if (code !== 0) {
-    throw new Error(`Failed to list droplets`)
-  }
-  const names = stdout
-    .split('\n')
-    .map(line => line.trim())
-    .filter(Boolean)
-  return names.includes(name)
 }
 
 /**
@@ -92,132 +69,13 @@ export function parseProvisionArgs(args: string[]): ProvisionArgs {
 }
 
 /**
- * Appends domain (unhashed) and IP (hashed) host key entries to the given known_hosts file.
- * Idempotent: if entries for this host are already present, skips the append.
+ * Returns the SSH key fingerprint for the gateway key.
+ * Accepts an optional keyName override; falls back to GATEWAY_SSH_KEY_NAME env var,
+ * then to the default 'fro-bot-gateway'.
  */
-export async function pinHostKeys(domain: string, ip: string, knownHostsPath: string): Promise<void> {
-  const existing = readFileSync(knownHostsPath, 'utf-8')
-  const marker = `# gateway droplet (${ip} / ${domain})`
-
-  if (existing.includes(marker)) {
-    console.log(`\u001B[1;34m==>\u001B[0m Host keys already pinned for ${ip}`)
-    return
-  }
-
-  const domainKeys = await runCapture(['ssh-keyscan', domain])
-  const ipKeys = await runCapture(['ssh-keyscan', '-H', ip])
-
-  const newBlock = `\n${marker}\n${domainKeys}\n${ipKeys}\n`
-  appendFileSync(knownHostsPath, newBlock)
-  console.log(`\u001B[1;32m✓\u001B[0m Pinned host keys for ${ip} / ${domain} in .github/known_hosts`)
-  console.log('  Commit the updated .github/known_hosts before running CI deploy.')
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-async function runCapture(command: string[]): Promise<string> {
-  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
-  const stdout = await new Response(proc.stdout).text()
-  const stderr = await new Response(proc.stderr).text()
-  const code = await proc.exited
-  if (code !== 0) {
-    throw new Error(stderr.trim() || `Command failed: ${command.join(' ')}`)
-  }
-  return stdout.trim()
-}
-
-async function run(label: string, command: string[]): Promise<void> {
-  console.log(`\u001B[1;34m==>\u001B[0m ${label}`)
-  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
-  const stdout = await new Response(proc.stdout).text()
-  const stderr = await new Response(proc.stderr).text()
-  const code = await proc.exited
-  if (stdout.trim()) console.log(stdout.trim())
-  if (code !== 0) {
-    console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
-    if (stderr.trim()) console.error(stderr.trim())
-    process.exit(1)
-  }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise(resolvePromise => setTimeout(resolvePromise, ms))
-}
-
-function ssh(host: string, command: string): string[] {
-  return [
-    'ssh',
-    '-o',
-    'BatchMode=yes',
-    '-o',
-    'StrictHostKeyChecking=accept-new',
-    '-o',
-    'ConnectTimeout=10',
-    `${REMOTE_USER}@${host}`,
-    command,
-  ]
-}
-
-export async function getSshFingerprint(keyName?: string): Promise<string> {
+export async function getGatewaySshFingerprint(keyName?: string): Promise<string> {
   const name = keyName ?? process.env.GATEWAY_SSH_KEY_NAME ?? 'fro-bot-gateway'
-  const raw = await runCapture(['doctl', 'compute', 'ssh-key', 'list', '--format', 'Name,FingerPrint', '--no-header'])
-
-  // Each row: "<Name padded with spaces>  <FingerPrint>"
-  // The Name column can contain spaces, @, and dots, so we treat the last
-  // whitespace-delimited token as the fingerprint and everything before it as the name.
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    const lastSpace = trimmed.lastIndexOf(' ')
-    if (lastSpace === -1) continue
-    const rowName = trimmed.slice(0, lastSpace).trim()
-    const fingerprint = trimmed.slice(lastSpace + 1).trim()
-    if (rowName === name) {
-      return fingerprint
-    }
-  }
-
-  throw new Error(
-    `SSH key named "${name}" not found in DigitalOcean account. ` +
-      `Run \`doctl compute ssh-key list\` to see available keys, ` +
-      `or set GATEWAY_SSH_KEY_NAME to override the default ("fro-bot-gateway").`,
-  )
-}
-
-async function getDropletIpWithWait(): Promise<string> {
-  for (let attempt = 1; attempt <= 20; attempt += 1) {
-    const ip = await runCapture([
-      'doctl',
-      'compute',
-      'droplet',
-      'get',
-      DROPLET_NAME,
-      '--format',
-      'PublicIPv4',
-      '--no-header',
-    ])
-    if (ip) {
-      return ip
-    }
-    await sleep(5_000)
-  }
-
-  throw new Error('Timed out waiting for droplet IPv4 address')
-}
-
-async function waitForSsh(host: string): Promise<void> {
-  for (let attempt = 1; attempt <= 24; attempt += 1) {
-    const proc = Bun.spawn(ssh(host, 'echo ready'), {stdout: 'pipe', stderr: 'pipe'})
-    const code = await proc.exited
-    if (code === 0) {
-      return
-    }
-    await sleep(5_000)
-  }
-
-  throw new Error('Timed out waiting for SSH connectivity to droplet')
+  return getSshFingerprint(name, {envVarName: 'GATEWAY_SSH_KEY_NAME', defaultKeyName: 'fro-bot-gateway'})
 }
 
 function printOperatorSetupMessage(dropletIp: string, gatewayHost: string): void {
@@ -250,7 +108,7 @@ function printOperatorSetupMessage(dropletIp: string, gatewayHost: string): void
 export async function main(): Promise<void> {
   const {force, checkExists} = parseProvisionArgs(process.argv.slice(2))
 
-  validateDoctl()
+  await validateDoctl({checkAuth: true})
 
   if (checkExists) {
     console.log(JSON.stringify(await checkDropletExistence()))
@@ -266,8 +124,6 @@ export async function main(): Promise<void> {
 
   const gatewayHost = process.env.GATEWAY_HOST ?? ''
 
-  await run('Validating doctl authentication', ['doctl', 'account', 'get'])
-
   const exists = await dropletExists(DROPLET_NAME)
 
   if (exists && !force) {
@@ -282,7 +138,7 @@ export async function main(): Promise<void> {
   }
 
   if (!exists) {
-    const fingerprint = await getSshFingerprint()
+    const fingerprint = await getGatewaySshFingerprint()
     await run(`Creating droplet ${DROPLET_NAME}`, [
       'doctl',
       'compute',
@@ -301,11 +157,13 @@ export async function main(): Promise<void> {
     ])
   }
 
-  const dropletIp = await getDropletIpWithWait()
-  await waitForSsh(dropletIp)
+  const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
+  await waitForSsh(dropletIp, REMOTE_USER)
 
   const knownHostsPath = resolve(join(import.meta.dir, '..', '..', '..', '.github', 'known_hosts'))
-  await pinHostKeys(gatewayHost, dropletIp, knownHostsPath)
+  await pinHostKeys(gatewayHost, dropletIp, knownHostsPath, {
+    marker: `# gateway droplet (${dropletIp} / ${gatewayHost})`,
+  })
 
   printOperatorSetupMessage(dropletIp, gatewayHost)
 }

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -12,6 +12,8 @@ import {
   waitForSsh,
 } from '@marcusrbrown/infra-shared/server/droplet-helpers'
 
+import {validateGatewayHost} from '../src/host'
+
 const DROPLET_NAME = 'gateway'
 const DROPLET_IMAGE = 'docker-20-04'
 const DROPLET_SIZE = 's-1vcpu-2gb'
@@ -122,7 +124,7 @@ export async function main(): Promise<void> {
     process.exit(1)
   }
 
-  const gatewayHost = process.env.GATEWAY_HOST ?? ''
+  const gatewayHost = validateGatewayHost(process.env.GATEWAY_HOST ?? '')
 
   const exists = await dropletExists(DROPLET_NAME)
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,17 +26,23 @@
     },
     "apps/cliproxy": {
       "name": "@marcusrbrown/infra-cliproxy",
+      "dependencies": {
+        "@marcusrbrown/infra-shared": "workspace:*",
+      },
     },
     "apps/gateway": {
       "name": "@marcusrbrown/infra-gateway",
       "version": "0.0.0",
+      "dependencies": {
+        "@marcusrbrown/infra-shared": "workspace:*",
+      },
     },
     "apps/keeweb": {
       "name": "@marcusrbrown/infra-keeweb",
     },
     "packages/cli": {
       "name": "@marcusrbrown/infra",
-      "version": "0.4.9",
+      "version": "0.4.11",
       "bin": {
         "infra": "src/cli.ts",
       },
@@ -50,6 +56,10 @@
       "devDependencies": {
         "yaml": "2.9.0",
       },
+    },
+    "packages/shared": {
+      "name": "@marcusrbrown/infra-shared",
+      "version": "0.0.0",
     },
   },
   "packages": {
@@ -160,6 +170,8 @@
     "@marcusrbrown/infra-gateway": ["@marcusrbrown/infra-gateway@workspace:apps/gateway"],
 
     "@marcusrbrown/infra-keeweb": ["@marcusrbrown/infra-keeweb@workspace:apps/keeweb"],
+
+    "@marcusrbrown/infra-shared": ["@marcusrbrown/infra-shared@workspace:packages/shared"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,25 @@
+# Shared Ops Helpers
+
+Shared TypeScript utilities for DigitalOcean droplet provisioning. Used by `apps/cliproxy` and `apps/gateway` provision scripts. Not consumed by the published `@marcusrbrown/infra` runtime CLI.
+
+## CONTENTS
+
+| File | Description |
+| --- | --- |
+| `server/droplet-helpers.ts` | Shared helpers: `ssh`, `scp`, `run`, `runCapture`, `sleep`, `validateDoctl`, `dropletExists`, `getSshFingerprint`, `getDropletIpWithWait`, `waitForSsh`, `pinHostKeys` |
+
+## USAGE
+
+Import directly from the workspace path:
+
+```ts
+import {ssh, run, validateDoctl} from '@marcusrbrown/infra-shared/server/droplet-helpers'
+```
+
+## NOTES
+
+- This package is `private: true` — it is never published to npm.
+- Tests are colocated: `server/droplet-helpers.test.ts`.
+- `getSshFingerprint(name)` matches by key name (not first-key). Callers must pass the key name explicitly.
+- `validateDoctl({checkAuth: true})` runs `doctl account get`; the no-arg form only checks PATH.
+- `pinHostKeys` requires an explicit `opts.marker` for idempotency — callers control the marker string.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@marcusrbrown/infra-shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server/droplet-helpers": "./server/droplet-helpers.ts"
+  }
+}

--- a/packages/shared/server/droplet-helpers.test.ts
+++ b/packages/shared/server/droplet-helpers.test.ts
@@ -1,0 +1,411 @@
+import {mkdtempSync, readFileSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
+
+import {
+  dropletExists,
+  getDropletIpWithWait,
+  getSshFingerprint,
+  pinHostKeys,
+  runCapture,
+  scp,
+  sleep,
+  ssh,
+  validateDoctl,
+  waitForSsh,
+} from './droplet-helpers'
+
+// ---------------------------------------------------------------------------
+// Spawn mock helpers
+// ---------------------------------------------------------------------------
+
+interface SpawnResult {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+function makeSpawnResult(stdout: string, exitCode: number): SpawnResult {
+  const enc = new TextEncoder()
+  return {
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(enc.encode(stdout))
+        controller.close()
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+  }
+}
+
+function makeSpawnResultWithStderr(stderr: string, exitCode: number): SpawnResult {
+  const enc = new TextEncoder()
+  return {
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.enqueue(enc.encode(stderr))
+        controller.close()
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spy lifecycle management
+// ---------------------------------------------------------------------------
+
+// Track spies so they're restored even if a test throws.
+const spies: {mockRestore: () => void}[] = []
+
+afterEach(() => {
+  while (spies.length) {
+    spies.pop()?.mockRestore()
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('droplet-helpers', () => {
+  // -------------------------------------------------------------------------
+  // Pure logic: ssh
+  // -------------------------------------------------------------------------
+
+  describe('ssh', () => {
+    it('returns the exact 8-element array with all 3 -o flag pairs and user@host', () => {
+      const result = ssh('1.2.3.4', 'echo hello', 'root')
+      expect(result).toEqual([
+        'ssh',
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'ConnectTimeout=10',
+        'root@1.2.3.4',
+        'echo hello',
+      ])
+    })
+
+    it('uses the provided user in user@host', () => {
+      const result = ssh('example.com', 'ls', 'deploy-user')
+      expect(result[7]).toBe('deploy-user@example.com')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Pure logic: scp
+  // -------------------------------------------------------------------------
+
+  describe('scp', () => {
+    it('returns the exact 8-element array with all 3 -o flag pairs', () => {
+      const result = scp('1.2.3.4', '/local/file', '/remote/path', 'root')
+      expect(result).toEqual([
+        'scp',
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'ConnectTimeout=10',
+        '/local/file',
+        'root@1.2.3.4:/remote/path',
+      ])
+    })
+
+    it('uses the provided user in user@host:target', () => {
+      const result = scp('host.example.com', '/src', '/dst', 'myuser')
+      expect(result[8]).toBe('myuser@host.example.com:/dst')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Pure logic: sleep
+  // -------------------------------------------------------------------------
+
+  describe('sleep', () => {
+    it('resolves after at least the specified milliseconds', async () => {
+      const start = Date.now()
+      await sleep(10)
+      const elapsed = Date.now() - start
+      expect(elapsed).toBeGreaterThanOrEqual(9) // allow 1ms tolerance
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // validateDoctl
+  // -------------------------------------------------------------------------
+
+  describe('validateDoctl', () => {
+    it('throws with install URL when doctl is not on PATH', async () => {
+      const whichSpy = spyOn(Bun, 'which').mockReturnValue(null)
+      spies.push(whichSpy)
+
+      await expect(validateDoctl()).rejects.toThrow(/doctl is required/)
+      await expect(validateDoctl()).rejects.toThrow(/https:\/\/docs\.digitalocean\.com/)
+    })
+
+    it('does not call spawn when doctl is found (no-arg form)', async () => {
+      const whichSpy = spyOn(Bun, 'which').mockReturnValue('/usr/local/bin/doctl')
+      const spawnSpy = spyOn(Bun, 'spawn')
+      spies.push(whichSpy, spawnSpy)
+
+      await validateDoctl()
+
+      expect(spawnSpy).not.toHaveBeenCalled()
+    })
+
+    it('runs doctl account get when checkAuth is true', async () => {
+      const whichSpy = spyOn(Bun, 'which').mockReturnValue('/usr/local/bin/doctl')
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('account info', 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(whichSpy, spawnSpy)
+
+      await validateDoctl({checkAuth: true})
+
+      expect(spawnSpy).toHaveBeenCalledTimes(1)
+      const cmd = spawnSpy.mock.calls[0]?.[0] as string[]
+      expect(cmd).toContain('doctl')
+      expect(cmd).toContain('account')
+      expect(cmd).toContain('get')
+    })
+
+    it('throws when doctl account get returns non-zero', async () => {
+      const whichSpy = spyOn(Bun, 'which').mockReturnValue('/usr/local/bin/doctl')
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResultWithStderr('unauthorized', 1) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(whichSpy, spawnSpy)
+
+      await expect(validateDoctl({checkAuth: true})).rejects.toThrow(/unauthorized/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // runCapture
+  // -------------------------------------------------------------------------
+
+  describe('runCapture', () => {
+    it('returns trimmed stdout on exit 0', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('  hello world  \n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const result = await runCapture(['echo', 'hello world'])
+      expect(result).toBe('hello world')
+    })
+
+    it('throws with stderr text on non-zero exit', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResultWithStderr('something went wrong', 1) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      await expect(runCapture(['false'])).rejects.toThrow(/something went wrong/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // dropletExists
+  // -------------------------------------------------------------------------
+
+  describe('dropletExists', () => {
+    it('returns true when name is in stdout', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('cliproxy\nother-droplet\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const result = await dropletExists('cliproxy')
+      expect(result).toBe(true)
+    })
+
+    it('returns false when name is not in stdout', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('other-droplet\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const result = await dropletExists('cliproxy')
+      expect(result).toBe(false)
+    })
+
+    it('throws when doctl fails', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResultWithStderr('doctl error', 1) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      await expect(dropletExists('cliproxy')).rejects.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getSshFingerprint
+  // -------------------------------------------------------------------------
+
+  const MULTI_KEY_OUTPUT = [
+    'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+    'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+    'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+    'fro-bot-cliproxy                                      e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+  ].join('\n')
+
+  describe('getSshFingerprint', () => {
+    it('finds the row matching name and returns the fingerprint', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const fp = await getSshFingerprint('fro-bot-cliproxy')
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+      // Must NOT return the first key's fingerprint
+      expect(fp).not.toBe('91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9')
+    })
+
+    it('supports key names with internal whitespace', async () => {
+      const spacedKeyOutput = [
+        'fro-bot-cliproxy                                      e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+        'my key with spaces                                    11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00',
+        'another-key                                           ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(spacedKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const fp = await getSshFingerprint('my key with spaces')
+      expect(fp).toBe('11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00')
+    })
+
+    it('throws a helpful error mentioning the key name when not found', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(getSshFingerprint('nonexistent-key')).rejects.toThrow(/nonexistent-key/)
+      await expect(getSshFingerprint('nonexistent-key')).rejects.toThrow(/not found/)
+    })
+
+    it('throws on doctl non-zero exit', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResultWithStderr('unauthorized', 1) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      await expect(getSshFingerprint('fro-bot-cliproxy')).rejects.toThrow(/unauthorized/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getDropletIpWithWait
+  // -------------------------------------------------------------------------
+
+  describe('getDropletIpWithWait', () => {
+    it('returns IP on first attempt when doctl returns IP', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('1.2.3.4', 0) as ReturnType<typeof Bun.spawn>,
+      )
+      spies.push(spawnSpy)
+
+      const ip = await getDropletIpWithWait('cliproxy', {maxAttempts: 2, intervalMs: 1})
+      expect(ip).toBe('1.2.3.4')
+    })
+
+    it('times out and throws after maxAttempts when doctl returns empty', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(makeSpawnResult('', 0) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResult('', 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(getDropletIpWithWait('cliproxy', {maxAttempts: 2, intervalMs: 1})).rejects.toThrow(/Timed out/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // waitForSsh
+  // -------------------------------------------------------------------------
+
+  describe('waitForSsh', () => {
+    it('resolves when spawn returns exit 0', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(makeSpawnResult('ready', 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(waitForSsh('1.2.3.4', 'root', {maxAttempts: 2, intervalMs: 1})).resolves.toBeUndefined()
+    })
+
+    it('throws after maxAttempts when spawn returns non-zero each time', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(makeSpawnResult('', 1) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResult('', 1) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(waitForSsh('1.2.3.4', 'root', {maxAttempts: 2, intervalMs: 1})).rejects.toThrow(/Timed out/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // pinHostKeys
+  // -------------------------------------------------------------------------
+
+  describe('pinHostKeys', () => {
+    let tmpDir: string
+    let knownHostsPath: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'shared-test-'))
+      knownHostsPath = join(tmpDir, 'known_hosts')
+      writeFileSync(knownHostsPath, '')
+    })
+
+    it('writes both unhashed domain and hashed IP keys to known_hosts', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(
+          makeSpawnResult('example.com ssh-ed25519 AAAA...domain', 0) as ReturnType<typeof Bun.spawn>,
+        )
+        .mockReturnValueOnce(makeSpawnResult('|1|hash== ssh-ed25519 AAAA...ip', 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await pinHostKeys('example.com', '1.2.3.4', knownHostsPath, {
+        marker: '# cliproxy droplet (1.2.3.4 / example.com)',
+      })
+
+      const contents = readFileSync(knownHostsPath, 'utf-8')
+      expect(contents).toContain('example.com ssh-ed25519')
+      expect(contents).toContain('|1|hash==')
+      expect(contents).toContain('# cliproxy droplet (1.2.3.4 / example.com)')
+    })
+
+    it('is idempotent when marker already present — no-op', async () => {
+      const marker = '# cliproxy droplet (1.2.3.4 / example.com)'
+      writeFileSync(knownHostsPath, `${marker}\nexample.com ssh-ed25519 AAAA...\n`)
+
+      const spawnSpy = spyOn(Bun, 'spawn')
+      spies.push(spawnSpy)
+
+      await pinHostKeys('example.com', '1.2.3.4', knownHostsPath, {marker})
+
+      expect(spawnSpy).not.toHaveBeenCalled()
+      const contents = readFileSync(knownHostsPath, 'utf-8')
+      expect(contents.split(marker).length).toBe(2) // only one occurrence
+    })
+  })
+})

--- a/packages/shared/server/droplet-helpers.ts
+++ b/packages/shared/server/droplet-helpers.ts
@@ -1,0 +1,255 @@
+import {appendFileSync, readFileSync} from 'node:fs'
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds an SSH command array with standard BatchMode/StrictHostKeyChecking/ConnectTimeout flags.
+ */
+export function ssh(host: string, command: string, user: string): string[] {
+  return [
+    'ssh',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=accept-new',
+    '-o',
+    'ConnectTimeout=10',
+    `${user}@${host}`,
+    command,
+  ]
+}
+
+/**
+ * Builds an SCP command array with standard BatchMode/StrictHostKeyChecking/ConnectTimeout flags.
+ */
+export function scp(host: string, source: string, target: string, user: string): string[] {
+  return [
+    'scp',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=accept-new',
+    '-o',
+    'ConnectTimeout=10',
+    source,
+    `${user}@${host}:${target}`,
+  ]
+}
+
+/**
+ * Sleeps for the given number of milliseconds.
+ */
+export async function sleep(ms: number): Promise<void> {
+  await new Promise(resolvePromise => setTimeout(resolvePromise, ms))
+}
+
+// ---------------------------------------------------------------------------
+// Spawn-based helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a command, streams stdout, exits process on non-zero exit code.
+ */
+export async function run(label: string, command: string[]): Promise<void> {
+  console.log(`\u001B[1;34m==>\u001B[0m ${label}`)
+  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (stdout.trim()) console.log(stdout.trim())
+  if (code !== 0) {
+    console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
+    if (stderr.trim()) console.error(stderr.trim())
+    process.exit(1)
+  }
+}
+
+/**
+ * Runs a command and returns trimmed stdout. Throws on non-zero exit with stderr message.
+ */
+export async function runCapture(command: string[]): Promise<string> {
+  const proc = Bun.spawn(command, {stdout: 'pipe', stderr: 'pipe'})
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(stderr.trim() || `Command failed: ${command.join(' ')}`)
+  }
+  return stdout.trim()
+}
+
+export interface ValidateDoctlOptions {
+  /** When true, also runs `doctl account get` to verify authentication. */
+  checkAuth?: boolean
+}
+
+/**
+ * Checks that doctl is available on PATH. Throws with install instructions if not.
+ * When opts.checkAuth is true, also runs `doctl account get`.
+ */
+export async function validateDoctl(opts?: ValidateDoctlOptions): Promise<void> {
+  if (!Bun.which('doctl')) {
+    throw new Error(
+      'doctl is required. Install it first: https://docs.digitalocean.com/reference/doctl/how-to/install/',
+    )
+  }
+
+  if (opts?.checkAuth) {
+    await runCapture(['doctl', 'account', 'get'])
+  }
+}
+
+/**
+ * Checks whether a droplet with the given name exists in the DigitalOcean account.
+ */
+export async function dropletExists(name: string): Promise<boolean> {
+  const proc = Bun.spawn(['doctl', 'compute', 'droplet', 'list', '--format', 'Name', '--no-header'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(stderr.trim() || 'Failed to list droplets')
+  }
+  const names = stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+  return names.includes(name)
+}
+
+/**
+ * Finds the SSH key fingerprint for the named key in the DigitalOcean account.
+ * Matches by name (supports names with internal whitespace).
+ * Throws a helpful error if the key is not found.
+ */
+export interface GetSshFingerprintOptions {
+  /** Env var name to mention in the not-found error message, e.g. 'CLIPROXY_SSH_KEY_NAME'. */
+  envVarName?: string
+  /** Default key name to mention in the not-found error message, e.g. 'fro-bot-cliproxy'. */
+  defaultKeyName?: string
+}
+
+export async function getSshFingerprint(name: string, opts?: GetSshFingerprintOptions): Promise<string> {
+  const raw = await runCapture(['doctl', 'compute', 'ssh-key', 'list', '--format', 'Name,FingerPrint', '--no-header'])
+
+  // Each row: "<Name padded with spaces>  <FingerPrint>"
+  // The Name column can contain spaces, @, and dots, so we treat the last
+  // whitespace-delimited token as the fingerprint and everything before it as the name.
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const lastSpace = trimmed.lastIndexOf(' ')
+    if (lastSpace === -1) continue
+    const rowName = trimmed.slice(0, lastSpace).trim()
+    const fingerprint = trimmed.slice(lastSpace + 1).trim()
+    if (rowName === name) {
+      return fingerprint
+    }
+  }
+
+  const remediation =
+    opts?.envVarName && opts?.defaultKeyName
+      ? ` or set ${opts.envVarName} to override the default ("${opts.defaultKeyName}")`
+      : ''
+  throw new Error(
+    `SSH key named "${name}" not found in DigitalOcean account. ` +
+      `Run \`doctl compute ssh-key list\` to see available keys${remediation}.`,
+  )
+}
+
+export interface RetryOptions {
+  maxAttempts?: number
+  intervalMs?: number
+}
+
+/**
+ * Polls doctl for the droplet's public IPv4 address until it appears.
+ * Defaults: 20 attempts × 5000ms.
+ */
+export async function getDropletIpWithWait(dropletName: string, opts?: RetryOptions): Promise<string> {
+  const maxAttempts = opts?.maxAttempts ?? 20
+  const intervalMs = opts?.intervalMs ?? 5_000
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const ip = await runCapture([
+      'doctl',
+      'compute',
+      'droplet',
+      'get',
+      dropletName,
+      '--format',
+      'PublicIPv4',
+      '--no-header',
+    ])
+    if (ip) {
+      return ip
+    }
+    await sleep(intervalMs)
+  }
+
+  throw new Error('Timed out waiting for droplet IPv4 address')
+}
+
+/**
+ * Waits for SSH connectivity to the given host.
+ * Defaults: 24 attempts × 5000ms.
+ */
+export async function waitForSsh(host: string, user: string, opts?: RetryOptions): Promise<void> {
+  const maxAttempts = opts?.maxAttempts ?? 24
+  const intervalMs = opts?.intervalMs ?? 5_000
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const proc = Bun.spawn(ssh(host, 'echo ready', user), {stdout: 'pipe', stderr: 'pipe'})
+    const code = await proc.exited
+    if (code === 0) {
+      return
+    }
+    await sleep(intervalMs)
+  }
+
+  throw new Error('Timed out waiting for SSH connectivity to droplet')
+}
+
+export interface PinHostKeysOptions {
+  /** Marker line written before the key block, used for idempotency detection. */
+  marker: string
+}
+
+/**
+ * Appends domain (unhashed) and IP (hashed) host key entries to the given known_hosts file.
+ * Idempotent: if the marker is already present, skips the append.
+ */
+export async function pinHostKeys(
+  domain: string,
+  ip: string,
+  knownHostsPath: string,
+  opts: PinHostKeysOptions,
+): Promise<void> {
+  const existing = readFileSync(knownHostsPath, 'utf-8')
+  const {marker} = opts
+
+  if (existing.includes(marker)) {
+    console.log(`\u001B[1;34m==>\u001B[0m Host keys already pinned for ${ip}`)
+    return
+  }
+
+  const domainKeys = await runCapture(['ssh-keyscan', domain])
+  const ipKeys = await runCapture(['ssh-keyscan', '-H', ip])
+
+  if (!domainKeys.trim() && !ipKeys.trim()) {
+    console.warn(
+      `Both ssh-keyscan calls returned empty output for domain=${domain} ip=${ip}. Skipping known_hosts pin.`,
+    )
+    return
+  }
+
+  const newBlock = `\n${marker}\n${domainKeys}\n${ipKeys}\n`
+  appendFileSync(knownHostsPath, newBlock)
+  console.log(`\u001B[1;32m✓\u001B[0m Pinned host keys for ${ip} / ${domain} in .github/known_hosts`)
+  console.log('  Commit the updated .github/known_hosts before running CI deploy.')
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@bfra.me/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["bun"],
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules", ".cache"]
+}


### PR DESCRIPTION
## Summary

The cliproxy and gateway provision scripts had ~200 lines of duplicated DigitalOcean helpers — `ssh`/`scp` builders, `run`/`runCapture`, `sleep`, `validateDoctl`, `dropletExists`, `getSshFingerprint`, `getDropletIpWithWait`, `waitForSsh`, `pinHostKeys`. Worse, they had diverged subtly: cliproxy's `getSshFingerprint` returned the *first* SSH key regardless of name (a latent bug — gateway already used name-based lookup since PR #268), and `validateDoctl` had inconsistent auth-check behavior across the two callers.

This PR consolidates all 10 helpers into a new private workspace `@marcusrbrown/infra-shared` at `packages/shared/`. Both provision scripts now import from the shared module. The name-based SSH key lookup is backported to cliproxy via a new `CLIPROXY_SSH_KEY_NAME` env var (default `fro-bot-cliproxy`), mirroring the existing `GATEWAY_SSH_KEY_NAME`/`fro-bot-gateway` pattern.

## What's in the diff

- **`packages/shared/`** — new private workspace `@marcusrbrown/infra-shared`. Contains the 10 helpers plus 24 TDD-first unit tests in `server/droplet-helpers.test.ts` covering pure logic, spawn-mocked behavior, retry boundaries, and pinning idempotency. AGENTS.md documents the module shape and consumer contract.
- **`apps/cliproxy/server/provision-droplet.ts`** — 231 lines deleted (helpers extracted). Call sites pass the new opts where needed. New env var `CLIPROXY_SSH_KEY_NAME` documented in `apps/cliproxy/AGENTS.md`.
- **`apps/gateway/server/provision-droplet.ts`** — 186 lines deleted. Gateway already used name-based key lookup, so no behavioral change beyond the cleanup. `validateDoctl({checkAuth: true})` replaces the prior separate PATH-check + manual `doctl account get` call pair (see "Hardening" below).
- **`apps/gateway/server/provision-droplet.test.ts`** — 225 lines deleted (duplicate helper tests). Gateway-specific tests retained (env validation, arg parsing, existence-state wrapper).
- **`AGENTS.md`** (root) — new `packages/shared/` entry in the structure tree; `ssh-keyscan` anti-pattern reworded to reference the shared helper.
- **`bun.lock`** — workspace dependency link.

Net delta: 13 files, +839/-546.

## Hardening applied while extracting

The refactor went through `ce:review` autofix. Four findings were resolved in this PR:

1. **Restored empty-`ssh-keyscan` guard** — both `pinHostKeys` callers now skip pinning when both scans return zero exit but empty stdout (transparent proxy / silent network drop). The cliproxy version had this; the gateway version did not.
2. **Caller-neutral `getSshFingerprint` error** — the not-found message no longer hardcodes cliproxy's env var name. Each consumer passes `{envVarName, defaultKeyName}` and gets a remediation hint pointing at the right env var.
3. **`Bun.spawn` spy cleanup via `afterEach`** — shared test file no longer leaks spies when a test throws mid-flight.
4. **Simpler gateway doctl validation** — `validateDoctl({checkAuth: true})` replaces the prior PATH-check + manual `doctl account get` pair (eliminates one redundant `Bun.spawn`).

One subtle behavior change worth flagging: gateway's doctl auth check now runs *before* env var validation, where it previously ran *after*. Strictly better UX (auth issues surface before the operator has to set env vars), and matches cliproxy's existing ordering.

## Why no changeset

`@marcusrbrown/infra-shared` is `private: true` and is **not** imported by the published `@marcusrbrown/infra` CLI (`packages/cli/src/`). Confirmed via `rg "@marcusrbrown/infra-shared" packages/cli/src` returning no matches. This refactor has zero runtime impact on the published package.

## Verification

```
bun install                      # workspace re-linked, bun.lock updated
bun run lint                     # 0 errors, 42 warnings (pre-existing no-console in provision scripts)
bunx tsc --noEmit                # clean
bun test --recursive             # 433 pass, 0 fail (up from 418 baseline: +24 new shared - 9 removed duplicates)
bun run --cwd apps/cliproxy provision-droplet --help   # script parses, exits cleanly
bun run --cwd apps/gateway provision --help            # script parses, exits cleanly
```

## Deferred follow-ups (not blocking this PR)

`ce:review` flagged 7 residual items, all P2/P3, all in the test/type-hardening category. Tracked in `.context/systematic/ce-review/20260523-112326-d2b60bf8/run-summary.md`:

- Add direct unit tests for `run` (zero-exit + non-zero `process.exit(1)` paths)
- Add transient-failure recovery tests for `getDropletIpWithWait`/`waitForSsh` (currently only test first-success + full-timeout)
- Add `pinHostKeys` ssh-keyscan failure coverage
- Thread `validateGatewayHost` through gateway's `pinHostKeys` call so corrupted `GATEWAY_HOST` env values can't reach the helper
- Tighten `pinHostKeys` marker parameter from `string` to a branded/parsed type (prevent newline injection into known_hosts)
- Apply similar parsed-types narrowing to SSH command builders for `host`/`user` params
- Relax `ssh`/`scp` test assertions away from exact `-o` ordering (currently brittle)

None of these gate the extraction. They're incremental hardening for a future tightening PR.

## Refs

Closes the work tracked under note #104 (provision-droplet helper extraction audit).
