### PR TITLE
feat(cli): MCP fidelity for status-only commands

### DIFF
--- a/.changeset/mcp-fidelity-status-only.md
+++ b/.changeset/mcp-fidelity-status-only.md
@@ -1,0 +1,11 @@
+---
+"@marcusrbrown/infra": minor
+---
+
+MCP server now returns the same formatted output operators see at the terminal, instead of empty content. The change refactors the 10 read-style commands (`gateway status`, `gateway backup`, `cliproxy status`, `cliproxy keys list/add/remove`, `cliproxy config get/set`, `keeweb status`, and the unified `status` dashboard) to route output through goke's per-action execution context, so `@goke/mcp` captures it into the `CallToolResult`.
+
+Two commands (`cliproxy keys list` and `cliproxy config get`) additionally return parseable structured data alongside the formatted text — MCP consumers receive both blocks, so agents can act on the data without re-parsing the formatted output.
+
+The 9 CLI-only commands (deploys, gateway logs, gateway restore, cliproxy login/open/setup, keeweb open) are deliberately excluded from MCP via an explicit `commandFilter` allowlist in `mcp.ts`. Each exclusion has a one-line reason in the source — subprocess streaming deferred to MCP v2 (#291), TTY requirements, destructive policy (#292), and host-machine side effects.
+
+`packages/cli/AGENTS.md` documents the full MCP fidelity contract: allowlist authority, ctx threading rules, Mode C eligibility criteria, the Tier-1+Tier-2 test bar, and `@goke/mcp` upgrade discipline (pre-1.0 means manual review).

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "yaml": "2.9.0",
       },
     },

--- a/docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md
+++ b/docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md
@@ -1,0 +1,116 @@
+---
+date: 2026-05-23
+topic: mcp-fidelity-status-only
+---
+
+# MCP Fidelity for Read-Style CLI Commands
+
+## Summary
+
+`infra mcp` exposes 19 CLI tools today; every one returns empty `content` because actions write to global `console.log` and the `Bun.spawn({stdout: 'inherit'})` subprocess flow that `@goke/mcp@0.0.10` cannot capture. This brainstorm scopes a refactor that wires the 10 read-style commands through the goke execution context so MCP returns the same human-readable output that operators see at a terminal, plus an explicit structured-return escape hatch for the two commands that already produce parseable data (`cliproxy_keys_list`, `cliproxy_config_get`). The 9 commands that depend on real-tty I/O, interactive prompts, or destructive policy stay out of MCP by an explicit `commandFilter` allowlist.
+
+---
+
+## Problem Frame
+
+`@goke/mcp@0.0.10` provides a per-action `ctx` argument with capture streams: `ctx.console.log` and `ctx.process.stdout.write` get hoisted into the `CallToolResult.content`, but global `console.log` writes go nowhere (or worse, corrupt the JSON-RPC channel that shares `process.stdout`). Today every action in `packages/cli/src/commands/` writes via the globals, so every MCP tool returns `{"content":[{"type":"text","text":""}]}`.
+
+Two pains compound:
+
+1. **Empty tool responses train agents that the tool surface is broken.** An agent that tries `cliproxy_status` and gets nothing back has no way to know whether the proxy is healthy, whether the call failed silently, or whether the tool is mis-implemented. Either it stops calling these tools (lost capability) or it learns to ignore null responses (lost signal).
+2. **9 of the 19 commands cannot be safely captured** (`gateway deploy`, `gateway logs`, `gateway restore`, `cliproxy deploy`, `cliproxy login`, `cliproxy open`, `cliproxy setup`, `keeweb deploy`, `keeweb open`). They spawn subprocesses with `stdout: 'inherit'`, use `@clack/prompts`, wait on TTY input, or perform destructive mutations that should require explicit operator approval. Exposing them as MCP tools — even working tools — is misleading because agents can't invoke them safely or shouldn't be allowed to.
+
+**Why now:** Fro Bot already calls into this CLI via MCP during autohealing (category 5 deploy-pipeline-health checks, see `.github/workflows/fro-bot.yaml`). Each of those `cliproxy_status` / `gateway_status` invocations gets back empty content, so the autohealing report has to fall back to running `gh` queries directly instead of using the proxy/gateway's own health surface. The cost compounds: every new app added to the autohealing surface inherits the same empty-content limitation until this is fixed.
+
+Memory #3191 captured the root cause when this surfaced as a smoke-test gap in `ce:review` run `20260517-225635-143624c4`. Memory #3618 set the gate "design work stays paused until `@goke/mcp` capture behavior is verified" — that gate cleared in this session when the contract was confirmed empirically from `node_modules/.bun/@goke+mcp@0.0.10+a6b6ab9123cdf578/node_modules/@goke/mcp/src/cli-to-mcp.ts`.
+
+---
+
+## Requirements
+
+**Action refactor**
+
+- R1. The 10 read-style commands' action callbacks accept the goke execution context as their last positional argument (`(options, ctx) => ...`) and route all user-facing output directly through `ctx.console.log` / `ctx.console.error` / `ctx.process.stdout.write` / `ctx.process.stderr.write` instead of the global `console` / `process.stdout` / `process.stderr`. Helper signatures (e.g., `formatSummary`, the table-printers, the `OK`/`WARN`/`ERROR` line builders) stay unchanged; actions inline-build captured text via `ctx.console` directly, since helpers return strings or structured objects today and the action already does the print step.
+- R2. Process exits driven by failures continue to surface — actions call `ctx.process.exit(code)` (which `@goke/mcp` converts to `GokeProcessExit` and then to an error `CallToolResult`) rather than mutating `process.exitCode` or calling global `process.exit`.
+- R3. **Structured-return escape hatch (Mode C exception).** Two commands MAY additionally return raw structured data alongside their captured text output: `cliproxy_keys_list` (returns `{api-keys: string[]}`) and `cliproxy_config_get` (returns the full config object). `@goke/mcp`'s `buildCallToolResult` will emit both blocks — captured human-readable text first, stringified structured value second — when an action both writes to `ctx.console` and returns a non-empty value. The other 8 commands stay text-only.
+
+**Tool surface and filtering**
+
+- R4. `createMcpAction` in `packages/cli/src/commands/mcp.ts` receives an explicit `commandFilter` that admits only the 10 in-scope commands. The filter is a single source-of-truth `Set<string>` in the same module, sized small enough that adding a future capturable command requires one edit. Each cli-only command stays excluded for a stated reason: `gateway deploy` / `cliproxy deploy` / `keeweb deploy` / `gateway logs` use `Bun.spawn({stdout: 'inherit'})` (subprocess streaming, deferred); `cliproxy login` / `cliproxy open` / `cliproxy setup` require a TTY and stdin (interactive, no agent surface); `gateway restore` mutates the live gateway by replacing the mitmproxy CA (destructive policy); `keeweb open` spawns a local browser (host-machine side effect that an agent should not trigger without user intent).
+
+**Test contracts**
+
+- R5. A Tier-1 integration test spawns `bunx infra mcp`, sends a `tools/list` JSON-RPC request, and asserts the returned tool names match the 10-command allowlist exactly (no missing, no extra). The test asserts the `inputSchema` shape for each tool is present (does not assert exact field-by-field shape — that's `@goke/mcp`'s contract).
+- R6. Tier-2 unit tests cover each of the 10 refactored actions individually via a **shared `ctx` fixture** that mirrors `@goke/mcp`'s real construction:
+  - `ctx.console.log` / `ctx.console.error` capture into arrays
+  - `ctx.process.stdout.write` / `ctx.process.stderr.write` capture into arrays
+  - `ctx.process.exit(code)` throws an `Error` tagged with the exit code (so tests can assert exit behavior without killing the test runner)
+  - Each action is invoked with a stubbed system surface (mocked `fetch` for HTTP, spied `Bun.spawn` for SSH, etc.) and tested for: (a) **captured output is non-empty** on success path, (b) **captured output references contract markers** for the command — e.g., `cliproxy_status` captured text contains the version field, `gateway_backup` captured text contains the output path and byte count, `cliproxy_keys_list` captured text contains every key from the mocked API response, (c) **failures throw via `ctx.process.exit`** with the correct exit code and the captured error stream contains the failure reason.
+- R7. The existing 451-test baseline continues to pass after the refactor with no test deletions. Existing action-level tests that use `spyOn(console, 'log')` (e.g., `packages/cli/src/commands/status.test.ts`) MUST be migrated to use the new shared `ctx` fixture rather than global `console` spies — otherwise they will silently no-op once actions route through `ctx.console`. Any test that cannot be migrated must be replaced by a stronger assertion in the `droplet-helpers.test.ts` style, not deleted to bypass a failure.
+
+**Out-of-scope guarantees**
+
+- R8. `bunx infra mcp` lists exactly 10 tools. When an agent calls `tools/list` on the running MCP server, the cli-only commands MUST NOT appear in the result.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4, R8.** Given `infra mcp` is running, when an agent sends `{"method": "tools/list"}`, the response `tools` array contains exactly 10 entries whose names are: `gateway_status`, `gateway_backup`, `cliproxy_status`, `keeweb_status`, `status`, `cliproxy_keys_list`, `cliproxy_keys_add`, `cliproxy_keys_remove`, `cliproxy_config_get`, `cliproxy_config_set`. None of `gateway_deploy`, `gateway_logs`, `gateway_restore`, `cliproxy_deploy`, `cliproxy_login`, `cliproxy_open`, `cliproxy_setup`, `keeweb_deploy`, `keeweb_open` appear.
+- AE2. **Covers R1, R6.** Given an agent calls `tools/call` with name `cliproxy_status` against the running MCP server and a reachable proxy, the response is a non-error `CallToolResult` whose `content[0].text` contains the same formatted summary string a human sees at `bunx infra cliproxy status` (HTTP status line, usage stats line, version line).
+- AE3. **Covers R2.** Given an agent calls `tools/call` with name `cliproxy_keys_remove` and a value that doesn't match any registered key, the action calls `ctx.process.exit(1)` and `@goke/mcp` returns a `CallToolResult` with `isError: true` and `content` containing the captured error text.
+- AE4. **Covers R3.** Given an agent calls `tools/call` with name `cliproxy_keys_list` against the running MCP server with a reachable proxy that has 3 registered keys, the response `content` array contains two text blocks: the first is the formatted table operators see at `bunx infra cliproxy keys list`, the second is the stringified raw response `{"api-keys": ["key1", "key2", "key3"]}` parsable as JSON by the agent.
+- AE5. **Covers R2, R6.** Given an agent calls `tools/call` with name `gateway_status` against a running MCP server but the gateway droplet is unreachable (SSH connection refused), the action calls `ctx.process.exit(1)` with the SSH failure reason in the captured stderr stream, and `@goke/mcp` returns `CallToolResult` with `isError: true` containing the captured failure text.
+
+---
+
+## Success Criteria
+
+- After the refactor, an agent invoking `tools/list` followed by `tools/call gateway_status` sees the same actionable output (service states, healthy/degraded summary, footer) that an operator sees at the terminal — verified by hand against a live droplet at least once and by AE2 in CI on every change.
+- The 9 cli-only commands stay out of the MCP tool list permanently. Adding a new command that uses `Bun.spawn({stdout: 'inherit'})` does not silently leak into MCP — the explicit allowlist forces a deliberate registration step (per R4).
+- An agent calling `cliproxy_keys_list` or `cliproxy_config_get` gets BOTH a formatted human-readable rendering AND a parseable JSON block in the same response, removing the need to re-parse formatted tables (per R3).
+- A downstream planner reading this doc and the existing `apps/*/AGENTS.md` files can implement the refactor without needing to invent product behavior. The only judgment calls left for planning are: which file path holds the allowlist, what stub shape the shared Tier-2 ctx fixture uses, whether the Mode C structured-return exception applies anywhere beyond the two commands listed in R3.
+
+---
+
+## Scope Boundaries
+
+- **Subprocess streaming refactor is out of scope.** `gateway deploy`, `cliproxy deploy`, `keeweb deploy`, and `gateway logs` use `Bun.spawn({stdout: 'inherit'})` to give operators live progress. Capturing their output for MCP would require buffering subprocess streams and emitting them after completion, which loses live progress at the human CLI unless we also implement a dual-mode write-fanout. That tradeoff deserves its own brainstorm.
+- **Interactive commands are out of scope.** `cliproxy login` (OAuth callback URL paste), `cliproxy open` (SSH TUI), `cliproxy setup` (`@clack/prompts` wizard) all require a TTY and stdin input. Exposing them via MCP would mislead agents into trying to call them.
+- **Destructive commands are out of scope.** `gateway restore` mutates the live gateway by replacing the mitmproxy CA; an MCP-callable restore would let an agent corrupt production without operator approval. Stays cli-only by policy, not just by capture-incompatibility.
+- **The `gateway backup` write-to-disk side effect is in scope.** It writes a tarball to a local path the caller provided. An agent invoking it must pass `--output`; the action validates the path and returns a structured success/failure. This is the lone "filesystem write" tool in v1 — including it tests the contract for write-tools in v2.
+- **No new MCP discovery resource for the cli-only commands.** Considered ("Hybrid: exclude + emit a discovery resource") and rejected because `createMcpAction` doesn't expose hooks to register additional request handlers. Dropping `createMcpAction` to own the lower-level Server construction is ~50 LOC and forward-compat cost not worth paying for v1. Discovery stays in `bunx infra --help` and the per-app `AGENTS.md` files.
+- **No fundamental contract changes to `@goke/mcp`.** The integration uses the published `0.0.10` shape: `createMcpAction({cli, commandFilter})`. If upstream evolves the contract, this brainstorm's design is renegotiated, not extended.
+- **No MCP authentication or capability negotiation.** v1 is stdio transport, default capabilities. Adding HTTP transport, OAuth, or per-tool permission gating is a separate brainstorm.
+
+---
+
+## Key Decisions
+
+- **Mode A (`ctx.console` capture) as the default, with Mode C (mixed text + structured return) as an explicit exception for `cliproxy_keys_list` and `cliproxy_config_get`.** Default text-only keeps the per-command diff small and uniform; the two-command Mode C exception unblocks agents from regex-parsing formatted tables when they could read raw JSON instead. `@goke/mcp`'s `buildCallToolResult` already concatenates captured streams with a stringified return when both are present, so the exception costs zero new framework code.
+- **Pattern A (`ctx` flows via callback parameter) over Pattern B (global console shim middleware) or Pattern C (`withCtx` HOF wrapper).** Per memory #3766 ("no module-load side effects") and the general repo discipline of explicit-over-clever, threading `ctx` as a callback argument is testable, traceable, and impossible to accidentally short-circuit.
+- **Inline `ctx.console` calls in actions, no helper API change.** Earlier draft proposed an optional `output` parameter on every formatter helper for dual CLI/MCP routing. Three reviewers flagged that as ceremony for a one-time mechanical refactor. Helpers stay unchanged; actions inline their `ctx.console.log(formatSummary(result))` calls directly. If a future deploy-streaming refactor needs the helper indirection, add it then.
+- **`commandFilter` Set with stated exclusion rationale, no discovery resource.** `createMcpAction` has no Server hook; the cli-only-but-listed alternative needs ~50 LOC of MCP server boilerplate. Defer until v2 if agents demonstrably need it. R4 captures the rationale for each excluded command inline so the allowlist isn't a magic incantation.
+- **v1 is deliberately a read-only diagnostic surface.** Three reviewers (product-lens, adversarial × 2) challenged the read-only framing as a strategic limitation. Confirmed deliberate: the path to full agent autonomy goes through (a) subprocess-streaming refactor for deploys, (b) authentication/approval gating for mutating tools. Both are explicit v2 work. v1 ships the observability cut because Fro Bot autohealing already calls these tools and is currently getting empty content.
+- **Tier 1 + Tier 2 test bar with a shared `ctx` fixture.** Tier 1 catches "allowlist drift". Tier 2 catches "silent regression" AND "output correctness" via contract markers (e.g., `cliproxy_status` captured text must contain the version line). The shared fixture mirrors `@goke/mcp`'s real `createCallToolExecutionContext` shape so tests don't drift from production capture behavior.
+
+---
+
+## Dependencies / Assumptions
+
+- **`@goke/mcp@0.0.10` capture contract verified.** Action receives `ctx` as last arg; `ctx.console.log` / `ctx.process.stdout.write` get captured into a text block; return-value `{content: [...]}` is honored as a manual escape hatch; non-`{content}` return values get stringified and appended as a trailing text block; `ctx.process.exit(code)` produces an error `CallToolResult` via `GokeProcessExit`. Source: `node_modules/.bun/@goke+mcp@0.0.10+a6b6ab9123cdf578/node_modules/@goke/mcp/src/cli-to-mcp.ts` lines 245-365, 458, 649-686.
+- **Version pinned to `@goke/mcp@0.0.10`.** Any bump (including a 0.0.11 patch) requires re-validation of the capture contract before merging. The action signature, `ctx` shape, `buildCallToolResult` precedence rules, and `GokeProcessExit` translation are all upstream contracts that the design depends on; a quiet contract change would silently break R3, R6, and AE2-AE5. The package.json range MUST be tightened to `~0.0.10` (patch-only) rather than the current `^0.0.10` (minor-permissive), and the Tier-1 integration test must run before any goke/mcp bump lands on main.
+- `goke@6.8.0` does not merge global CLI options into subcommand action types (memory #399). Each refactored action declares its own options via `.option()`. No change to that contract here.
+- The 5 always-on conventions in repo: TypeScript-only (no new bash), no `as any` / `@ts-ignore`, no `bundledDependencies`, ESLint clean, tsc clean.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R4][Technical] Should the allowlist be a typed `readonly tuple` of command names exported from `mcp.ts`, or a `Set<string>` literal? Type-level guarantees vs runtime flexibility. R4 specifies `Set<string>` but the readonly-tuple form would give TypeScript checking when a new command name is added.
+- [Affects R5][Technical] Can the Tier-1 integration test invoke `tools/list` via the `@modelcontextprotocol/sdk` client directly inside Bun (in-process transport), or does it need to spawn a subprocess and pipe JSON-RPC manually? The in-process form is faster + easier to maintain if Bun supports the SDK's transport abstraction.
+- [Affects R6][Needs research] Where should the shared `ctx` fixture live? Two candidates: (a) `packages/cli/src/__test__/mcp-ctx-fixture.ts` exported as a shared helper, (b) inside each command's test file but factored as a local helper module. The former is DRYer if more than 3 command tests use it; the latter avoids a new module if only a few use it.
+- [Affects R8][Technical] Naming of the unified `status` command in MCP — does `@goke/mcp`'s default `sanitizeToolName` translate `status` (single word, no subcommand prefix) to a tool name that doesn't collide with the per-app statuses (`gateway_status`, `cliproxy_status`, `keeweb_status`)? Verify against the empirical `tools/list` output before locking AE1's exact name list — if collisions exist, supply a custom `sanitizeToolName` in `mcp.ts`.
+- [Affects R3][Technical] How to extend the Mode C exception cleanly if a third command needs the structured-return shape later? R3 lists two commands by name; a future command would need a documented criterion for inclusion. Capture criterion in the implementation comment so future maintainers don't have to re-derive it.

--- a/docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md
+++ b/docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md
@@ -1,0 +1,517 @@
+---
+title: MCP Fidelity for Read-Style CLI Commands
+type: feat
+status: active
+date: 2026-05-23
+origin: docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md
+---
+
+# MCP Fidelity for Read-Style CLI Commands
+
+## Overview
+
+`infra mcp` exposes 19 CLI tools via `@goke/mcp@0.0.10`'s `createMcpAction`. Every tool returns empty `content` because the actions write to global `console.log` and `process.stdout`, which the `@goke/mcp` capture flow does not see. This plan wires the 10 read-style commands through goke's per-action execution context (`ctx`) so each tool returns the same formatted output operators see at the terminal, with a structured-return escape hatch for the two commands that naturally produce JSON (`cliproxy keys list`, `cliproxy config get`). The 9 remaining commands stay out of MCP via an explicit `commandFilter` allowlist.
+
+The refactor is mechanical: replace `console.log`/`console.error`/`process.exit` calls in 10 action callbacks with `ctx.console.log`/`ctx.console.error`/`ctx.process.exit`. No helper signatures change. The new pieces are a shared test fixture for `ctx` capture, a Tier-1 in-process integration test that exercises `@goke/mcp` over `InMemoryTransport`, and Tier-2 per-action unit tests asserting captured-output contract markers.
+
+## Problem Frame
+
+`@goke/mcp@0.0.10` reads from a `ctx` object it constructs per tool call. `ctx.console.log` writes hit a `TextCaptureStream` that lands in `CallToolResult.content` as a text block; global `console.log` writes do not get captured (worse: under `StdioServerTransport`, global writes to `process.stdout` corrupt the JSON-RPC channel). The four lines of `packages/cli/src/commands/mcp.ts` use the default `createMcpAction({cli})`, which exposes every registered command as a tool, but every action callback currently routes through globals.
+
+Fro Bot autohealing (`.github/workflows/fro-bot.yaml`, category 5) already calls these tools via MCP and gets back empty content, so the autohealing report has to fall back to running `gh` queries directly. Every new app added to autohealing inherits the same gap until this is fixed.
+
+See origin: `docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md`.
+
+## Requirements Trace
+
+- R1. 10 read-style commands' actions accept `ctx` as last positional arg and route output through `ctx.console`/`ctx.process` instead of globals. Helpers stay unchanged; actions inline-build captured output.
+- R2. Failures call `ctx.process.exit(code)` (not global `process.exit` or `process.exitCode`).
+- R3. Structured-return Mode C exception: `cliproxy_keys_list` and `cliproxy_config_get` return raw structured data alongside captured text.
+- R4. `mcp.ts` passes an explicit `commandFilter` as a `Set<string>` allowlist of the 10 in-scope commands, with each excluded command annotated by reason in a JSDoc-adjacent comment block.
+- R5. Tier-1 integration test exercises `tools/list` in-process against `@goke/mcp` over `InMemoryTransport` from `@modelcontextprotocol/sdk`, asserts the 10 expected tool names and presence of `inputSchema` per command. (The earlier requirements doc framing of "spawns `bunx infra mcp` and pipes JSON-RPC" is superseded — in-process is verified-feasible via `createTransport` hook and avoids subprocess overhead.)
+- R6. Tier-2 unit tests per action use a shared `ctx` fixture; assert (a) non-empty captured output on success, (b) contract markers per command, (c) failure paths throw via `ctx.process.exit` with captured stderr.
+- R7. The existing 451-test baseline passes; `packages/cli/src/commands/status.test.ts` (global `console` spies) is migrated to the new fixture.
+- R8. `bunx infra mcp` lists exactly 10 tools; the 9 cli-only commands MUST NOT appear in `tools/list` output.
+
+## Scope Boundaries
+
+- **No subprocess streaming refactor.** Deploys + gateway logs stay cli-only. `Bun.spawn({stdout: 'inherit'})` capture deserves its own brainstorm.
+- **No interactive commands in MCP.** `cliproxy login`, `cliproxy open`, `cliproxy setup` require TTY and stdin.
+- **No destructive commands in MCP.** `gateway restore` stays cli-only by policy.
+- **No new discovery resource.** `createMcpAction` exposes no Server hook; the lower-level `addCliToolsToMcp` path costs ~50 LOC and is deferred to v2.
+- **No `@goke/mcp` contract changes.** Integration uses the published `0.0.10` shape; upstream changes renegotiate this plan.
+- **No new MCP authentication or per-tool capability gating.** v1 ships stdio transport, default capabilities.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/cli/src/commands/mcp.ts` — 7-line MCP registration. Currently `cli.command('mcp', '...').action(createMcpAction({cli}))`. Will receive an explicit `commandFilter` arg.
+- `packages/cli/src/cli.ts` — goke CLI instance + command registration via per-app barrels (`keeweb`, `cliproxy`, `gateway`).
+- `packages/cli/src/commands/{keeweb,cliproxy,gateway}/*.ts` — 17 source files, 10 of which need refactoring.
+- `packages/cli/src/commands/status.ts` — unified top-level status; aggregates per-app `getStatusSummary` helpers.
+- `packages/cli/src/__test__/` — does NOT exist yet. New test fixture lands here.
+- `packages/cli/src/commands/status.test.ts` — uses `spyOn(console, 'log')` today; needs migration to the shared `ctx` fixture.
+- Goke skill at `.agents/skills/goke/SKILL.md`, sections "MCP server" and "Injectable I/O".
+- `@goke/mcp@0.0.10` source confirms the action receives `ctx` as the last arg (`cli-to-mcp.ts:458`); `buildCallToolResult` concatenates captured stdout, captured stderr, and stringified return value when present (`cli-to-mcp.ts:336-365`); `GokeProcessExit` converts to an `isError: true` CallToolResult on exit (`cli-to-mcp.ts:347-365`).
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md` — cliproxy patterns
+- `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md` — gateway patterns
+- Memory #3191: `@goke/mcp` does not capture global `console`/`process.stdout` writes. Root cause behind this plan.
+- Memory #3618: design work paused until `@goke/mcp` capture contract verified. Gate cleared.
+- Memory #3766: `import.meta.main` guard is required for any module that exports symbols for testing. Already in effect across the codebase; planning here only.
+- Memory #399: `goke@6.8.0` does not merge global CLI options into subcommand action types. Each command declares its own options.
+
+### External References
+
+None needed — `@goke/mcp` source and the `@modelcontextprotocol/sdk@1.29.0` `InMemoryTransport` were inspected directly during the brainstorm. No external best-practice research beyond that.
+
+## Key Technical Decisions
+
+- **`ctx.console` capture (Mode A) as default, Mode C exception for `cliproxy_keys_list` and `cliproxy_config_get`.** Mode A preserves human readability; Mode C lets agents avoid regex-parsing tables. `@goke/mcp`'s `buildCallToolResult` already concatenates text capture + structured return value, so the exception costs zero framework changes.
+- **`ctx` flows via callback parameter (Pattern A).** Per memory #3766 and repo discipline of explicit-over-clever. No global console shim, no HOF wrapper.
+- **Inline `ctx.console` calls in actions; helpers unchanged.** Three reviewers flagged a helper-output-parameter pattern as ceremony for a one-time refactor. Helpers continue to return strings or structured objects; actions are the print site.
+- **`commandFilter` allowlist as a `Set<string>` in `mcp.ts` with per-command exclusion rationale in a JSDoc comment.** `Set<string>` is one allocation, one lookup per command, and trivially extensible. Adding a future capturable command is one entry. Listing each excluded command's reason inline turns the allowlist from a magic incantation into self-documenting filter.
+- **Tier-1 test uses `InMemoryTransport` from `@modelcontextprotocol/sdk@1.29.0` via `createTransport` hook.** `createMcpAction` exposes `createTransport: () => Transport | Promise<Transport>` (see `@goke/mcp@0.0.10/cli-to-mcp.ts:622-633`). The test builds a linked transport pair, runs `createMcpAction` with the server side, connects a client to the other side, and exercises `tools/list` without spawning a subprocess. Faster, deterministic, no JSON-RPC string parsing.
+- **Tier-2 shared fixture at `packages/cli/src/__test__/mcp-ctx-fixture.ts`.** Approximates `@goke/mcp`'s `createCallToolExecutionContext` shape sufficiently for action-level testing: `ctx.console.log/error` push to arrays, `ctx.process.stdout.write`/`stderr.write` push to arrays, `ctx.process.exit(code)` throws a tagged error. Returns `{ctx, captured: {stdout, stderr, exit}}` per test invocation. The fixture is an approximation, not a contract-equivalent re-implementation — Unit 7's Tier-1 test covers the real `@goke/mcp` path. If a test needs precise contract behavior it should use the Tier-1 harness.
+- **v1 is deliberately an observability surface.** Path to full agent autonomy goes through subprocess streaming + auth/approval gating. Both are explicit v2.
+- **`@goke/mcp` upgrade policy: manual review only, no version constraint change.** For pre-1.0 packages, npm/Bun semver treats `~0.0.10` and `^0.0.10` IDENTICALLY (both lock at patch-only resolution). Tightening the constraint operator is a no-op. The real lever is a Renovate-level policy: `@goke/mcp` bumps are flagged for manual review and must pass Tier-1 + Tier-2 tests before merge. Documented in `packages/cli/AGENTS.md` per Unit 8.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Allowlist shape (R4):** `Set<string>` with inline JSDoc rationale for each excluded command.
+- **Tier-1 test transport (R5):** `InMemoryTransport` via `createTransport` hook. Verified hook exists in `@goke/mcp@0.0.10` source (`cli-to-mcp.ts:622-633`).
+- **Shared `ctx` fixture location (R6):** `packages/cli/src/__test__/mcp-ctx-fixture.ts` — single source for all 10 Tier-2 callers.
+- **`status` command tool-name collision (R8):** Default `@goke/mcp` `sanitizeToolName` replaces spaces with underscores. `gateway status` → `gateway_status`, `cliproxy status` → `cliproxy_status`, `keeweb status` → `keeweb_status`, top-level `status` → `status`. No collision. AE1's expected name list stands.
+- **Mode C extension criterion (R3):** Stricter gate — a command qualifies for Mode C ONLY when ALL of the following hold: (a) it wraps a single management-API GET call returning structured data, (b) the structured payload is a single object (not a paginated stream or large blob), (c) an agent consuming the tool plausibly needs to parse the structure programmatically (not just display it). Currently `cliproxy_keys_list` and `cliproxy_config_get` qualify. `cliproxy_keys_add`/`remove` and `cliproxy_config_set` do NOT qualify because they return success/failure status (Mode A). Future additions require re-evaluating against this 3-clause gate.
+
+### Deferred to Implementation
+
+- Exact `Bun.spawn` mock shape per action's Tier-2 test (varies by what the action calls: `fetch`, `Bun.spawn`, etc.). Each test author resolves by reading the action's surface.
+- Whether to add a brief inline comment in each refactored action signature explaining the `ctx` param, or rely on the goke skill documentation as the contract reference. Implementer call.
+- Final wording of each command's contract markers in Tier-2 tests (e.g., is `version line` literally the regex `/v\d+\.\d+\.\d+/` or just "contains the word 'version'"?). Resolved when writing each test.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**MCP request lifecycle, after refactor:**
+
+```text
+Agent: tools/list                              Agent: tools/call cliproxy_status
+        │                                              │
+        ▼                                              ▼
+@goke/mcp ListToolsRequestSchema           @goke/mcp CallToolRequestSchema
+  filters via cmd commandFilter Set            creates ctx with capture streams
+  returns 10 tools                             invokes action(options, ctx)
+                                                  │
+                                                  ▼
+                                          action body:
+                                            const summary = formatSummary(...)
+                                            ctx.console.log(summary)
+                                            // OR for Mode C commands:
+                                            ctx.console.log(formatTable(data))
+                                            return data
+                                                  │
+                                                  ▼
+                                          buildCallToolResult(
+                                            returnValue,
+                                            capturedStdout,
+                                            capturedStderr
+                                          )
+                                            ├─ Mode A: content = [{type:'text', text: stdout}]
+                                            └─ Mode C: content = [
+                                                {type:'text', text: stdout},
+                                                {type:'text', text: stringify(data)}
+                                              ]
+```
+
+**Per-action diff shape (illustrative, not literal):**
+
+```ts
+// before
+cli.command('cliproxy status', '...')
+  .action(async (options) => {
+    const summary = await getCliproxyStatusSummary(...)
+    console.log(formatSummary(summary))
+    if (summary.error) process.exit(1)
+  })
+
+// after
+cli.command('cliproxy status', '...')
+  .action(async (options, ctx) => {
+    const summary = await getCliproxyStatusSummary(...)
+    ctx.console.log(formatSummary(summary))
+    if (summary.error) ctx.process.exit(1)
+  })
+
+// after, Mode C exception (cliproxy keys list)
+cli.command('cliproxy keys list', '...')
+  .action(async (options, ctx) => {
+    const data = await fetchKeys(...)
+    ctx.console.log(formatKeysTable(data))
+    return data
+  })
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Shared MCP test fixture**
+
+**Goal:** Build the shared `ctx` capture fixture that all Tier-2 tests will use. This unit blocks Units 4–6 (per-app refactors).
+
+**Requirements:** R6
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/cli/src/__test__/mcp-ctx-fixture.ts`
+- Test: `packages/cli/src/__test__/mcp-ctx-fixture.test.ts`
+
+**Approach:**
+- Export `createCapturedCtx()` that returns `{ctx, captured}`.
+- `ctx` matches `@goke/mcp`'s `GokeExecutionContext` shape:
+  - `ctx.console.log(...args)` pushes the formatted string to `captured.stdout`
+  - `ctx.console.error(...args)` pushes to `captured.stderr`
+  - `ctx.process.stdout.write(chunk)` pushes to `captured.stdout` (string or Buffer/Uint8Array)
+  - `ctx.process.stderr.write(chunk)` pushes to `captured.stderr`
+  - `ctx.process.exit(code)` throws a tagged error `MockProcessExit(code)` so the test can assert exit semantics without killing the runner
+- `captured` is `{stdout: string[], stderr: string[], exit: {code: number} | null}` where `exit` is populated when `ctx.process.exit` is caught.
+- Provide a small helper `expectCapturedToInclude(captured, marker: string | RegExp)` that searches concatenated stdout for a match — keeps assertions terse.
+
+**Execution note:** Test-first. Write the fixture's own tests against `createCapturedCtx()` before exporting it.
+
+**Patterns to follow:**
+- `packages/shared/server/droplet-helpers.test.ts` for `spyOn` and afterEach restore patterns
+- `node_modules/.bun/@goke+mcp@0.0.10+a6b6ab9123cdf578/node_modules/@goke/mcp/src/cli-to-mcp.ts` lines 304-324 for the real construction the fixture mirrors
+
+**Test scenarios:**
+- Happy path: `ctx.console.log('hello')` populates `captured.stdout` with `['hello']`.
+- Happy path: `ctx.process.stdout.write('chunk')` populates `captured.stdout` (string variant).
+- Happy path: `ctx.process.stdout.write(Buffer.from('chunk'))` populates `captured.stdout` (buffer variant decoded as utf-8).
+- Error path: `ctx.process.exit(1)` throws `MockProcessExit`, and after the throw `captured.exit.code === 1`.
+- Edge case: calling `ctx.process.exit(0)` still throws (exit 0 is still an exit in tool-call semantics).
+- Integration: the fixture's behavior matches what `@goke/mcp` would produce — write a sanity test that wraps a no-op action in `createMcpAction`'s real flow via `InMemoryTransport` (or skip if too coupled — note "Cross-check verified manually" in the fixture comment).
+
+**Verification:**
+- `bun test packages/cli/src/__test__/mcp-ctx-fixture.test.ts` passes.
+- Other Tier-2 unit tests (Units 4–6) can import the fixture and use it without modification.
+
+---
+
+- [ ] **Unit 2: Refactor `mcp.ts` to use `commandFilter` allowlist**
+
+**Goal:** Replace the unconditional `createMcpAction({cli})` with an explicit `commandFilter` Set that admits only the 10 in-scope commands. Annotate every excluded command's reason in the same file so the allowlist self-documents.
+
+Landing Units 2 and 7 together (allowlist + Tier-1 test) before Units 3-6 sharpens early feedback: implementers see the empty-content failure at the contract layer before refactoring each action, which prevents "the test went green for the wrong reason".
+
+**Requirements:** R4, R8
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/cli/src/commands/mcp.ts`
+- Test: `packages/cli/src/commands/mcp.test.ts` (new — Tier-1 integration test lands here in Unit 7)
+
+**Approach:**
+- Add a `const MCP_ALLOWLIST = new Set<string>([...10 names])` constant at module scope. The 10 names match `@goke/mcp`'s `command.name` exactly:
+  - `gateway status`, `gateway backup`
+  - `cliproxy status`, `cliproxy keys list`, `cliproxy keys add`, `cliproxy keys remove`, `cliproxy config get`, `cliproxy config set`
+  - `keeweb status`
+  - `status` (the top-level unified status)
+- Add a JSDoc-style comment block above the allowlist listing each EXCLUDED command and its one-line reason — verbatim from R4.
+- Update `registerMcp(cli)` to call `createMcpAction({cli, commandFilter: (name) => MCP_ALLOWLIST.has(name)})`.
+- Do NOT export the allowlist from `mcp.ts` yet (R4 specifies "single source-of-truth in the same module"). If Unit 7's Tier-1 test needs the allowlist, it can re-derive from the same names — keeps the production surface tight.
+
+**Patterns to follow:**
+- `packages/cli/src/commands/mcp.ts` current 7-line shape
+- `@goke/mcp@0.0.10` `commandFilter` signature: `(commandName: string) => boolean`
+
+**Test scenarios:**
+- Test expectation: none for this unit's own behavior beyond what Unit 7's Tier-1 integration covers — the allowlist's correctness is observable via `tools/list`. No standalone unit test for the Set.
+
+**Verification:**
+- `bunx infra mcp` (run interactively or via the Tier-1 test in Unit 7) lists exactly 10 tools.
+- Manual check via `mcp inspector` or the Tier-1 test passes AE1.
+
+---
+
+- [ ] **Unit 3: Refactor gateway commands (status, backup)**
+
+**Goal:** Migrate `gateway/status.ts` and `gateway/backup.ts` actions to use `ctx.console`/`ctx.process` per R1 and R2. No helper signature changes.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1 (fixture).
+
+**Files:**
+- Modify: `packages/cli/src/commands/gateway/status.ts`
+- Modify: `packages/cli/src/commands/gateway/backup.ts`
+- Test: `packages/cli/src/commands/gateway/status.test.ts` (extend with Tier-2 fixture-based tests)
+- Test: `packages/cli/src/commands/gateway/backup.test.ts` (extend)
+
+**Approach:**
+- For each action, change signature from `(options) => ...` to `(options, ctx) => ...`.
+- Replace `console.log` → `ctx.console.log`, `console.error` → `ctx.console.error`, `process.exit(code)` → `ctx.process.exit(code)`.
+- **Helper exception for `gateway/backup.ts`:** the existing `backupGatewayCa(..., printErr?: (msg: string) => void)` helper writes a sensitive-data warning to stderr via `process.stderr.write` when `printErr` is not provided. After the refactor, the action MUST pass `printErr: (msg) => ctx.process.stderr.write(`${msg}\n`)` (or equivalent) so the warning lands in MCP capture instead of leaking to the host stderr. The helper signature already accepts the injection point; this is a call-site change, not a signature change. Other helpers in these two files (`formatGatewayStatusSummary`, etc.) return strings only and stay unchanged.
+- Audit Unit 3 acceptance: grep `process.std(out|err).write` and `console\.` in both files post-refactor. Both should return zero hits.
+
+**Execution note:** Add a fixture-based Tier-2 test BEFORE modifying the action signature — the test exercises the captured-output contract, then implementing the refactor turns it green.
+
+**Patterns to follow:**
+- `@goke/mcp@0.0.10` `cli-to-mcp.ts:458` — action signature `(...positionalValues, optionsObject, ctx)`.
+- The goke skill ".agents/skills/goke/SKILL.md" — `cli.createExecutionContext` shape.
+
+**Test scenarios:**
+- Happy path (`gateway_status`): Given a mocked reachable droplet, when the action runs with the fixture's `ctx`, `captured.stdout` contains the service-state table AND a line mentioning "healthy" (or "degraded" if any service is in that state).
+- Edge case (`gateway_status`): Given a mocked unreachable droplet (SSH connection refused), the action calls `ctx.process.exit(1)`, `captured.exit.code === 1`, and `captured.stderr` contains the SSH error message.
+- Happy path (`gateway_backup`): Given a mocked successful tarball write of 1234 bytes to `/tmp/out.tar.gz`, `captured.stdout` contains both `/tmp/out.tar.gz` and `1234`.
+- Error path (`gateway_backup`): Given a mocked file-write error, the action calls `ctx.process.exit(1)` and `captured.stderr` contains the write-error reason.
+- Integration: When invoked via `@goke/mcp` (i.e., real `createCallToolExecutionContext`) — covered by Unit 7's Tier-1 + an E2E `tools/call` smoke test if time permits, otherwise deferred to v2 polish.
+
+**Verification:**
+- All Tier-2 tests in these two files pass.
+- `bun test packages/cli/src/commands/gateway/` passes.
+
+---
+
+- [ ] **Unit 4: Refactor cliproxy commands (status, keys list/add/remove, config get/set) including Mode C exception**
+
+**Positional-argument note:** Several actions in this unit take positional args, not options-only. Per `@goke/mcp@0.0.10` (`cli-to-mcp.ts:458`), `ctx` is ALWAYS the last argument regardless of how many positional args precede it. So the migration shapes are:
+- `(apiKeyToAdd, options) => ...` becomes `(apiKeyToAdd, options, ctx) => ...`
+- `(apiKeyToRemove, options) => ...` becomes `(apiKeyToRemove, options, ctx) => ...`
+- `(field, value, options) => ...` becomes `(field, value, options, ctx) => ...`
+- `(options) => ...` (status, keys list, config get) becomes `(options, ctx) => ...`
+
+**Goal:** Migrate the 6 cliproxy commands (status, 3 keys, 2 config) per R1 + R2. For `cliproxy keys list` and `cliproxy config get`, additionally return the structured data per R3 (Mode C).
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1 (fixture).
+
+**Files:**
+- Modify: `packages/cli/src/commands/cliproxy/status.ts`
+- Modify: `packages/cli/src/commands/cliproxy/keys.ts`
+- Modify: `packages/cli/src/commands/cliproxy/config.ts`
+- Test: `packages/cli/src/commands/cliproxy/status.test.ts` (extend)
+- Test: `packages/cli/src/commands/cliproxy/keys.test.ts` (extend)
+- Test: `packages/cli/src/commands/cliproxy/config.test.ts` (extend)
+
+**Approach:**
+- Same migration pattern as Unit 3.
+- For `cliproxy keys list` action: AFTER `ctx.console.log(formatKeysTable(data))`, add `return data` (where `data` is the raw `{api-keys: string[]}` from the management API). `@goke/mcp` will emit two text blocks per AE4.
+- For `cliproxy config get` action: same shape — `ctx.console.log(formatConfig(config))` then `return config`.
+- For `cliproxy keys add`, `cliproxy keys remove`, `cliproxy config set`: text-only Mode A. Do not return structured data; these are mutations whose success/failure is conveyed through the captured text.
+- Add an inline code comment above each Mode C `return` statement explaining the criterion: "Mode C exception per docs/plans/2026-05-23-001 — wraps a single management-API call returning structured data".
+
+**Execution note:** Test-first. The Mode C test asserts that `captured.stdout` AND the action's return value are both non-empty.
+
+**Patterns to follow:**
+- Unit 3's gateway migration
+- `@goke/mcp@0.0.10` `cli-to-mcp.ts:336-365` for the `buildCallToolResult` precedence rules
+
+**Test scenarios:**
+- Happy path (`cliproxy_status`): Given mocked HTTP 200 from the proxy with usage stats, `captured.stdout` contains the version line, the HTTP status line, and the usage stats line.
+- Error path (`cliproxy_status`): Given mocked HTTP 503, the action calls `ctx.process.exit(1)`, `captured.exit.code === 1`, `captured.stderr` contains the HTTP error.
+- Happy path / Mode C (`cliproxy_keys_list`): Given a mocked management API response with 3 keys, `captured.stdout` contains all 3 key fingerprints/names in the formatted table AND the action's return value is the raw `{api-keys: [...]}` object.
+- Happy path (`cliproxy_keys_add`): Given a mocked successful add, `captured.stdout` contains the added key value or a confirmation message; action does NOT return structured data (Mode A).
+- Error path (`cliproxy_keys_remove`): Given a value that doesn't match any registered key, the action calls `ctx.process.exit(1)` per AE3.
+- Happy path / Mode C (`cliproxy_config_get`): Given a mocked config response, `captured.stdout` contains the formatted config display AND the action returns the raw config object.
+- Happy path (`cliproxy_config_set`): Given a mocked PUT success, `captured.stdout` contains a confirmation.
+- Edge case (Mode A/C boundary): Verify that `cliproxy_keys_add`'s action returns `undefined` (not a structured value), so `buildCallToolResult` does not produce a stray second text block.
+
+**Verification:**
+- All Tier-2 tests in these three files pass.
+- `bun test packages/cli/src/commands/cliproxy/` passes.
+
+---
+
+- [ ] **Unit 5: Refactor keeweb command (status)**
+
+**Goal:** Migrate `keeweb/status.ts` per R1 + R2.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1 (fixture).
+
+**Files:**
+- Modify: `packages/cli/src/commands/keeweb/status.ts`
+- Test: `packages/cli/src/commands/keeweb/status.test.ts` (extend)
+
+**Approach:**
+- Same migration pattern as Unit 3.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Unit 3's gateway migration
+
+**Test scenarios:**
+- Happy path (`keeweb_status`): Given mocked HTTP 200, content-hash match, and last-deploy success, `captured.stdout` contains "OK" markers for each of the 3 checks.
+- Error path (`keeweb_status`): Given mocked HTTP 503, the action calls `ctx.process.exit(1)` and `captured.stderr` contains the error.
+- Edge case (`keeweb_status`): Given a content-hash drift between local dist and remote, `captured.stdout` flags the drift but does NOT exit non-zero (drift is a warning, not an error).
+
+**Verification:**
+- All Tier-2 tests pass.
+- `bun test packages/cli/src/commands/keeweb/` passes.
+
+---
+
+- [ ] **Unit 6: Refactor unified top-level `status` command + migrate existing tests**
+
+**Goal:** Migrate `packages/cli/src/commands/status.ts` (the unified aggregator) per R1 + R2, AND migrate the existing `status.test.ts` from `spyOn(console, 'log')` to the shared fixture per R7.
+
+**Requirements:** R1, R2, R7
+
+**Dependencies:** Unit 1 (fixture), Units 3-5 (per-app status helpers).
+
+**Files:**
+- Modify: `packages/cli/src/commands/status.ts`
+- Modify: `packages/cli/src/commands/status.test.ts`
+
+**Approach:**
+- Same migration pattern as Unit 3 for the action.
+- For the test file migration: replace every `spyOn(console, 'log')` block with a `createCapturedCtx()` call. The test asserts on `captured.stdout.join('\n')` instead of the spy's call arguments. Where the test used `spyOn(process, 'exit')`, replace with assertions on `captured.exit.code`. Where the test passed args via `process.argv` shimming, pass `ctx` and `options` directly — the test is exercising the action callback, not the goke parse layer.
+- Audit: are there any OTHER test files in the repo using `spyOn(console, ...)` for the 10 refactored commands? If yes, migrate them in this unit too. If they're for cli-only commands (not refactored here), leave them.
+
+**Execution note:** Migrate the tests in place — keep the existing test cases' intent; just swap the harness.
+
+**Patterns to follow:**
+- Unit 1's `createCapturedCtx()` API
+- The replaced tests' assertion patterns (e.g., the JSON output test asserts on the structured shape of `captured.stdout[0]` parsed as JSON)
+
+**Test scenarios:**
+- Happy path (unified `status`): Given all 3 per-app status helpers return OK, `captured.stdout` contains all 3 app names and "OK" markers.
+- Error path (unified `status`): Given any per-app helper returns ERROR, `captured.stdout` contains the failing app and `captured.exit.code === 1`.
+- Edge case (`--json` flag): Given `options.json === true`, `captured.stdout[0]` parsed as JSON contains the structured summary for all 3 apps.
+- Edge case (test migration): At least one test that previously used `spyOn(console, 'log')` now uses the fixture and produces the same assertion intent.
+
+**Verification:**
+- `bun test packages/cli/src/commands/status.test.ts` passes with all original test cases still intact.
+- No `spyOn(console, ...)` or `spyOn(process, ...)` calls remain in `packages/cli/src/commands/status.test.ts`.
+- Full `bun test --recursive` baseline holds: tests increase by ≥ N (the Tier-2 additions) and do not decrease.
+
+---
+
+- [ ] **Unit 7: Tier-1 integration test via `InMemoryTransport`**
+
+**Goal:** Write the Tier-1 integration test that exercises `@goke/mcp` end-to-end without spawning a subprocess. The test spawns the goke CLI in-process, connects an MCP client via `InMemoryTransport`, and asserts `tools/list` returns exactly the 10 expected names.
+
+**Requirements:** R5, R8
+
+**Dependencies:** Unit 2 (allowlist registered).
+
+**Files:**
+- Create: `packages/cli/src/commands/mcp.test.ts`
+
+**Approach:**
+- Build the test as follows (illustrative shape only — not literal code):
+  1. Import `InMemoryTransport` from `@modelcontextprotocol/sdk/inMemory.js` and `Client` from `@modelcontextprotocol/sdk/client/index.js`.
+  2. Create a linked transport pair: `const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()`.
+  3. Build a goke CLI instance matching the production registration (call the same `register*` functions from `packages/cli/src/cli.ts` so the test exercises the real command tree — DO NOT duplicate the registration list, that's a test smell).
+  4. Construct the action via `createMcpAction({cli, commandFilter: ..., createTransport: () => serverTransport})` — the `createTransport` hook is the entry point.
+  5. Invoke the MCP-command action (it returns a Promise that resolves when the server is connected).
+  6. Connect a client to `clientTransport`, send `tools/list`, assert the result.
+- The test asserts:
+  - `result.tools.length === 10`
+  - The set of tool names matches AE1 exactly (use a sorted-array equality check).
+  - Each tool has a non-null `inputSchema` (does not assert exact schema shape).
+- Tear down: close client + server cleanly after the test.
+
+**Execution note:** Implement test-first against the post-Unit-2 allowlist.
+
+**Fallback path if `InMemoryTransport` fails to work under Bun:** If the SDK's stream implementation is incompatible with Bun's event loop or the linked-pair lifecycle hangs in cleanup:
+1. Replace step 2 (linked transports) with a subprocess spawn: `Bun.spawn(['bunx', '@marcusrbrown/infra', 'mcp'], {stdin: 'pipe', stdout: 'pipe'})`.
+2. Write a `tools/list` JSON-RPC request directly to `subprocess.stdin` (one line of newline-delimited JSON-RPC 2.0).
+3. Read response lines from `subprocess.stdout` until a matching `id` arrives.
+4. Assert the same 10-tool name set and `inputSchema` presence.
+5. Tear down with `subprocess.kill()`.
+
+The subprocess path is more expensive but it's the canonical MCP transport behavior, so the contract assertions remain equivalent. If both paths are unblocked, prefer in-process for speed. If the in-process path is blocked, ship the subprocess form — do NOT skip the test entirely.
+
+**Patterns to follow:**
+- `node_modules/.bun/@goke+mcp@0.0.10+a6b6ab9123cdf578/node_modules/@goke/mcp/src/__test__/create-mcp-action.test.ts` — `@goke/mcp`'s own tests show how to wire `createMcpAction` for testing.
+- `@modelcontextprotocol/sdk@1.29.0`'s `InMemoryTransport.createLinkedPair()` example in the SDK docs.
+
+**Test scenarios:**
+- Happy path: `tools/list` returns exactly the 10 expected tool names per AE1.
+- Edge case: All 10 tools have non-null `inputSchema`. (Note: `inputSchema` for option-less commands is `{type: 'object', properties: {}}` — still non-null, just empty. The unified `status` command has options, so this is uniform.)
+- Defensive assertion: None of the 9 cli-only command names appear in the response (explicit list check, not just a count).
+- **Mode C contract assertion (covers R3, AE4):** Issue a `tools/call` with name `cliproxy_keys_list` against a mocked proxy (use a fixture that returns `{"api-keys": ["k1", "k2", "k3"]}`). Assert the returned `CallToolResult.content` is exactly 2 text blocks: the first matches the human-formatted keys table, the second parses as JSON and matches `{"api-keys": ["k1", "k2", "k3"]}`. This proves the Mode C path works end-to-end through `@goke/mcp`'s `buildCallToolResult`, not just through our fixture.
+
+**Verification:**
+- `bun test packages/cli/src/commands/mcp.test.ts` passes with the 3 scenarios above.
+- A future regression where someone removes a tool from the allowlist OR adds a tool without registering it would fail this test.
+
+---
+
+- [ ] **Unit 8: Documentation**
+
+**Goal:** Update `packages/cli/AGENTS.md` to reflect the new MCP behavior, the allowlist as single-source-of-truth, the Mode C exception's stricter gate, and the manual-review policy for `@goke/mcp` bumps.
+
+**Requirements:** R3 (criterion documentation), R4 (allowlist documentation), upgrade policy from Key Technical Decisions.
+
+**Dependencies:** Units 2, 3, 4, 5, 6, 7 (the refactor must be in place before documenting it).
+
+**Files:**
+- Modify: `packages/cli/AGENTS.md`
+
+**Approach:**
+- Add a brief "MCP fidelity" subsection under the existing CLI patterns, explaining:
+  - Actions thread `ctx` as the last positional arg per the goke skill
+  - `packages/cli/src/commands/mcp.ts` allowlist is the single source of truth for MCP-exposed tools
+  - Mode C structured-return exception applies only to commands meeting the 3-clause gate in Key Technical Decisions; future additions require re-evaluation
+  - `@goke/mcp` upgrades flagged for manual review — bumps must pass Tier-1 + Tier-2 tests before merge
+- Renovate config changes are intentionally omitted from this unit. Existing Renovate behavior already opens PRs for `@goke/mcp` bumps; the manual-review discipline is an ops practice documented in AGENTS.md, not a config-level enforcement. If the manual policy proves insufficient in practice, add a `packageRules` entry in a follow-up.
+
+**Test scenarios:**
+- Test expectation: none — pure documentation.
+
+**Verification:**
+- The AGENTS.md addition is reachable from the existing structure (linked from the relevant section).
+- The 4 documented points (ctx threading, allowlist authority, Mode C gate, upgrade policy) are individually distinguishable in the section text.
+
+## System-Wide Impact
+
+- **Interaction graph:** Fro Bot autohealing (`.github/workflows/fro-bot.yaml` category 5) currently calls these 10 tools via MCP and gets empty content. After this refactor, Fro Bot gets real responses. Autohealing logic may need a one-line tweak to actually use the captured text instead of falling back to `gh` — but that change is in `fro-bot.yaml`, not this repo's runtime. Capture as a follow-up smart note after this lands.
+- **Error propagation:** `ctx.process.exit(code)` throws `GokeProcessExit`, which `@goke/mcp`'s `runCliTool` catches and converts to a `CallToolResult` with `isError: true`. In CLI mode (when running outside MCP), goke's default `ctx.process.exit` is the real `process.exit`, so error behavior is unchanged for terminal users.
+- **State lifecycle risks:** None new. The 10 commands are read-style; the only mutation is `gateway backup` writing to a local path the caller specified, which already happens today.
+- **API surface parity:** The CLI behavior (human-facing) does not change. The MCP behavior changes from empty to populated. Operators running `bunx infra cliproxy status` see identical output before and after.
+- **Integration coverage:** The Tier-1 `InMemoryTransport` test covers the `mcp.ts` ↔ `@goke/mcp` ↔ `@modelcontextprotocol/sdk` integration seam. Tier-2 tests cover the action ↔ `ctx` capture seam per command. Cross-layer not covered: live calls through `bunx infra mcp` against a real MCP client (Claude Desktop, Cursor, etc.) — manual smoke verification only.
+- **Unchanged invariants:** Helper signatures (`formatSummary`, `formatKeysTable`, etc.) remain unchanged. The published `@marcusrbrown/infra` CLI interface (commands, options, help text) is unchanged for terminal users. The 9 cli-only commands continue to work via the terminal and continue to NOT appear in MCP. The MCP transport remains stdio in production.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `@goke/mcp@0.0.10` upstream releases a breaking 0.0.11 patch that changes `ctx` shape or `commandFilter` semantics | Manual-review policy documented in AGENTS.md (per Unit 8). Renovate PRs for `@goke/mcp` bumps must pass Tier-1 + Tier-2 tests before merge. Version-constraint tightening is intentionally NOT used because npm/Bun treat `~0.0.x` identically to `^0.0.x` for pre-1.0 packages. |
+| `InMemoryTransport` API in `@modelcontextprotocol/sdk@1.29.0` doesn't behave as expected (lifecycle/cleanup quirks) | Unit 7 starts with a smoke test; if blocked, fall back to subprocess + JSON-RPC pipe. Document the fallback in the test file. |
+| Existing `status.test.ts` console-spy tests reveal assertions that the fixture-based form can't replicate cleanly | Migration in Unit 6 keeps the test cases' intent — if a specific assertion can't translate, replace with a stronger Tier-2 assertion against the captured-output contract. Do NOT delete tests to make migration green. |
+| A future contributor adds an 11th capturable command but forgets to add it to the allowlist | Unit 7's Tier-1 test asserts exact-set equality. Adding a new command without registering would make the set `≠ 10` and fail the test. |
+| Mode C structured return for `cliproxy_keys_list` produces too-large output blocks for some agents | Output is text in both cases; the structured block is a stringified JSON object usually < 1 KB. Not a concern at v1 scale. Revisit if usage data ever needs streaming. |
+| Manual-review discipline for `@goke/mcp` bumps drifts over time | Renovate PRs already require a passing CI run; the Tier-1 test asserts the contract is intact. If a bump merges with broken behavior, the post-merge CI run on `main` will fail and Fro Bot autohealing will surface the regression in its daily report. Acceptable risk for a single dep used in one module. |
+
+## Documentation / Operational Notes
+
+- **Fro Bot autohealing follow-up.** After this lands, Fro Bot autohealing (`.github/workflows/fro-bot.yaml` category 5) needs a one-line update to actually consume the captured MCP output instead of falling back to `gh`. Concrete next step: write a smart note triggered on this plan's PR merge that opens a follow-up PR updating category 5's prompt to query via MCP first, then fall back to `gh`. Without that follow-up, the autohealing value driver named in the Problem Frame doesn't materialize.
+- **Mode C criterion re-examination.** The 3-clause gate is documented in Key Technical Decisions and AGENTS.md (Unit 8). The first time a new command becomes a candidate for Mode C, walk through all 3 clauses against the candidate. If any clause feels mushy or arbitrary in practice, surface that as a re-brainstorm trigger — the gate is meant to constrain, not be reinterpreted on each addition.
+- **v2 momentum.** Subprocess streaming refactor and authentication/approval gating are explicit v2. Follow-up issues filed:
+  - [#291](https://github.com/marcusrbrown/infra/issues/291) — MCP v2: subprocess streaming for deploys and logs
+  - [#292](https://github.com/marcusrbrown/infra/issues/292) — MCP v2: authentication and approval gating for mutating tools
+
+  Both issues capture trigger conditions, constraint inputs, and design questions so they remain actionable when the time comes.
+- **Changelog.** No entry for the refactor's CLI behavior (unchanged). DO add a changelog entry for the MCP fidelity improvement — operators using `bunx infra mcp` see meaningful content for the first time.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md](./docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md)
+- `.local/mcp-fidelity-survey.md` — per-command survey (action shape, helper shape, capturable verdict)
+- `.agents/skills/goke/SKILL.md` — goke + `@goke/mcp` reference
+- `node_modules/.bun/@goke+mcp@0.0.10+a6b6ab9123cdf578/node_modules/@goke/mcp/src/cli-to-mcp.ts` lines 245-365 (capture flow), 458 (action signature), 622-686 (createMcpAction)
+- `node_modules/.bun/@modelcontextprotocol+sdk@1.29.0/node_modules/@modelcontextprotocol/sdk/dist/esm/inMemory.d.ts` — `InMemoryTransport` API
+- Related PRs: #290 (refactor pattern + lessons applied here)
+- Related memories: #3191 (capture root cause), #3618 (design gate), #3766 (import.meta.main rule), #399 (goke 6.8.0 type behavior)

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -73,7 +73,7 @@ The MCP server (`mcp.ts`) exposes a curated subset of commands as MCP tools via 
 - `process.stderr.write(...)` → `ctx.process.stderr.write(...)`
 - `process.exit(code)` → `ctx.process.exit(code)`
 
-Use the shared `ActionCtx` type from `src/__test__/mcp-ctx-fixture.ts` — a structural subtype of `GokeExecutionContext` that captures exactly the surface actions consume. Action bodies are exported as named functions (e.g., `gatewayStatusAction`, `cliproxyKeysListAction`) and the `.action(...)` callback delegates to them, so Tier-2 tests invoke actions directly with `createCapturedCtx()`.
+Use the shared `ActionCtx` type from `src/lib/action-ctx.ts` — a structural subtype of `GokeExecutionContext` that captures exactly the surface actions consume. `createCapturedCtx()`, `expectCapturedToInclude()`, and `MockProcessExit` remain in `src/__test__/mcp-ctx-fixture.ts` for test use only. Action bodies are exported as named functions (e.g., `gatewayStatusAction`, `cliproxyKeysListAction`) and the `.action(...)` callback delegates to them, so Tier-2 tests invoke actions directly with `createCapturedCtx()`.
 
 **Mode C (structured-return commands).** Two commands return structured data alongside ctx-printed text so MCP consumers get both formatted output AND parseable JSON in the `CallToolResult`:
 
@@ -81,6 +81,12 @@ Use the shared `ActionCtx` type from `src/__test__/mcp-ctx-fixture.ts` — a str
 - `cliproxy config get` returns the parsed config object (the `--output` path still returns the object even when also writing to disk)
 
 Return values are plain data (arrays, objects) — never `{content: [...]}` shapes. `@goke/mcp` stringifies them and emits one text block per data plus one per captured stream. Extending Mode C: a command qualifies only if it wraps a single management-API call returning structured data the agent will likely parse (mutations and complex orchestrations stay Mode A — text only). When in doubt, leave it Mode A; opening Mode C creates a contract MCP consumers may come to depend on.
+
+**Failure-path parity for capturable actions.** Every allowlisted action must catch its expected operational failures (missing env vars, HTTP non-2xx, JSON parse errors, unsupported config fields) and write the reason to `ctx.console.error` before `ctx.process.exit(1)`. Do not rely on thrown exceptions for MCP-visible content — @goke/mcp may surface the exception text in the CallToolResult, but the format isn't guaranteed and operators looking at captured.stderr see nothing useful. Wrap the action body in try/catch when adding a new capturable command.
+
+**Mode C eligibility is data-shape based, not transport-source based.** A command qualifies for Mode C when it produces bounded structured data the agent will parse, regardless of whether the data comes from a management API, an SSH command, a local file read, or a docker query. `cliproxy keys list` (management API) and `gateway status` (SSH + docker compose ps) are both candidates by this rule. The criterion that matters: would re-parsing the formatted text be lossy or fragile? If yes, return the structured form alongside the text.
+
+**Mutating tools must verify the mutation.** When an MCP tool changes state (e.g., `cliproxy keys add`, `cliproxy keys remove`, `cliproxy config set`), the action must verify the mutation succeeded before reporting success via ctx. For `keys remove`, this means confirming the key existed before the DELETE; for `keys add`, confirming the management API echoed the new key in the response or in a follow-up list call. Returning the raw API response without verification means MCP can report success on a no-op deletion or a silently-failed add.
 
 **Tier-1 + Tier-2 test bar.** Every MCP-capturable command has Tier-2 unit tests using `createCapturedCtx()` to verify output flows through ctx, plus one Tier-1 integration test in `commands/mcp.test.ts` that spins up the real `@goke/mcp` server via `InMemoryTransport` and asserts the tool surface matches `MCP_ALLOWLIST`. The Tier-1 test re-derives the expected tool names from a list of strings rather than importing `MCP_ALLOWLIST`, so allowlist drift surfaces as a test failure.
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -59,6 +59,39 @@ Space-separated subcommands: `cli.command('keeweb status', '...')`. Zod schemas 
 - **Compensating delete**: `cliproxy setup` wraps key creation in try/catch. On failure after a key was created, best-effort `DELETE /v0/management/api-keys?value=<key>` to avoid phantom keys. Error messages scrub key material.
 - **Tests**: colocated `*.test.ts`. Snapshots in `src/__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic output. Mock `fetch` and `Bun.spawn` at the boundary. Never spawn the real CLI for commands that launch browser (`keeweb open`) or SSH (`cliproxy open`) — test exported helpers and `--help` output only.
 
+## MCP FIDELITY
+
+The MCP server (`mcp.ts`) exposes a curated subset of commands as MCP tools via `@goke/mcp`. Two rules govern that surface and how actions must be written to participate in it.
+
+**Allowlist authority (`src/commands/mcp.ts`).** The `MCP_ALLOWLIST` `Set` in `mcp.ts` is the **single source of truth** for which commands appear as MCP tools. Every excluded command has a one-line reason in the JSDoc block above the allowlist (subprocess streaming → deferred to MCP v2 #291, interactive TTY requirement, destructive policy → deferred to #292, host-machine side effect). Adding a new MCP-capturable command means adding its name to the `Set` and confirming the action threads `ctx`; adding a CLI-only command means leaving the allowlist alone and documenting the exclusion reason in the JSDoc.
+
+**Ctx threading for capturable commands.** Each command in the allowlist receives goke's per-action execution context as the last positional argument and **must** route every byte of output through `ctx`:
+
+- `console.log(...)` → `ctx.console.log(...)`
+- `console.error(...)` → `ctx.console.error(...)`
+- `process.stdout.write(...)` → `ctx.process.stdout.write(...)`
+- `process.stderr.write(...)` → `ctx.process.stderr.write(...)`
+- `process.exit(code)` → `ctx.process.exit(code)`
+
+Use the shared `ActionCtx` type from `src/__test__/mcp-ctx-fixture.ts` — a structural subtype of `GokeExecutionContext` that captures exactly the surface actions consume. Action bodies are exported as named functions (e.g., `gatewayStatusAction`, `cliproxyKeysListAction`) and the `.action(...)` callback delegates to them, so Tier-2 tests invoke actions directly with `createCapturedCtx()`.
+
+**Mode C (structured-return commands).** Two commands return structured data alongside ctx-printed text so MCP consumers get both formatted output AND parseable JSON in the `CallToolResult`:
+
+- `cliproxy keys list` returns the parsed API-key array
+- `cliproxy config get` returns the parsed config object (the `--output` path still returns the object even when also writing to disk)
+
+Return values are plain data (arrays, objects) — never `{content: [...]}` shapes. `@goke/mcp` stringifies them and emits one text block per data plus one per captured stream. Extending Mode C: a command qualifies only if it wraps a single management-API call returning structured data the agent will likely parse (mutations and complex orchestrations stay Mode A — text only). When in doubt, leave it Mode A; opening Mode C creates a contract MCP consumers may come to depend on.
+
+**Tier-1 + Tier-2 test bar.** Every MCP-capturable command has Tier-2 unit tests using `createCapturedCtx()` to verify output flows through ctx, plus one Tier-1 integration test in `commands/mcp.test.ts` that spins up the real `@goke/mcp` server via `InMemoryTransport` and asserts the tool surface matches `MCP_ALLOWLIST`. The Tier-1 test re-derives the expected tool names from a list of strings rather than importing `MCP_ALLOWLIST`, so allowlist drift surfaces as a test failure.
+
+**`@goke/mcp` upgrade discipline.** This package is pre-1.0; semver does not apply. Bumping `@goke/mcp` is a **manual-review** change — never automerge. Confirm before merging:
+
+1. `mcp.ts` still compiles against the new `createMcpAction` signature.
+2. The Tier-1 integration test still spins up the in-process MCP server (no API breakage on `commandFilter`, `createTransport`, or the action ctx shape).
+3. The full test suite passes (`bun test --recursive`).
+
+A future `@goke/mcp` may rename `commandFilter`, change ctx's shape, or break `InMemoryTransport` injection — all three are observable failures the test suite catches, but only if the upgrade ran through CI before merge.
+
 ## ANTI-PATTERNS
 
 - Never use `bundledDependencies` — Bun's `.bun/` symlinks create `../../` paths that npm rejects with E415.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "yaml": "2.9.0"
   },
   "engines": {

--- a/packages/cli/src/__test__/mcp-ctx-fixture.test.ts
+++ b/packages/cli/src/__test__/mcp-ctx-fixture.test.ts
@@ -1,0 +1,108 @@
+import {describe, expect, it} from 'bun:test'
+
+import {createCapturedCtx, expectCapturedToInclude} from './mcp-ctx-fixture'
+
+describe('createCapturedCtx', () => {
+  describe('ctx.console.log', () => {
+    it('populates captured.stdout with a single string arg', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.console.log('hello')
+      expect(captured.stdout).toEqual(['hello'])
+    })
+
+    it('space-joins multiple args matching console.log behavior', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.console.log('foo', 'bar', 42)
+      expect(captured.stdout).toEqual(['foo bar 42'])
+    })
+  })
+
+  describe('ctx.process.stdout.write', () => {
+    it('pushes a string chunk to captured.stdout', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.process.stdout.write('chunk')
+      expect(captured.stdout).toEqual(['chunk'])
+    })
+
+    it('decodes a Uint8Array chunk as utf-8 and pushes to captured.stdout', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.process.stdout.write(new TextEncoder().encode('buf'))
+      expect(captured.stdout).toEqual(['buf'])
+    })
+  })
+
+  describe('ctx.process.stderr.write', () => {
+    it('pushes a string chunk to captured.stderr', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.process.stderr.write('err-chunk')
+      expect(captured.stderr).toEqual(['err-chunk'])
+    })
+  })
+
+  describe('ctx.console.error', () => {
+    it('pushes formatted string to captured.stderr', () => {
+      const {ctx, captured} = createCapturedCtx()
+      ctx.console.error('oops', 99)
+      expect(captured.stderr).toEqual(['oops 99'])
+    })
+  })
+
+  describe('ctx.process.exit', () => {
+    it('throws after populating captured.exit with code 1', () => {
+      const {ctx, captured} = createCapturedCtx()
+      let threw = false
+      try {
+        ctx.process.exit(1)
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+      expect(captured.exit).toEqual({code: 1})
+    })
+
+    it('also throws for exit code 0', () => {
+      const {ctx, captured} = createCapturedCtx()
+      let threw = false
+      try {
+        ctx.process.exit(0)
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+      expect(captured.exit).toEqual({code: 0})
+    })
+  })
+
+  it('starts with empty stdout, stderr, and null exit', () => {
+    const {captured} = createCapturedCtx()
+    expect(captured.stdout).toEqual([])
+    expect(captured.stderr).toEqual([])
+    expect(captured.exit).toBeNull()
+  })
+})
+
+describe('expectCapturedToInclude', () => {
+  it('returns true when stdout contains the string marker', () => {
+    const {ctx, captured} = createCapturedCtx()
+    ctx.console.log('hello world')
+    expect(expectCapturedToInclude(captured, 'hello')).toBe(true)
+  })
+
+  it('returns false when stdout does not contain the string marker', () => {
+    const {ctx, captured} = createCapturedCtx()
+    ctx.console.log('goodbye')
+    expect(expectCapturedToInclude(captured, 'hello')).toBe(false)
+  })
+
+  it('returns true when stdout matches a regex marker', () => {
+    const {ctx, captured} = createCapturedCtx()
+    ctx.console.log('hello world')
+    expect(expectCapturedToInclude(captured, /^hello/)).toBe(true)
+  })
+
+  it('returns false when stdout does not match a regex marker', () => {
+    const {ctx, captured} = createCapturedCtx()
+    ctx.console.log('hello world')
+    expect(expectCapturedToInclude(captured, /^world/)).toBe(false)
+  })
+})

--- a/packages/cli/src/__test__/mcp-ctx-fixture.ts
+++ b/packages/cli/src/__test__/mcp-ctx-fixture.ts
@@ -1,0 +1,102 @@
+import {format} from 'node:util'
+
+/**
+ * Captured output from a `createCapturedCtx()` invocation.
+ */
+export interface CapturedOutput {
+  stdout: string[]
+  stderr: string[]
+  exit: {code: number} | null
+}
+
+/**
+ * Error thrown by `ctx.process.exit()` in the mock context.
+ * Mirrors the `GokeProcessExit` pattern from goke — exit always throws
+ * so action code cannot silently swallow it.
+ */
+export class MockProcessExit extends Error {
+  readonly code: number
+
+  constructor(code: number) {
+    super(`MockProcessExit: process.exit(${code})`)
+    this.name = 'MockProcessExit'
+    this.code = code
+  }
+}
+
+/**
+ * Minimal surface of `GokeExecutionContext` that action code consumes.
+ * Matches `ctx.console.{log,error}`, `ctx.process.{stdout,stderr}.write`,
+ * and `ctx.process.exit` — the same shape produced by
+ * `createCallToolExecutionContext` in `@goke/mcp`.
+ */
+export interface CapturedCtx {
+  console: {
+    log: (...args: unknown[]) => void
+    error: (...args: unknown[]) => void
+  }
+  process: {
+    stdout: {write: (chunk: string | Uint8Array) => void}
+    stderr: {write: (chunk: string | Uint8Array) => void}
+    exit: (code: number) => never
+  }
+}
+
+function decodeChunk(chunk: string | Uint8Array): string {
+  if (typeof chunk === 'string') return chunk
+  return new TextDecoder().decode(chunk)
+}
+
+/**
+ * Create a fresh mock `GokeExecutionContext` with output capture.
+ *
+ * Each call returns an independent `{ctx, captured}` pair — no shared state.
+ * Use one call per test to keep tests isolated.
+ */
+export function createCapturedCtx(): {ctx: CapturedCtx; captured: CapturedOutput} {
+  const captured: CapturedOutput = {
+    stdout: [],
+    stderr: [],
+    exit: null,
+  }
+
+  const ctx: CapturedCtx = {
+    console: {
+      log(...args: unknown[]) {
+        captured.stdout.push(format(...args))
+      },
+      error(...args: unknown[]) {
+        captured.stderr.push(format(...args))
+      },
+    },
+    process: {
+      stdout: {
+        write(chunk: string | Uint8Array) {
+          captured.stdout.push(decodeChunk(chunk))
+        },
+      },
+      stderr: {
+        write(chunk: string | Uint8Array) {
+          captured.stderr.push(decodeChunk(chunk))
+        },
+      },
+      exit(code: number): never {
+        captured.exit = {code}
+        throw new MockProcessExit(code)
+      },
+    },
+  }
+
+  return {ctx, captured}
+}
+
+/**
+ * Returns `true` when the concatenated stdout contains `marker`.
+ *
+ * Composable — does not throw. Use with `expect(...).toBe(true)`.
+ */
+export function expectCapturedToInclude(captured: CapturedOutput, marker: string | RegExp): boolean {
+  const text = captured.stdout.join('')
+  if (typeof marker === 'string') return text.includes(marker)
+  return marker.test(text)
+}

--- a/packages/cli/src/__test__/mcp-ctx-fixture.ts
+++ b/packages/cli/src/__test__/mcp-ctx-fixture.ts
@@ -1,5 +1,7 @@
 import {format} from 'node:util'
 
+export type {ActionCtx} from '../lib/action-ctx'
+
 /**
  * Captured output from a `createCapturedCtx()` invocation.
  */
@@ -21,33 +23,6 @@ export class MockProcessExit extends Error {
     super(`MockProcessExit: process.exit(${code})`)
     this.name = 'MockProcessExit'
     this.code = code
-  }
-}
-
-/**
- * Minimal `ctx` interface every MCP-capturable action accepts.
- *
- * Structural subtype of goke's real `GokeExecutionContext` — actions
- * consume only `console.{log,error}`, `process.{stdout,stderr}.write`,
- * and `process.exit`, never the `fs` surface. Source files import this
- * shape from the fixture module so the action contract is defined in
- * one place.
- *
- * The `write` parameter is `string` (narrower than goke's real
- * `string | Uint8Array`) because every action passes string values;
- * `CapturedCtx.write(string | Uint8Array)` is still assignable to
- * `ActionCtx.write(string)` via contravariance, so tests using
- * `CapturedCtx` satisfy this interface.
- */
-export interface ActionCtx {
-  console: {
-    log: (...args: unknown[]) => void
-    error: (...args: unknown[]) => void
-  }
-  process: {
-    stdout: {write: (chunk: string) => void}
-    stderr: {write: (chunk: string) => void}
-    exit: (code: number) => never | void
   }
 }
 

--- a/packages/cli/src/__test__/mcp-ctx-fixture.ts
+++ b/packages/cli/src/__test__/mcp-ctx-fixture.ts
@@ -25,7 +25,34 @@ export class MockProcessExit extends Error {
 }
 
 /**
- * Minimal surface of `GokeExecutionContext` that action code consumes.
+ * Minimal `ctx` interface every MCP-capturable action accepts.
+ *
+ * Structural subtype of goke's real `GokeExecutionContext` — actions
+ * consume only `console.{log,error}`, `process.{stdout,stderr}.write`,
+ * and `process.exit`, never the `fs` surface. Source files import this
+ * shape from the fixture module so the action contract is defined in
+ * one place.
+ *
+ * The `write` parameter is `string` (narrower than goke's real
+ * `string | Uint8Array`) because every action passes string values;
+ * `CapturedCtx.write(string | Uint8Array)` is still assignable to
+ * `ActionCtx.write(string)` via contravariance, so tests using
+ * `CapturedCtx` satisfy this interface.
+ */
+export interface ActionCtx {
+  console: {
+    log: (...args: unknown[]) => void
+    error: (...args: unknown[]) => void
+  }
+  process: {
+    stdout: {write: (chunk: string) => void}
+    stderr: {write: (chunk: string) => void}
+    exit: (code: number) => never | void
+  }
+}
+
+/**
+ * Minimal surface of `GokeExecutionContext` that the capture fixture provides.
  * Matches `ctx.console.{log,error}`, `ctx.process.{stdout,stderr}.write`,
  * and `ctx.process.exit` — the same shape produced by
  * `createCallToolExecutionContext` in `@goke/mcp`.

--- a/packages/cli/src/commands/cliproxy/config.test.ts
+++ b/packages/cli/src/commands/cliproxy/config.test.ts
@@ -1,9 +1,35 @@
-import {chmodSync, existsSync, statSync} from 'node:fs'
+import {existsSync, statSync} from 'node:fs'
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
-import {buildSetRequest, formatConfigAsColumns, parseBoolean, parseNumber, resolveManagementKey} from './config'
+import {createCapturedCtx, expectCapturedToInclude} from '../../__test__/mcp-ctx-fixture'
+import {
+  buildSetRequest,
+  cliproxyConfigGetAction,
+  cliproxyConfigSetAction,
+  formatConfigAsColumns,
+  parseBoolean,
+  parseNumber,
+  resolveManagementKey,
+} from './config'
 import {toStringArray} from './keys'
 import {requireSshAuthSock, resolveHost} from './login'
+
+const originalFetch = globalThis.fetch
+
+type FetchReplacement = (url: string, init?: RequestInit) => Promise<Response>
+
+function createFetchImplementation(handler: FetchReplacement): typeof fetch {
+  return Object.assign(
+    (input: string | URL | Request, init?: RequestInit) => {
+      if (typeof input !== 'string') {
+        throw new TypeError(`Unexpected non-string fetch input: ${String(input)}`)
+      }
+
+      return handler(input, init)
+    },
+    {preconnect: originalFetch.preconnect},
+  )
+}
 
 describe('cliproxy config helpers', () => {
   describe('parseBoolean', () => {
@@ -100,95 +126,6 @@ describe('cliproxy config helpers', () => {
       expect(() => resolveManagementKey()).toThrow()
     })
   })
-
-  describe('config get --output', () => {
-    it('writes config JSON to file with 0600 permissions', async () => {
-      const testFile = '/tmp/test-config-output.json'
-      const mockConfig = {debug: true, 'api-keys': ['key1', 'key2']}
-
-      const originalFetch = globalThis.fetch as typeof fetch
-      ;(globalThis.fetch as unknown) = async () => {
-        return new Response(JSON.stringify(mockConfig), {status: 200})
-      }
-
-      try {
-        const baseUrl = 'https://cliproxy.example.com'
-        const managementKey = 'test-key'
-        const endpoint = `${baseUrl}/v0/management/config`
-        const response = await fetch(endpoint, {
-          method: 'GET',
-          headers: new Headers({
-            'x-management-key': managementKey,
-            'content-type': 'application/json',
-          }),
-        })
-        const payload = await response.json()
-        const jsonOutput = JSON.stringify(payload, null, 2)
-
-        await Bun.write(testFile, jsonOutput)
-        chmodSync(testFile, 0o600)
-        const {mode} = statSync(testFile)
-        const permissions = mode & 0o777
-
-        expect(existsSync(testFile)).toBe(true)
-        expect(permissions).toBe(0o600)
-
-        const content = await Bun.file(testFile).text()
-        expect(JSON.parse(content)).toEqual(mockConfig)
-      } finally {
-        ;(globalThis.fetch as unknown) = originalFetch
-        if (existsSync(testFile)) {
-          const fs = await import('node:fs/promises')
-          await fs.unlink(testFile).catch(() => {})
-        }
-      }
-    })
-
-    it('prints API key warning to stderr when writing to stdout', async () => {
-      const mockConfig = {debug: true, 'api-keys': ['secret-key']}
-      const stderrLines: string[] = []
-      const stdoutLines: string[] = []
-
-      const originalError = console.error
-      const originalLog = console.log
-      console.error = (...args: unknown[]) => {
-        stderrLines.push(String(args[0]))
-      }
-      console.log = (...args: unknown[]) => {
-        stdoutLines.push(String(args[0]))
-      }
-
-      const originalFetch = globalThis.fetch as typeof fetch
-      ;(globalThis.fetch as unknown) = async () => {
-        return new Response(JSON.stringify(mockConfig), {status: 200})
-      }
-
-      try {
-        const baseUrl = 'https://cliproxy.example.com'
-        const managementKey = 'test-key'
-        const endpoint = `${baseUrl}/v0/management/config`
-        const response = await fetch(endpoint, {
-          method: 'GET',
-          headers: new Headers({
-            'x-management-key': managementKey,
-            'content-type': 'application/json',
-          }),
-        })
-        const payload = await response.json()
-        const jsonOutput = JSON.stringify(payload, null, 2)
-
-        console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
-        console.log(jsonOutput)
-
-        expect(stderrLines.some(line => line.includes('API keys'))).toBe(true)
-        expect(stdoutLines.some(line => line.includes('debug'))).toBe(true)
-      } finally {
-        console.error = originalError
-        console.log = originalLog
-        ;(globalThis.fetch as unknown) = originalFetch
-      }
-    })
-  })
 })
 
 describe('formatConfigAsColumns', () => {
@@ -214,6 +151,132 @@ describe('formatConfigAsColumns', () => {
   it('falls back to JSON.stringify for non-objects', () => {
     expect(formatConfigAsColumns(null)).toBe('null')
     expect(formatConfigAsColumns([1, 2])).toBe('[\n  1,\n  2\n]')
+  })
+})
+
+describe('cliproxyConfigGetAction (Mode C, Tier-2 ctx capture)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode C: captures formatted config to ctx.stdout and returns config object', async () => {
+    const mockConfig = {debug: true, 'request-retry': 3}
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(mockConfig), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    const result = await cliproxyConfigGetAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    // Tier-2: stdout contains formatted config
+    expect(expectCapturedToInclude(captured, 'debug')).toBe(true)
+    expect(expectCapturedToInclude(captured, 'request-retry')).toBe(true)
+
+    // Mode C: action returns the config object
+    expect(result).toEqual(mockConfig)
+  })
+
+  it('Mode C: security warning goes to ctx.stderr', async () => {
+    const mockConfig = {debug: false}
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(mockConfig), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyConfigGetAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    const stderrText = captured.stderr.join('')
+    expect(stderrText).toContain('API keys')
+  })
+
+  it('Mode C: --json flag outputs raw JSON to ctx.stdout', async () => {
+    const mockConfig = {debug: true}
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(mockConfig), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    const result = await cliproxyConfigGetAction(
+      {url: 'https://cliproxy.example.com', key: 'mgmt-key', json: true},
+      ctx,
+    )
+
+    const stdoutText = captured.stdout.join('')
+    expect(JSON.parse(stdoutText)).toEqual(mockConfig)
+    expect(result).toEqual(mockConfig)
+  })
+
+  it('Mode C: --output writes file and prints confirmation to ctx.stdout', async () => {
+    const testFile = '/tmp/test-cliproxy-config-get-action.json'
+    const mockConfig = {debug: true, 'api-keys': ['key1', 'key2']}
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(mockConfig), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    try {
+      const result = await cliproxyConfigGetAction(
+        {url: 'https://cliproxy.example.com', key: 'mgmt-key', output: testFile},
+        ctx,
+      )
+
+      expect(existsSync(testFile)).toBe(true)
+      const {mode} = statSync(testFile)
+      expect(mode & 0o777).toBe(0o600)
+      expect(JSON.parse(await Bun.file(testFile).text())).toEqual(mockConfig)
+      expect(expectCapturedToInclude(captured, '✓ Config written to')).toBe(true)
+      expect(result).toEqual(mockConfig)
+    } finally {
+      if (existsSync(testFile)) {
+        const fs = await import('node:fs/promises')
+        await fs.unlink(testFile).catch(() => {})
+      }
+    }
+  })
+})
+
+describe('cliproxyConfigSetAction (Mode A, two positional args, Tier-2 ctx capture)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode A: captures PUT response to ctx.stdout', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify({value: true}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyConfigSetAction('debug', 'true', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'value')).toBe(true)
+    expect(expectCapturedToInclude(captured, 'true')).toBe(true)
+  })
+
+  it('Mode A: throws for unsupported field', async () => {
+    const {ctx} = createCapturedCtx()
+    await expect(
+      cliproxyConfigSetAction('unsupported-field', 'val', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toThrow('not a supported mutable field')
   })
 })
 

--- a/packages/cli/src/commands/cliproxy/config.test.ts
+++ b/packages/cli/src/commands/cliproxy/config.test.ts
@@ -272,11 +272,118 @@ describe('cliproxyConfigSetAction (Mode A, two positional args, Tier-2 ctx captu
     expect(expectCapturedToInclude(captured, 'true')).toBe(true)
   })
 
-  it('Mode A: throws for unsupported field', async () => {
-    const {ctx} = createCapturedCtx()
+  it('Mode A: routes unsupported field error through ctx.console.error + exit(1)', async () => {
+    const {ctx, captured} = createCapturedCtx()
     await expect(
       cliproxyConfigSetAction('unsupported-field', 'val', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
-    ).rejects.toThrow('not a supported mutable field')
+    ).rejects.toMatchObject({name: 'MockProcessExit', code: 1})
+    expect(captured.stderr.join('')).toContain('not a supported mutable field')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})
+
+describe('cliproxyConfigGetAction (Tier-2 failure-path parity)', () => {
+  const originalManagementKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalManagementKey === undefined) {
+      delete process.env.CLIPROXY_MANAGEMENT_KEY
+    } else {
+      process.env.CLIPROXY_MANAGEMENT_KEY = originalManagementKey
+    }
+  })
+
+  it('Tier-2: missing CLIPROXY_MANAGEMENT_KEY routes to ctx.console.error + exit(1)', async () => {
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(cliproxyConfigGetAction({url: 'https://cliproxy.example.com'}, ctx)).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Management API key')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: HTTP 500 response routes to ctx.console.error + exit(1)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('server error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyConfigGetAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('HTTP 500')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: --output write failure routes to ctx.console.error + exit(1)', async () => {
+    const mockConfig = {debug: true}
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(mockConfig), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    // Use a path that cannot be written (directory as file path)
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyConfigGetAction(
+        {url: 'https://cliproxy.example.com', key: 'mgmt-key', output: '/dev/null/cannot-write'},
+        ctx,
+      ),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Failed to write config')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})
+
+describe('cliproxyConfigSetAction (Tier-2 failure-path parity)', () => {
+  const originalManagementKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalManagementKey === undefined) {
+      delete process.env.CLIPROXY_MANAGEMENT_KEY
+    } else {
+      process.env.CLIPROXY_MANAGEMENT_KEY = originalManagementKey
+    }
+  })
+
+  it('Tier-2: missing CLIPROXY_MANAGEMENT_KEY routes to ctx.console.error + exit(1)', async () => {
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyConfigSetAction('debug', 'true', {url: 'https://cliproxy.example.com'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Management API key')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: HTTP 500 response routes to ctx.console.error + exit(1)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('server error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyConfigSetAction('debug', 'true', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('HTTP 500')
+    expect(captured.exit).toEqual({code: 1})
   })
 })
 

--- a/packages/cli/src/commands/cliproxy/config.ts
+++ b/packages/cli/src/commands/cliproxy/config.ts
@@ -1,12 +1,12 @@
 import type {goke} from 'goke'
 
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 import {chmodSync} from 'node:fs'
 
 import {z} from 'zod'
 
 /** Minimal ctx surface consumed by cliproxy config actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
-// ActionCtx imported from fixture — single source of truth for action ctx shape
+// ActionCtx imported from lib/action-ctx — single source of truth for action ctx shape
 
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
 const HTTP_TIMEOUT_MS = 10_000
@@ -144,6 +144,11 @@ export interface ConfigGetOptions {
   json?: boolean
 }
 
+/**
+ * Mode C: prints formatted config via ctx AND returns the parsed config object so MCP consumers
+ * receive both formatted text and parseable structured data. Return type is `Promise<unknown>`
+ * because the config shape is server-defined and genuinely loose at the TypeScript boundary.
+ */
 export async function cliproxyConfigGetAction(options: ConfigGetOptions, ctx: ActionCtx): Promise<unknown> {
   const baseUrl = resolveBaseUrl(options.url)
   const managementKey = resolveManagementKey(options.key)

--- a/packages/cli/src/commands/cliproxy/config.ts
+++ b/packages/cli/src/commands/cliproxy/config.ts
@@ -144,40 +144,44 @@ export interface ConfigGetOptions {
   json?: boolean
 }
 
-/**
- * Mode C: prints formatted config via ctx AND returns the parsed config object so MCP consumers
- * receive both formatted text and parseable structured data. Return type is `Promise<unknown>`
- * because the config shape is server-defined and genuinely loose at the TypeScript boundary.
- */
 export async function cliproxyConfigGetAction(options: ConfigGetOptions, ctx: ActionCtx): Promise<unknown> {
-  const baseUrl = resolveBaseUrl(options.url)
-  const managementKey = resolveManagementKey(options.key)
-  const endpoint = `${baseUrl}/v0/management/config`
-  const payload = await requestJson(endpoint, {
-    method: 'GET',
-    headers: managementHeaders(managementKey),
-  })
+  try {
+    const baseUrl = resolveBaseUrl(options.url)
+    const managementKey = resolveManagementKey(options.key)
+    const endpoint = `${baseUrl}/v0/management/config`
+    const payload = await requestJson(endpoint, {
+      method: 'GET',
+      headers: managementHeaders(managementKey),
+    })
 
-  const jsonOutput = JSON.stringify(payload, null, 2)
+    const jsonOutput = JSON.stringify(payload, null, 2)
 
-  if (options.output) {
-    try {
-      await Bun.write(options.output, jsonOutput)
-      chmodSync(options.output, 0o600)
-      ctx.console.log(`✓ Config written to ${options.output}`)
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to write config to ${options.output}: ${message}`)
+    if (options.output) {
+      try {
+        await Bun.write(options.output, jsonOutput)
+        chmodSync(options.output, 0o600)
+        ctx.console.log(`✓ Config written to ${options.output}`)
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        ctx.console.error(`Failed to write config to ${options.output}: ${message}`)
+        ctx.process.exit(1)
+        return undefined // unreachable
+      }
+    } else if (options.json) {
+      ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
+      ctx.console.log(jsonOutput)
+    } else {
+      ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
+      ctx.console.log(formatConfigAsColumns(payload))
     }
-  } else if (options.json) {
-    ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
-    ctx.console.log(jsonOutput)
-  } else {
-    ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
-    ctx.console.log(formatConfigAsColumns(payload))
-  }
 
-  return payload
+    return payload
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
+    return undefined // unreachable; satisfies TS that all paths return
+  }
 }
 
 export interface ConfigSetOptions {
@@ -191,17 +195,23 @@ export async function cliproxyConfigSetAction(
   options: ConfigSetOptions,
   ctx: ActionCtx,
 ): Promise<void> {
-  const baseUrl = resolveBaseUrl(options.url)
-  const managementKey = resolveManagementKey(options.key)
-  const request = buildSetRequest(baseUrl, field, value)
+  try {
+    const baseUrl = resolveBaseUrl(options.url)
+    const managementKey = resolveManagementKey(options.key)
+    const request = buildSetRequest(baseUrl, field, value)
 
-  const payload = await requestJson(request.endpoint, {
-    method: 'PUT',
-    headers: managementHeaders(managementKey),
-    body: request.body,
-  })
+    const payload = await requestJson(request.endpoint, {
+      method: 'PUT',
+      headers: managementHeaders(managementKey),
+      body: request.body,
+    })
 
-  ctx.console.log(JSON.stringify(payload, null, 2))
+    ctx.console.log(JSON.stringify(payload, null, 2))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
+  }
 }
 
 export function registerCliproxyConfig(cli: ReturnType<typeof goke>): void {

--- a/packages/cli/src/commands/cliproxy/config.ts
+++ b/packages/cli/src/commands/cliproxy/config.ts
@@ -1,7 +1,12 @@
 import type {goke} from 'goke'
 
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
 import {chmodSync} from 'node:fs'
+
 import {z} from 'zod'
+
+/** Minimal ctx surface consumed by cliproxy config actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
+// ActionCtx imported from fixture — single source of truth for action ctx shape
 
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
 const HTTP_TIMEOUT_MS = 10_000
@@ -132,6 +137,68 @@ export function formatConfigAsColumns(payload: unknown): string {
     .join('\n')
 }
 
+export interface ConfigGetOptions {
+  url?: string
+  key?: string
+  output?: string
+  json?: boolean
+}
+
+export async function cliproxyConfigGetAction(options: ConfigGetOptions, ctx: ActionCtx): Promise<unknown> {
+  const baseUrl = resolveBaseUrl(options.url)
+  const managementKey = resolveManagementKey(options.key)
+  const endpoint = `${baseUrl}/v0/management/config`
+  const payload = await requestJson(endpoint, {
+    method: 'GET',
+    headers: managementHeaders(managementKey),
+  })
+
+  const jsonOutput = JSON.stringify(payload, null, 2)
+
+  if (options.output) {
+    try {
+      await Bun.write(options.output, jsonOutput)
+      chmodSync(options.output, 0o600)
+      ctx.console.log(`✓ Config written to ${options.output}`)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to write config to ${options.output}: ${message}`)
+    }
+  } else if (options.json) {
+    ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
+    ctx.console.log(jsonOutput)
+  } else {
+    ctx.console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
+    ctx.console.log(formatConfigAsColumns(payload))
+  }
+
+  return payload
+}
+
+export interface ConfigSetOptions {
+  url?: string
+  key?: string
+}
+
+export async function cliproxyConfigSetAction(
+  field: string,
+  value: string,
+  options: ConfigSetOptions,
+  ctx: ActionCtx,
+): Promise<void> {
+  const baseUrl = resolveBaseUrl(options.url)
+  const managementKey = resolveManagementKey(options.key)
+  const request = buildSetRequest(baseUrl, field, value)
+
+  const payload = await requestJson(request.endpoint, {
+    method: 'PUT',
+    headers: managementHeaders(managementKey),
+    body: request.body,
+  })
+
+  ctx.console.log(JSON.stringify(payload, null, 2))
+}
+
 export function registerCliproxyConfig(cli: ReturnType<typeof goke>): void {
   cli
     .command('cliproxy config get', 'Fetch current CLIProxyAPI config as JSON.')
@@ -154,34 +221,7 @@ export function registerCliproxyConfig(cli: ReturnType<typeof goke>): void {
         .describe('Write config JSON to a file instead of stdout. File permissions set to 0600 (owner-read-only).'),
     )
     .option('--json', 'Output raw JSON instead of aligned key: value columns.')
-    .action(async options => {
-      const baseUrl = resolveBaseUrl(options.url)
-      const managementKey = resolveManagementKey(options.key)
-      const endpoint = `${baseUrl}/v0/management/config`
-      const payload = await requestJson(endpoint, {
-        method: 'GET',
-        headers: managementHeaders(managementKey),
-      })
-
-      const jsonOutput = JSON.stringify(payload, null, 2)
-
-      if (options.output) {
-        try {
-          await Bun.write(options.output, jsonOutput)
-          chmodSync(options.output, 0o600)
-          console.log(`✓ Config written to ${options.output}`)
-        } catch (error: unknown) {
-          const message = error instanceof Error ? error.message : String(error)
-          throw new Error(`Failed to write config to ${options.output}: ${message}`)
-        }
-      } else if (options.json) {
-        console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
-        console.log(jsonOutput)
-      } else {
-        console.error('⚠️  Output may contain API keys — avoid logging or storing in shared locations')
-        console.log(formatConfigAsColumns(payload))
-      }
-    })
+    .action(cliproxyConfigGetAction)
 
   cli
     .command(
@@ -203,17 +243,5 @@ export function registerCliproxyConfig(cli: ReturnType<typeof goke>): void {
     .example('infra cliproxy config set debug true')
     .example('infra cliproxy config set request-retry 5')
     .example('infra cliproxy config set proxy-url https://proxy.example.com')
-    .action(async (field, value, options) => {
-      const baseUrl = resolveBaseUrl(options.url)
-      const managementKey = resolveManagementKey(options.key)
-      const request = buildSetRequest(baseUrl, field, value)
-
-      const payload = await requestJson(request.endpoint, {
-        method: 'PUT',
-        headers: managementHeaders(managementKey),
-        body: request.body,
-      })
-
-      console.log(JSON.stringify(payload, null, 2))
-    })
+    .action(cliproxyConfigSetAction)
 }

--- a/packages/cli/src/commands/cliproxy/keys.test.ts
+++ b/packages/cli/src/commands/cliproxy/keys.test.ts
@@ -1,0 +1,205 @@
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+
+import {createCapturedCtx, expectCapturedToInclude} from '../../__test__/mcp-ctx-fixture'
+import {cliproxyKeysAddAction, cliproxyKeysListAction, cliproxyKeysRemoveAction, toStringArray} from './keys'
+
+const originalFetch = globalThis.fetch
+
+type FetchReplacement = (url: string, init?: RequestInit) => Promise<Response>
+
+function createFetchImplementation(handler: FetchReplacement): typeof fetch {
+  return Object.assign(
+    (input: string | URL | Request, init?: RequestInit) => {
+      if (typeof input !== 'string') {
+        throw new TypeError(`Unexpected non-string fetch input: ${String(input)}`)
+      }
+
+      return handler(input, init)
+    },
+    {preconnect: originalFetch.preconnect},
+  )
+}
+
+describe('toStringArray', () => {
+  it('returns string array as-is', () => {
+    expect(toStringArray(['a', 'b', 'c'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('filters non-string items from array', () => {
+    expect(toStringArray(['a', 1, null, 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('extracts api-keys from object', () => {
+    expect(toStringArray({'api-keys': ['x', 'y']})).toEqual(['x', 'y'])
+  })
+
+  it('extracts api_keys from object (underscore variant)', () => {
+    expect(toStringArray({api_keys: ['x', 'y']})).toEqual(['x', 'y'])
+  })
+
+  it('returns empty array for null', () => {
+    expect(toStringArray(null)).toEqual([])
+  })
+
+  it('returns empty array for unrecognized shape', () => {
+    expect(toStringArray({other: 'stuff'})).toEqual([])
+  })
+})
+
+describe('cliproxyKeysListAction (Mode C, Tier-2 ctx capture)', () => {
+  beforeEach(() => {
+    globalThis.fetch = createFetchImplementation(async () => {
+      throw new Error('Unexpected fetch call')
+    })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode C: captures numbered list to ctx.stdout and returns key array', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(['sk-live-aaa', 'sk-live-bbb']), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    const result = await cliproxyKeysListAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    // Tier-2: stdout contains formatted list
+    expect(expectCapturedToInclude(captured, 'sk-live-aaa')).toBe(true)
+    expect(expectCapturedToInclude(captured, '1.')).toBe(true)
+    expect(expectCapturedToInclude(captured, '2.')).toBe(true)
+
+    // Mode C: action returns the parsed array
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toEqual(['sk-live-aaa', 'sk-live-bbb'])
+  })
+
+  it('Mode C: security warning goes to ctx.stderr', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(['sk-live-aaa']), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyKeysListAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    const stderrText = captured.stderr.join('')
+    expect(stderrText).toContain('API keys')
+  })
+
+  it('Mode C: returns empty array and prints "No API keys configured" when list is empty', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    const result = await cliproxyKeysListAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'No API keys configured')).toBe(true)
+    expect(result).toEqual([])
+  })
+
+  it('Mode C: --json flag outputs JSON array to ctx.stdout', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify(['sk-live-aaa']), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    const result = await cliproxyKeysListAction({url: 'https://cliproxy.example.com', key: 'mgmt-key', json: true}, ctx)
+
+    const stdoutText = captured.stdout.join('')
+    const parsed = JSON.parse(stdoutText)
+    expect(parsed).toEqual(['sk-live-aaa'])
+    expect(result).toEqual(['sk-live-aaa'])
+  })
+})
+
+describe('cliproxyKeysAddAction (Mode A, positional arg, Tier-2 ctx capture)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode A: captures success message to ctx.stdout after adding key', async () => {
+    let putCalled = false
+    globalThis.fetch = createFetchImplementation(async (_url, init) => {
+      if (init?.method === 'PUT') {
+        putCalled = true
+        return new Response(JSON.stringify(['sk-live-existing', 'sk-live-new']), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      }
+
+      // GET current keys
+      return new Response(JSON.stringify(['sk-live-existing']), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyKeysAddAction('sk-live-new', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    expect(putCalled).toBe(true)
+    expect(expectCapturedToInclude(captured, 'sk-live-new')).toBe(true)
+    expect(expectCapturedToInclude(captured, 'Added key')).toBe(true)
+  })
+
+  it('Mode A: skips PUT when key already present', async () => {
+    let putCalled = false
+    globalThis.fetch = createFetchImplementation(async (_url, init) => {
+      if (init?.method === 'PUT') {
+        putCalled = true
+        return new Response('{}', {status: 200})
+      }
+
+      return new Response(JSON.stringify(['sk-live-existing']), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyKeysAddAction('sk-live-existing', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    expect(putCalled).toBe(false)
+    expect(expectCapturedToInclude(captured, 'already present')).toBe(true)
+  })
+})
+
+describe('cliproxyKeysRemoveAction (Mode A, positional arg, Tier-2 ctx capture)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode A: captures DELETE response to ctx.stdout', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify({removed: true}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyKeysRemoveAction('sk-live-old', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'removed')).toBe(true)
+  })
+})

--- a/packages/cli/src/commands/cliproxy/keys.test.ts
+++ b/packages/cli/src/commands/cliproxy/keys.test.ts
@@ -203,3 +203,124 @@ describe('cliproxyKeysRemoveAction (Mode A, positional arg, Tier-2 ctx capture)'
     expect(expectCapturedToInclude(captured, 'removed')).toBe(true)
   })
 })
+
+describe('cliproxyKeysListAction (Tier-2 failure-path parity)', () => {
+  const originalManagementKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalManagementKey === undefined) {
+      delete process.env.CLIPROXY_MANAGEMENT_KEY
+    } else {
+      process.env.CLIPROXY_MANAGEMENT_KEY = originalManagementKey
+    }
+  })
+
+  it('Tier-2: missing CLIPROXY_MANAGEMENT_KEY routes to ctx.console.error + exit(1)', async () => {
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(cliproxyKeysListAction({url: 'https://cliproxy.example.com'}, ctx)).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Management API key')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: HTTP 500 response routes to ctx.console.error + exit(1)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('server error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyKeysListAction({url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('HTTP 500')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})
+
+describe('cliproxyKeysAddAction (Tier-2 failure-path parity)', () => {
+  const originalManagementKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalManagementKey === undefined) {
+      delete process.env.CLIPROXY_MANAGEMENT_KEY
+    } else {
+      process.env.CLIPROXY_MANAGEMENT_KEY = originalManagementKey
+    }
+  })
+
+  it('Tier-2: missing CLIPROXY_MANAGEMENT_KEY routes to ctx.console.error + exit(1)', async () => {
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyKeysAddAction('sk-live-new', {url: 'https://cliproxy.example.com'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Management API key')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: HTTP 500 on GET routes to ctx.console.error + exit(1)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('server error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyKeysAddAction('sk-live-new', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('HTTP 500')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})
+
+describe('cliproxyKeysRemoveAction (Tier-2 failure-path parity)', () => {
+  const originalManagementKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalManagementKey === undefined) {
+      delete process.env.CLIPROXY_MANAGEMENT_KEY
+    } else {
+      process.env.CLIPROXY_MANAGEMENT_KEY = originalManagementKey
+    }
+  })
+
+  it('Tier-2: missing CLIPROXY_MANAGEMENT_KEY routes to ctx.console.error + exit(1)', async () => {
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyKeysRemoveAction('sk-live-old', {url: 'https://cliproxy.example.com'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Management API key')
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('Tier-2: HTTP 500 response routes to ctx.console.error + exit(1)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('server error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await expect(
+      cliproxyKeysRemoveAction('sk-live-old', {url: 'https://cliproxy.example.com', key: 'mgmt-key'}, ctx),
+    ).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('HTTP 500')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})

--- a/packages/cli/src/commands/cliproxy/keys.ts
+++ b/packages/cli/src/commands/cliproxy/keys.ts
@@ -1,6 +1,11 @@
 import type {goke} from 'goke'
 
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+
 import {z} from 'zod'
+
+/** Minimal ctx surface consumed by cliproxy keys actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
+// ActionCtx imported from fixture — single source of truth for action ctx shape
 
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
 const HTTP_TIMEOUT_MS = 10_000
@@ -64,6 +69,95 @@ export function toStringArray(payload: unknown): string[] {
   return []
 }
 
+export interface KeysListOptions {
+  url?: string
+  key?: string
+  json?: boolean
+}
+
+export async function cliproxyKeysListAction(options: KeysListOptions, ctx: ActionCtx): Promise<string[]> {
+  const baseUrl = resolveBaseUrl(options.url)
+  const managementKey = resolveManagementKey(options.key)
+  const endpoint = `${baseUrl}/v0/management/api-keys`
+  const payload = await requestJson(endpoint, {
+    method: 'GET',
+    headers: managementHeaders(managementKey),
+  })
+
+  const keys = toStringArray(payload)
+  ctx.console.error('⚠️  Output contains API keys — avoid logging or storing in shared locations')
+
+  if (options.json) {
+    ctx.console.log(JSON.stringify(keys, null, 2))
+  } else if (keys.length === 0) {
+    ctx.console.log('No API keys configured')
+  } else {
+    for (const [index, apiKey] of keys.entries()) {
+      ctx.console.log(`${index + 1}. ${apiKey}`)
+    }
+  }
+
+  return keys
+}
+
+export interface KeysAddOptions {
+  url?: string
+  key?: string
+}
+
+export async function cliproxyKeysAddAction(
+  apiKeyToAdd: string,
+  options: KeysAddOptions,
+  ctx: ActionCtx,
+): Promise<void> {
+  const baseUrl = resolveBaseUrl(options.url)
+  const managementKey = resolveManagementKey(options.key)
+  const endpoint = `${baseUrl}/v0/management/api-keys`
+
+  const currentPayload = await requestJson(endpoint, {
+    method: 'GET',
+    headers: managementHeaders(managementKey),
+  })
+  const currentKeys = toStringArray(currentPayload)
+
+  if (currentKeys.includes(apiKeyToAdd)) {
+    ctx.console.log('Key already present; no update required.')
+    return
+  }
+
+  const nextKeys = [...currentKeys, apiKeyToAdd]
+  await requestJson(endpoint, {
+    method: 'PUT',
+    headers: managementHeaders(managementKey),
+    body: JSON.stringify(nextKeys),
+  })
+
+  ctx.console.log(`Added key "${apiKeyToAdd}". Current key count: ${nextKeys.length}.`)
+}
+
+export interface KeysRemoveOptions {
+  url?: string
+  key?: string
+}
+
+export async function cliproxyKeysRemoveAction(
+  apiKeyToRemove: string,
+  options: KeysRemoveOptions,
+  ctx: ActionCtx,
+): Promise<void> {
+  const baseUrl = resolveBaseUrl(options.url)
+  const managementKey = resolveManagementKey(options.key)
+  const params = new URLSearchParams({value: apiKeyToRemove})
+  const endpoint = `${baseUrl}/v0/management/api-keys?${params.toString()}`
+
+  const payload = await requestJson(endpoint, {
+    method: 'DELETE',
+    headers: managementHeaders(managementKey),
+  })
+
+  ctx.console.log(JSON.stringify(payload, null, 2))
+}
+
 export function registerCliproxyKeys(cli: ReturnType<typeof goke>): void {
   cli
     .command('cliproxy keys list', 'List CLIProxyAPI API keys from the management API.')
@@ -80,28 +174,7 @@ export function registerCliproxyKeys(cli: ReturnType<typeof goke>): void {
       z.string().describe('Management API key. Falls back to CLIPROXY_MANAGEMENT_KEY when omitted.'),
     )
     .option('--json', 'Output raw JSON array instead of a numbered list.')
-    .action(async options => {
-      const baseUrl = resolveBaseUrl(options.url)
-      const managementKey = resolveManagementKey(options.key)
-      const endpoint = `${baseUrl}/v0/management/api-keys`
-      const payload = await requestJson(endpoint, {
-        method: 'GET',
-        headers: managementHeaders(managementKey),
-      })
-
-      const keys = toStringArray(payload)
-      console.error('⚠️  Output contains API keys — avoid logging or storing in shared locations')
-
-      if (options.json) {
-        console.log(JSON.stringify(keys, null, 2))
-      } else if (keys.length === 0) {
-        console.log('No API keys configured')
-      } else {
-        for (const [index, key] of keys.entries()) {
-          console.log(`${index + 1}. ${key}`)
-        }
-      }
-    })
+    .action(cliproxyKeysListAction)
 
   cli
     .command(
@@ -122,31 +195,7 @@ export function registerCliproxyKeys(cli: ReturnType<typeof goke>): void {
     )
     .example('# Add a new API key to the current key set')
     .example('infra cliproxy keys add sk-live-123')
-    .action(async (apiKeyToAdd, options) => {
-      const baseUrl = resolveBaseUrl(options.url)
-      const managementKey = resolveManagementKey(options.key)
-      const endpoint = `${baseUrl}/v0/management/api-keys`
-
-      const currentPayload = await requestJson(endpoint, {
-        method: 'GET',
-        headers: managementHeaders(managementKey),
-      })
-      const currentKeys = toStringArray(currentPayload)
-
-      if (currentKeys.includes(apiKeyToAdd)) {
-        console.log('Key already present; no update required.')
-        return
-      }
-
-      const nextKeys = [...currentKeys, apiKeyToAdd]
-      await requestJson(endpoint, {
-        method: 'PUT',
-        headers: managementHeaders(managementKey),
-        body: JSON.stringify(nextKeys),
-      })
-
-      console.log(`Added key "${apiKeyToAdd}". Current key count: ${nextKeys.length}.`)
-    })
+    .action(cliproxyKeysAddAction)
 
   cli
     .command('cliproxy keys remove <key>', 'Remove an API key via management API endpoint query parameter.')
@@ -164,17 +213,5 @@ export function registerCliproxyKeys(cli: ReturnType<typeof goke>): void {
     )
     .example('# Remove an API key from CLIProxyAPI')
     .example('infra cliproxy keys remove sk-live-123')
-    .action(async (apiKeyToRemove, options) => {
-      const baseUrl = resolveBaseUrl(options.url)
-      const managementKey = resolveManagementKey(options.key)
-      const params = new URLSearchParams({value: apiKeyToRemove})
-      const endpoint = `${baseUrl}/v0/management/api-keys?${params.toString()}`
-
-      const payload = await requestJson(endpoint, {
-        method: 'DELETE',
-        headers: managementHeaders(managementKey),
-      })
-
-      console.log(JSON.stringify(payload, null, 2))
-    })
+    .action(cliproxyKeysRemoveAction)
 }

--- a/packages/cli/src/commands/cliproxy/keys.ts
+++ b/packages/cli/src/commands/cliproxy/keys.ts
@@ -1,11 +1,11 @@
 import type {goke} from 'goke'
 
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 
 import {z} from 'zod'
 
 /** Minimal ctx surface consumed by cliproxy keys actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
-// ActionCtx imported from fixture — single source of truth for action ctx shape
+// ActionCtx imported from lib/action-ctx — single source of truth for action ctx shape
 
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
 const HTTP_TIMEOUT_MS = 10_000
@@ -75,6 +75,10 @@ export interface KeysListOptions {
   json?: boolean
 }
 
+/**
+ * Mode C: prints formatted table via ctx AND returns the parsed key array so MCP consumers
+ * receive both formatted text and parseable structured data.
+ */
 export async function cliproxyKeysListAction(options: KeysListOptions, ctx: ActionCtx): Promise<string[]> {
   const baseUrl = resolveBaseUrl(options.url)
   const managementKey = resolveManagementKey(options.key)

--- a/packages/cli/src/commands/cliproxy/keys.ts
+++ b/packages/cli/src/commands/cliproxy/keys.ts
@@ -75,33 +75,36 @@ export interface KeysListOptions {
   json?: boolean
 }
 
-/**
- * Mode C: prints formatted table via ctx AND returns the parsed key array so MCP consumers
- * receive both formatted text and parseable structured data.
- */
 export async function cliproxyKeysListAction(options: KeysListOptions, ctx: ActionCtx): Promise<string[]> {
-  const baseUrl = resolveBaseUrl(options.url)
-  const managementKey = resolveManagementKey(options.key)
-  const endpoint = `${baseUrl}/v0/management/api-keys`
-  const payload = await requestJson(endpoint, {
-    method: 'GET',
-    headers: managementHeaders(managementKey),
-  })
+  try {
+    const baseUrl = resolveBaseUrl(options.url)
+    const managementKey = resolveManagementKey(options.key)
+    const endpoint = `${baseUrl}/v0/management/api-keys`
+    const payload = await requestJson(endpoint, {
+      method: 'GET',
+      headers: managementHeaders(managementKey),
+    })
 
-  const keys = toStringArray(payload)
-  ctx.console.error('⚠️  Output contains API keys — avoid logging or storing in shared locations')
+    const keys = toStringArray(payload)
+    ctx.console.error('⚠️  Output contains API keys — avoid logging or storing in shared locations')
 
-  if (options.json) {
-    ctx.console.log(JSON.stringify(keys, null, 2))
-  } else if (keys.length === 0) {
-    ctx.console.log('No API keys configured')
-  } else {
-    for (const [index, apiKey] of keys.entries()) {
-      ctx.console.log(`${index + 1}. ${apiKey}`)
+    if (options.json) {
+      ctx.console.log(JSON.stringify(keys, null, 2))
+    } else if (keys.length === 0) {
+      ctx.console.log('No API keys configured')
+    } else {
+      for (const [index, apiKey] of keys.entries()) {
+        ctx.console.log(`${index + 1}. ${apiKey}`)
+      }
     }
-  }
 
-  return keys
+    return keys
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
+    return [] // unreachable; satisfies TS that all paths return
+  }
 }
 
 export interface KeysAddOptions {
@@ -114,29 +117,35 @@ export async function cliproxyKeysAddAction(
   options: KeysAddOptions,
   ctx: ActionCtx,
 ): Promise<void> {
-  const baseUrl = resolveBaseUrl(options.url)
-  const managementKey = resolveManagementKey(options.key)
-  const endpoint = `${baseUrl}/v0/management/api-keys`
+  try {
+    const baseUrl = resolveBaseUrl(options.url)
+    const managementKey = resolveManagementKey(options.key)
+    const endpoint = `${baseUrl}/v0/management/api-keys`
 
-  const currentPayload = await requestJson(endpoint, {
-    method: 'GET',
-    headers: managementHeaders(managementKey),
-  })
-  const currentKeys = toStringArray(currentPayload)
+    const currentPayload = await requestJson(endpoint, {
+      method: 'GET',
+      headers: managementHeaders(managementKey),
+    })
+    const currentKeys = toStringArray(currentPayload)
 
-  if (currentKeys.includes(apiKeyToAdd)) {
-    ctx.console.log('Key already present; no update required.')
-    return
+    if (currentKeys.includes(apiKeyToAdd)) {
+      ctx.console.log('Key already present; no update required.')
+      return
+    }
+
+    const nextKeys = [...currentKeys, apiKeyToAdd]
+    await requestJson(endpoint, {
+      method: 'PUT',
+      headers: managementHeaders(managementKey),
+      body: JSON.stringify(nextKeys),
+    })
+
+    ctx.console.log(`Added key "${apiKeyToAdd}". Current key count: ${nextKeys.length}.`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
   }
-
-  const nextKeys = [...currentKeys, apiKeyToAdd]
-  await requestJson(endpoint, {
-    method: 'PUT',
-    headers: managementHeaders(managementKey),
-    body: JSON.stringify(nextKeys),
-  })
-
-  ctx.console.log(`Added key "${apiKeyToAdd}". Current key count: ${nextKeys.length}.`)
 }
 
 export interface KeysRemoveOptions {
@@ -149,17 +158,23 @@ export async function cliproxyKeysRemoveAction(
   options: KeysRemoveOptions,
   ctx: ActionCtx,
 ): Promise<void> {
-  const baseUrl = resolveBaseUrl(options.url)
-  const managementKey = resolveManagementKey(options.key)
-  const params = new URLSearchParams({value: apiKeyToRemove})
-  const endpoint = `${baseUrl}/v0/management/api-keys?${params.toString()}`
+  try {
+    const baseUrl = resolveBaseUrl(options.url)
+    const managementKey = resolveManagementKey(options.key)
+    const params = new URLSearchParams({value: apiKeyToRemove})
+    const endpoint = `${baseUrl}/v0/management/api-keys?${params.toString()}`
 
-  const payload = await requestJson(endpoint, {
-    method: 'DELETE',
-    headers: managementHeaders(managementKey),
-  })
+    const payload = await requestJson(endpoint, {
+      method: 'DELETE',
+      headers: managementHeaders(managementKey),
+    })
 
-  ctx.console.log(JSON.stringify(payload, null, 2))
+    ctx.console.log(JSON.stringify(payload, null, 2))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
+  }
 }
 
 export function registerCliproxyKeys(cli: ReturnType<typeof goke>): void {

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -310,6 +310,36 @@ describe('cliproxy status helpers', () => {
   })
 })
 
+describe('cliproxyStatusAction (Tier-2 ctx capture, failure-path parity)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Tier-2: routes unexpected thrown error through ctx.console.error + ctx.process.exit(1)', async () => {
+    // Trigger an unexpected error by having ctx.console.log throw on first call
+    const {ctx, captured} = createCapturedCtx()
+    let callCount = 0
+    const originalLog = ctx.console.log
+    ctx.console.log = (...args: unknown[]) => {
+      callCount++
+      if (callCount === 1) {
+        throw new Error('Unexpected internal error during status output')
+      }
+
+      originalLog(...args)
+    }
+
+    globalThis.fetch = createFetchImplementation(async () => new Response('ok', {status: 200}))
+
+    await expect(cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+    expect(captured.stderr.join('')).toContain('Unexpected internal error')
+    expect(captured.exit).toEqual({code: 1})
+  })
+})
+
 describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -1,9 +1,11 @@
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
+import {createCapturedCtx, expectCapturedToInclude, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
 import {
   checkHttpReachability,
   checkUsageStats,
   checkVersion,
+  cliproxyStatusAction,
   formatDurationMs,
   formatUsageSummaryLine,
   levelLabel,
@@ -305,5 +307,53 @@ describe('cliproxy status helpers', () => {
 
       expect(result).toBe('Requests: 0 total, 0 failed (0.0% failure rate)')
     })
+  })
+})
+
+describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('Mode A: captures CLIProxyAPI status header to ctx.stdout', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('ok', {status: 200}))
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'CLIProxyAPI status')).toBe(true)
+    expect(expectCapturedToInclude(captured, 'HTTP reachability')).toBe(true)
+    expect(expectCapturedToInclude(captured, 'Summary:')).toBe(true)
+  })
+
+  it('Mode A: calls ctx.process.exit(1) on HTTP error', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('error', {status: 500}))
+
+    const {ctx, captured} = createCapturedCtx()
+    let threw: unknown
+    try {
+      await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+    } catch (error) {
+      threw = error
+    }
+
+    expect(threw).toBeInstanceOf(MockProcessExit)
+    expect(captured.exit?.code).toBe(1)
+    expect(expectCapturedToInclude(captured, 'ERROR')).toBe(true)
+  })
+
+  it('Mode A: shows management key warning when no key provided', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('ok', {status: 200}))
+
+    const savedKey = process.env.CLIPROXY_MANAGEMENT_KEY
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+    try {
+      const {ctx, captured} = createCapturedCtx()
+      await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+
+      expect(expectCapturedToInclude(captured, 'CLIPROXY_MANAGEMENT_KEY')).toBe(true)
+    } finally {
+      if (savedKey !== undefined) process.env.CLIPROXY_MANAGEMENT_KEY = savedKey
+    }
   })
 })

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -1,7 +1,11 @@
 import type {goke} from 'goke'
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
 import type {StatusSummary} from '../status'
 
 import {z} from 'zod'
+
+/** Minimal ctx surface consumed by cliproxy status actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
+// ActionCtx imported from fixture — single source of truth for action ctx shape
 
 declare const process: {
   env: Record<string, string | undefined>
@@ -197,13 +201,13 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
   }
 }
 
-function printCheckResult(result: CheckResult): void {
-  console.log(`[${levelLabel(result.level)}] ${result.title}`)
-  console.log(`  ${result.summary}`)
+function printCheckResult(result: CheckResult, ctx: ActionCtx): void {
+  ctx.console.log(`[${levelLabel(result.level)}] ${result.title}`)
+  ctx.console.log(`  ${result.summary}`)
 
   if (result.details && result.details.length > 0) {
     for (const detail of result.details) {
-      console.log(`  - ${detail}`)
+      ctx.console.log(`  - ${detail}`)
     }
   }
 }
@@ -247,6 +251,63 @@ export async function getCliproxyStatusSummary(baseUrl: string, key: string, ver
   }
 }
 
+export interface StatusOptions {
+  url?: string
+  key?: string
+  verbose?: boolean
+}
+
+export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCtx): Promise<void> {
+  const verbose = options.verbose === true
+  const baseUrl = stripTrailingSlash(options.url ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
+  const managementKey = options.key ?? process.env.CLIPROXY_MANAGEMENT_KEY
+
+  ctx.console.log('CLIProxyAPI status')
+  ctx.console.log('')
+
+  const results: CheckResult[] = [await checkHttpReachability(baseUrl, verbose)]
+
+  let capturedUsageResult: CheckResult | undefined
+
+  if (managementKey) {
+    const [usageResult, versionResult] = await Promise.all([
+      checkUsageStats(baseUrl, managementKey),
+      checkVersion(baseUrl, managementKey),
+    ])
+
+    capturedUsageResult = usageResult
+    results.push(usageResult, versionResult)
+  } else {
+    results.push({
+      title: 'Management checks',
+      level: 'warning',
+      summary:
+        'CLIPROXY_MANAGEMENT_KEY is not set. Skipping usage stats and version checks. Provide --key or set env var.',
+    })
+  }
+
+  for (const result of results) {
+    printCheckResult(result, ctx)
+    ctx.console.log('')
+  }
+
+  const errorCount = results.filter(result => result.level === 'error').length
+  const warningCount = results.filter(result => result.level === 'warning').length
+
+  ctx.console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
+
+  if (capturedUsageResult) {
+    const usageLine = formatUsageSummaryLine(capturedUsageResult)
+    if (usageLine) {
+      ctx.console.log(usageLine)
+    }
+  }
+
+  if (errorCount > 0) {
+    ctx.process.exit(1)
+  }
+}
+
 export function registerCliproxyStatus(cli: ReturnType<typeof goke>): void {
   cli
     .command('cliproxy status', 'Show operational health of CLIProxyAPI and its management endpoints.')
@@ -261,54 +322,5 @@ export function registerCliproxyStatus(cli: ReturnType<typeof goke>): void {
       z.string().describe('Management API key. Falls back to CLIPROXY_MANAGEMENT_KEY when omitted.'),
     )
     .option('--verbose', 'Enable verbose output for all commands')
-    .action(async options => {
-      const verbose = options.verbose === true
-      const baseUrl = stripTrailingSlash(options.url ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
-      const managementKey = options.key ?? process.env.CLIPROXY_MANAGEMENT_KEY
-
-      console.log('CLIProxyAPI status')
-      console.log('')
-
-      const results: CheckResult[] = [await checkHttpReachability(baseUrl, verbose)]
-
-      let capturedUsageResult: CheckResult | undefined
-
-      if (managementKey) {
-        const [usageResult, versionResult] = await Promise.all([
-          checkUsageStats(baseUrl, managementKey),
-          checkVersion(baseUrl, managementKey),
-        ])
-
-        capturedUsageResult = usageResult
-        results.push(usageResult, versionResult)
-      } else {
-        results.push({
-          title: 'Management checks',
-          level: 'warning',
-          summary:
-            'CLIPROXY_MANAGEMENT_KEY is not set. Skipping usage stats and version checks. Provide --key or set env var.',
-        })
-      }
-
-      for (const result of results) {
-        printCheckResult(result)
-        console.log('')
-      }
-
-      const errorCount = results.filter(result => result.level === 'error').length
-      const warningCount = results.filter(result => result.level === 'warning').length
-
-      console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
-
-      if (capturedUsageResult) {
-        const usageLine = formatUsageSummaryLine(capturedUsageResult)
-        if (usageLine) {
-          console.log(usageLine)
-        }
-      }
-
-      if (errorCount > 0) {
-        process.exitCode = 1
-      }
-    })
+    .action(cliproxyStatusAction)
 }

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -1,11 +1,11 @@
 import type {goke} from 'goke'
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 import type {StatusSummary} from '../status'
 
 import {z} from 'zod'
 
 /** Minimal ctx surface consumed by cliproxy status actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
-// ActionCtx imported from fixture — single source of truth for action ctx shape
+// ActionCtx imported from lib/action-ctx — single source of truth for action ctx shape
 
 declare const process: {
   env: Record<string, string | undefined>

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -258,49 +258,57 @@ export interface StatusOptions {
 }
 
 export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCtx): Promise<void> {
-  const verbose = options.verbose === true
-  const baseUrl = stripTrailingSlash(options.url ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
-  const managementKey = options.key ?? process.env.CLIPROXY_MANAGEMENT_KEY
+  let errorCount = 0
+  try {
+    const verbose = options.verbose === true
+    const baseUrl = stripTrailingSlash(options.url ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
+    const managementKey = options.key ?? process.env.CLIPROXY_MANAGEMENT_KEY
 
-  ctx.console.log('CLIProxyAPI status')
-  ctx.console.log('')
-
-  const results: CheckResult[] = [await checkHttpReachability(baseUrl, verbose)]
-
-  let capturedUsageResult: CheckResult | undefined
-
-  if (managementKey) {
-    const [usageResult, versionResult] = await Promise.all([
-      checkUsageStats(baseUrl, managementKey),
-      checkVersion(baseUrl, managementKey),
-    ])
-
-    capturedUsageResult = usageResult
-    results.push(usageResult, versionResult)
-  } else {
-    results.push({
-      title: 'Management checks',
-      level: 'warning',
-      summary:
-        'CLIPROXY_MANAGEMENT_KEY is not set. Skipping usage stats and version checks. Provide --key or set env var.',
-    })
-  }
-
-  for (const result of results) {
-    printCheckResult(result, ctx)
+    ctx.console.log('CLIProxyAPI status')
     ctx.console.log('')
-  }
 
-  const errorCount = results.filter(result => result.level === 'error').length
-  const warningCount = results.filter(result => result.level === 'warning').length
+    const results: CheckResult[] = [await checkHttpReachability(baseUrl, verbose)]
 
-  ctx.console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
+    let capturedUsageResult: CheckResult | undefined
 
-  if (capturedUsageResult) {
-    const usageLine = formatUsageSummaryLine(capturedUsageResult)
-    if (usageLine) {
-      ctx.console.log(usageLine)
+    if (managementKey) {
+      const [usageResult, versionResult] = await Promise.all([
+        checkUsageStats(baseUrl, managementKey),
+        checkVersion(baseUrl, managementKey),
+      ])
+
+      capturedUsageResult = usageResult
+      results.push(usageResult, versionResult)
+    } else {
+      results.push({
+        title: 'Management checks',
+        level: 'warning',
+        summary:
+          'CLIPROXY_MANAGEMENT_KEY is not set. Skipping usage stats and version checks. Provide --key or set env var.',
+      })
     }
+
+    for (const result of results) {
+      printCheckResult(result, ctx)
+      ctx.console.log('')
+    }
+
+    errorCount = results.filter(result => result.level === 'error').length
+    const warningCount = results.filter(result => result.level === 'warning').length
+
+    ctx.console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
+
+    if (capturedUsageResult) {
+      const usageLine = formatUsageSummaryLine(capturedUsageResult)
+      if (usageLine) {
+        ctx.console.log(usageLine)
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.console.error(message)
+    ctx.process.exit(1)
+    return
   }
 
   if (errorCount > 0) {

--- a/packages/cli/src/commands/gateway/backup.test.ts
+++ b/packages/cli/src/commands/gateway/backup.test.ts
@@ -2,7 +2,8 @@ import {statSync, writeFileSync} from 'node:fs'
 
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
-import {backupGatewayCa, type BackupSpawnFn} from './backup'
+import {createCapturedCtx, expectCapturedToInclude, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
+import {backupGatewayCa, gatewayBackupAction, type BackupSpawnFn} from './backup'
 
 // ─── SpawnFn helpers ──────────────────────────────────────────────────────────
 
@@ -284,5 +285,69 @@ describe('backupGatewayCa — SEC1: tmp file created with mode 0600 atomically',
     } finally {
       Bun.spawnSync(['rm', '-f', output])
     }
+  })
+})
+
+// ─── Tier-2: gatewayBackupAction ctx capture ─────────────────────────────────
+
+describe('gatewayBackupAction — ctx capture (Tier-2)', () => {
+  let originalEnv: Record<string, string | undefined>
+  let tmpOutput: string
+
+  beforeEach(() => {
+    originalEnv = {GATEWAY_HOST: process.env.GATEWAY_HOST}
+    process.env.GATEWAY_HOST = 'gateway.example.com'
+    tmpOutput = `/tmp/test-action-backup-${Date.now()}.tar`
+  })
+
+  afterEach(async () => {
+    if (originalEnv.GATEWAY_HOST === undefined) {
+      delete process.env.GATEWAY_HOST
+    } else {
+      process.env.GATEWAY_HOST = originalEnv.GATEWAY_HOST
+    }
+    try {
+      ;(await Bun.file(tmpOutput).exists()) && Bun.spawnSync(['rm', '-f', tmpOutput])
+    } catch {
+      // ignore
+    }
+  })
+
+  it('routes success message to ctx.console.log (stdout)', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await gatewayBackupAction({output: tmpOutput, includeCa: true}, ctx, makeSpawnOk(new Uint8Array([1, 2, 3])))
+
+    expect(expectCapturedToInclude(captured, 'CA backup written to')).toBe(true)
+  })
+
+  it('routes sensitive-content warning to ctx.process.stderr.write', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await gatewayBackupAction({output: tmpOutput, includeCa: true}, ctx, makeSpawnOk(new Uint8Array([1, 2, 3])))
+
+    const stderrText = captured.stderr.join('')
+    expect(stderrText.toLowerCase().includes('sensitive')).toBe(true)
+  })
+
+  it('routes error to ctx.console.error and calls ctx.process.exit(1) when GATEWAY_HOST is unset', async () => {
+    delete process.env.GATEWAY_HOST
+    const {ctx, captured} = createCapturedCtx()
+
+    await expect(gatewayBackupAction({output: tmpOutput, includeCa: true}, ctx)).rejects.toBeInstanceOf(MockProcessExit)
+
+    expect(captured.stderr.join('').includes('GATEWAY_HOST')).toBe(true)
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('routes backup failure to ctx.console.error and calls ctx.process.exit(1)', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await expect(
+      gatewayBackupAction({output: tmpOutput, includeCa: true}, ctx, makeSpawnError('Connection refused')),
+    ).rejects.toBeInstanceOf(MockProcessExit)
+
+    expect(captured.stderr.join('').toLowerCase().includes('backup failed')).toBe(true)
+    expect(captured.exit?.code).toBe(1)
   })
 })

--- a/packages/cli/src/commands/gateway/backup.ts
+++ b/packages/cli/src/commands/gateway/backup.ts
@@ -1,9 +1,10 @@
 import type {goke} from 'goke'
 
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+
 import {closeSync, constants as fsConstants, openSync, renameSync, unlinkSync, writeSync} from 'node:fs'
 
 import {z} from 'zod'
-
 import {validateGatewayHost} from './host'
 
 declare const process: {
@@ -11,6 +12,10 @@ declare const process: {
   exitCode?: number
   stderr: {write: (msg: string) => void}
 }
+
+// ─── Minimal ctx interface (subset of GokeExecutionContext used by this action) ─
+
+// ActionCtx imported from fixture — single source of truth for action ctx shape
 
 const MITMPROXY_CERTS_VOLUME = 'mitmproxy-certs'
 const CA_CERT_FILE = 'mitmproxy-ca-cert.pem'
@@ -134,6 +139,38 @@ export async function backupGatewayCa(
   return {ok: true, output: opts.output, bytesWritten: tarBytes.byteLength}
 }
 
+// ─── Action (exported for direct testing) ────────────────────────────────────
+
+export async function gatewayBackupAction(
+  options: {output?: string | undefined; includeCa?: boolean | undefined},
+  ctx: ActionCtx,
+  spawn?: BackupSpawnFn,
+): Promise<void> {
+  const hostEnvKey = 'GATEWAY_HOST'
+  const host = process.env[hostEnvKey]
+
+  if (!host) {
+    ctx.console.error(`Gateway host not set. Export ${hostEnvKey} before running backup.`)
+    ctx.process.exit(1)
+    return
+  }
+
+  const output = typeof options.output === 'string' ? options.output : DEFAULT_OUTPUT
+  const includeCa = options.includeCa !== false
+
+  const result = await backupGatewayCa({host, output, includeCa}, spawn, (msg: string) =>
+    ctx.process.stderr.write(`${msg}\n`),
+  )
+
+  if (!result.ok) {
+    ctx.console.error(`Backup failed: ${result.error}`)
+    ctx.process.exit(1)
+    return
+  }
+
+  ctx.console.log(`CA backup written to: ${output}`)
+}
+
 // ─── Command registration ─────────────────────────────────────────────────────
 
 export function registerGatewayBackup(cli: ReturnType<typeof goke>): void {
@@ -162,27 +199,5 @@ export function registerGatewayBackup(cli: ReturnType<typeof goke>): void {
     .example('infra gateway backup --include-ca')
     .example('# Back up the CA to a custom path')
     .example('infra gateway backup --output /secure/backup/mitmproxy-ca.tar')
-    .action(async options => {
-      const hostEnvKey = 'GATEWAY_HOST'
-      const host = process.env[hostEnvKey]
-
-      if (!host) {
-        console.error(`Gateway host not set. Export ${hostEnvKey} before running backup.`)
-        process.exitCode = 1
-        return
-      }
-
-      const output = typeof options.output === 'string' ? options.output : DEFAULT_OUTPUT
-      const includeCa = options.includeCa !== false
-
-      const result = await backupGatewayCa({host, output, includeCa})
-
-      if (!result.ok) {
-        console.error(`Backup failed: ${result.error}`)
-        process.exitCode = 1
-        return
-      }
-
-      console.log(`CA backup written to: ${output}`)
-    })
+    .action((options, ctx) => gatewayBackupAction(options, ctx))
 }

--- a/packages/cli/src/commands/gateway/backup.ts
+++ b/packages/cli/src/commands/gateway/backup.ts
@@ -1,6 +1,6 @@
 import type {goke} from 'goke'
 
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 
 import {closeSync, constants as fsConstants, openSync, renameSync, unlinkSync, writeSync} from 'node:fs'
 
@@ -15,7 +15,7 @@ declare const process: {
 
 // ─── Minimal ctx interface (subset of GokeExecutionContext used by this action) ─
 
-// ActionCtx imported from fixture — single source of truth for action ctx shape
+// ActionCtx imported from lib/action-ctx — single source of truth for action ctx shape
 
 const MITMPROXY_CERTS_VOLUME = 'mitmproxy-certs'
 const CA_CERT_FILE = 'mitmproxy-ca-cert.pem'
@@ -199,5 +199,5 @@ export function registerGatewayBackup(cli: ReturnType<typeof goke>): void {
     .example('infra gateway backup --include-ca')
     .example('# Back up the CA to a custom path')
     .example('infra gateway backup --output /secure/backup/mitmproxy-ca.tar')
-    .action((options, ctx) => gatewayBackupAction(options, ctx))
+    .action(gatewayBackupAction)
 }

--- a/packages/cli/src/commands/gateway/status.test.ts
+++ b/packages/cli/src/commands/gateway/status.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
-import {parseComposePs, parseComposePsOutput, type ComposePsEntry, type ServiceRow} from './status'
+import {createCapturedCtx, expectCapturedToInclude, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
+import {gatewayStatusAction, parseComposePs, parseComposePsOutput, type ComposePsEntry, type ServiceRow} from './status'
 
 // ─── parseComposePs ──────────────────────────────────────────────────────────
 
@@ -350,5 +351,133 @@ describe('getGatewayComposeStatus — NDJSON stdout', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error).toContain('Failed to parse docker compose ps output')
+  })
+})
+
+// ─── Tier-2: gatewayStatusAction ctx capture ─────────────────────────────────
+
+type StatusSpawnFn = (
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+) => {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+function makeStatusSpawnOk(jsonOutput: string): StatusSpawnFn {
+  return (_cmd, _opts) => {
+    const encoder = new TextEncoder()
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(jsonOutput))
+          controller.close()
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close()
+        },
+      }),
+      exited: Promise.resolve(0),
+    }
+  }
+}
+
+function makeStatusSpawnError(message: string): StatusSpawnFn {
+  return (_cmd, _opts) => {
+    const encoder = new TextEncoder()
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.close()
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(message))
+          controller.close()
+        },
+      }),
+      exited: Promise.resolve(1),
+    }
+  }
+}
+
+describe('gatewayStatusAction — ctx capture (Tier-2)', () => {
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalEnv = {GATEWAY_HOST: process.env.GATEWAY_HOST}
+    process.env.GATEWAY_HOST = 'gateway.example.com'
+  })
+
+  afterEach(() => {
+    if (originalEnv.GATEWAY_HOST === undefined) {
+      delete process.env.GATEWAY_HOST
+    } else {
+      process.env.GATEWAY_HOST = originalEnv.GATEWAY_HOST
+    }
+  })
+
+  it('routes "Status: OK" to ctx.console.log when all services are running', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    const psOutput = JSON.stringify([
+      {Name: 'gateway', State: 'running', Health: 'healthy'},
+      {Name: 'mitmproxy', State: 'running', Health: 'healthy'},
+    ])
+
+    await gatewayStatusAction({key: undefined}, ctx, makeStatusSpawnOk(psOutput))
+
+    expect(expectCapturedToInclude(captured, 'Status: OK')).toBe(true)
+  })
+
+  it('routes "Gateway status" header to ctx.console.log', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    const psOutput = JSON.stringify([{Name: 'gateway', State: 'running', Health: 'healthy'}])
+
+    await gatewayStatusAction({key: undefined}, ctx, makeStatusSpawnOk(psOutput))
+
+    expect(expectCapturedToInclude(captured, 'Gateway status')).toBe(true)
+  })
+
+  it('routes error to ctx.console.error and calls ctx.process.exit(1) when SSH fails', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await expect(
+      gatewayStatusAction({key: undefined}, ctx, makeStatusSpawnError('Connection refused')),
+    ).rejects.toBeInstanceOf(MockProcessExit)
+
+    expect(captured.stderr.join('').includes('Error')).toBe(true)
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('routes error to ctx.console.error and calls ctx.process.exit(1) when GATEWAY_HOST is unset', async () => {
+    delete process.env.GATEWAY_HOST
+    const {ctx, captured} = createCapturedCtx()
+
+    await expect(gatewayStatusAction({key: undefined}, ctx)).rejects.toBeInstanceOf(MockProcessExit)
+
+    expect(captured.stderr.join('').includes('GATEWAY_HOST')).toBe(true)
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('routes "Status: DEGRADED" to ctx.console.log and exits 1 when a service is not running', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    const psOutput = JSON.stringify([
+      {Name: 'gateway', State: 'exited', Health: ''},
+      {Name: 'mitmproxy', State: 'running', Health: 'healthy'},
+    ])
+
+    await expect(gatewayStatusAction({key: undefined}, ctx, makeStatusSpawnOk(psOutput))).rejects.toBeInstanceOf(
+      MockProcessExit,
+    )
+
+    expect(expectCapturedToInclude(captured, 'DEGRADED')).toBe(true)
+    expect(captured.exit?.code).toBe(1)
   })
 })

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -1,5 +1,5 @@
 import type {goke} from 'goke'
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 import type {StatusSummary} from '../status'
 
 import {z} from 'zod'

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -1,7 +1,10 @@
 import type {goke} from 'goke'
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
 import type {StatusSummary} from '../status'
 
 import {z} from 'zod'
+
+// ─── Minimal ctx interface (subset of GokeExecutionContext used by this action) ─
 
 import {validateGatewayHost} from './host'
 
@@ -175,6 +178,52 @@ export async function getGatewayStatusSummary(host: string): Promise<StatusSumma
   }
 }
 
+// ─── Action (exported for direct testing) ────────────────────────────────────
+
+export async function gatewayStatusAction(
+  options: {key?: string | undefined},
+  ctx: ActionCtx,
+  spawn?: SpawnFn,
+): Promise<void> {
+  const hostEnvKey = options.key ?? 'GATEWAY_HOST'
+  const host = process.env[hostEnvKey]
+
+  if (!host) {
+    ctx.console.error(`Gateway host not set. Export ${hostEnvKey} or pass --key <env-name> pointing to a set variable.`)
+    ctx.process.exit(1)
+    return
+  }
+
+  ctx.console.log('Gateway status')
+  ctx.console.log('')
+
+  const result = await getGatewayComposeStatus(host, spawn)
+
+  if (!result.ok && result.services.length === 0) {
+    ctx.console.error(`Error: ${result.error ?? 'Unknown error'}`)
+    ctx.process.exit(1)
+    return
+  }
+
+  ctx.console.log('Service          State      Health')
+  ctx.console.log('─────────────────────────────────────')
+
+  for (const row of result.services) {
+    const svc = row.service.padEnd(16)
+    const state = row.state.padEnd(10)
+    ctx.console.log(`${svc} ${state} ${row.health}`)
+  }
+
+  ctx.console.log('')
+
+  if (result.ok) {
+    ctx.console.log('Status: OK')
+  } else {
+    ctx.console.log('Status: DEGRADED (one or more services not running)')
+    ctx.process.exit(1)
+  }
+}
+
 // ─── Command registration ─────────────────────────────────────────────────────
 
 export function registerGatewayStatus(cli: ReturnType<typeof goke>): void {
@@ -184,43 +233,5 @@ export function registerGatewayStatus(cli: ReturnType<typeof goke>): void {
       '--key [key]',
       z.string().describe('Environment variable name holding the SSH host. Falls back to GATEWAY_HOST when omitted.'),
     )
-    .action(async options => {
-      const hostEnvKey = options.key ?? 'GATEWAY_HOST'
-      const host = process.env[hostEnvKey]
-
-      if (!host) {
-        console.error(`Gateway host not set. Export ${hostEnvKey} or pass --key <env-name> pointing to a set variable.`)
-        process.exitCode = 1
-        return
-      }
-
-      console.log('Gateway status')
-      console.log('')
-
-      const result = await getGatewayComposeStatus(host)
-
-      if (!result.ok && result.services.length === 0) {
-        console.error(`Error: ${result.error ?? 'Unknown error'}`)
-        process.exitCode = 1
-        return
-      }
-
-      console.log('Service          State      Health')
-      console.log('─────────────────────────────────────')
-
-      for (const row of result.services) {
-        const svc = row.service.padEnd(16)
-        const state = row.state.padEnd(10)
-        console.log(`${svc} ${state} ${row.health}`)
-      }
-
-      console.log('')
-
-      if (result.ok) {
-        console.log('Status: OK')
-      } else {
-        console.log('Status: DEGRADED (one or more services not running)')
-        process.exitCode = 1
-      }
-    })
+    .action((options, ctx) => gatewayStatusAction(options, ctx))
 }

--- a/packages/cli/src/commands/keeweb/status.test.ts
+++ b/packages/cli/src/commands/keeweb/status.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, mock, spyOn} from 'bun:test'
 
+import {createCapturedCtx, expectCapturedToInclude} from '../../__test__/mcp-ctx-fixture'
 import {
   checkContentHash,
   checkHttpReachability,
@@ -7,6 +8,7 @@ import {
   formatDate,
   formatDurationMs,
   hashSha256,
+  keewebStatusAction,
 } from './status'
 
 const originalFetch = globalThis.fetch
@@ -208,5 +210,149 @@ describe('keeweb status helpers', () => {
       expect(result.level).toBe('warning')
       expect(result.summary).toContain('not found')
     })
+  })
+})
+
+describe('keewebStatusAction (Tier-2 ctx capture)', () => {
+  let fetchMock: ReturnType<typeof mock<typeof fetch>>
+  let fileSpy: ReturnType<typeof spyOn<typeof Bun, 'file'>> | undefined
+  let spawnSpy: ReturnType<typeof spyOn<typeof Bun, 'spawn'>> | undefined
+
+  beforeEach(() => {
+    fetchMock = mock(
+      createFetchImplementation(async () => {
+        throw new Error('Unexpected fetch call')
+      }),
+    )
+    globalThis.fetch = Object.assign(fetchMock, {preconnect: originalFetch.preconnect})
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    fileSpy?.mockRestore()
+    fileSpy = undefined
+    spawnSpy?.mockRestore()
+    spawnSpy = undefined
+  })
+
+  it('writes "KeeWeb status" header to ctx.console.log (not global console)', async () => {
+    // Mock HTTP 200
+    fetchMock.mockImplementation(createFetchImplementation(async () => new Response('ok', {status: 200})))
+
+    // Mock gh CLI returning a successful run
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(() =>
+      mockSpawnResult(0, JSON.stringify([{createdAt: '2026-01-15T10:30:00Z', url: 'https://example.com'}])),
+    )
+
+    // Mock local dist file as missing (avoids filesystem dependency)
+    fileSpy = spyOn(Bun, 'file').mockImplementation(
+      () =>
+        ({
+          exists: async () => false,
+        }) as ReturnType<typeof Bun.file>,
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await keewebStatusAction({verbose: false}, ctx)
+
+    // 'KeeWeb status' is the header line in the formatted output — the contract
+    // marker confirming the action printed to ctx.console.log (captured) rather
+    // than the real global console (which would not appear in `captured`).
+    expect(expectCapturedToInclude(captured, 'KeeWeb status')).toBe(true)
+    // Summary footer is always emitted; pairing it with the header proves both
+    // ends of the formatted output flow through ctx capture.
+    expect(expectCapturedToInclude(captured, 'Summary:')).toBe(true)
+  })
+
+  it('writes HTTP check result to captured stdout', async () => {
+    fetchMock.mockImplementation(createFetchImplementation(async () => new Response('ok', {status: 200})))
+
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(() =>
+      mockSpawnResult(0, JSON.stringify([{createdAt: '2026-01-15T10:30:00Z', url: 'https://example.com'}])),
+    )
+
+    fileSpy = spyOn(Bun, 'file').mockImplementation(
+      () =>
+        ({
+          exists: async () => false,
+        }) as ReturnType<typeof Bun.file>,
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await keewebStatusAction({verbose: false}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'HTTP reachability')).toBe(true)
+    expect(expectCapturedToInclude(captured, '[OK]')).toBe(true)
+  })
+
+  it('writes summary line to captured stdout', async () => {
+    fetchMock.mockImplementation(createFetchImplementation(async () => new Response('ok', {status: 200})))
+
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(() =>
+      mockSpawnResult(0, JSON.stringify([{createdAt: '2026-01-15T10:30:00Z', url: 'https://example.com'}])),
+    )
+
+    fileSpy = spyOn(Bun, 'file').mockImplementation(
+      () =>
+        ({
+          exists: async () => false,
+        }) as ReturnType<typeof Bun.file>,
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await keewebStatusAction({verbose: false}, ctx)
+
+    expect(expectCapturedToInclude(captured, 'Summary:')).toBe(true)
+    expect(expectCapturedToInclude(captured, '3 checks')).toBe(true)
+  })
+
+  it('calls ctx.process.exit(1) when there are errors', async () => {
+    // HTTP 500 → error level
+    fetchMock.mockImplementation(createFetchImplementation(async () => new Response('error', {status: 500})))
+
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(() =>
+      mockSpawnResult(0, JSON.stringify([{createdAt: '2026-01-15T10:30:00Z', url: 'https://example.com'}])),
+    )
+
+    fileSpy = spyOn(Bun, 'file').mockImplementation(
+      () =>
+        ({
+          exists: async () => false,
+        }) as ReturnType<typeof Bun.file>,
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+
+    // ctx.process.exit throws MockProcessExit — catch it
+    await expect(keewebStatusAction({verbose: false}, ctx)).rejects.toMatchObject({
+      name: 'MockProcessExit',
+      code: 1,
+    })
+
+    expect(captured.exit).toEqual({code: 1})
+  })
+
+  it('does not call ctx.process.exit when all checks pass', async () => {
+    fetchMock.mockImplementation(createFetchImplementation(async () => new Response('ok', {status: 200})))
+
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(() =>
+      mockSpawnResult(0, JSON.stringify([{createdAt: '2026-01-15T10:30:00Z', url: 'https://example.com'}])),
+    )
+
+    fileSpy = spyOn(Bun, 'file').mockImplementation(
+      () =>
+        ({
+          exists: async () => false,
+        }) as ReturnType<typeof Bun.file>,
+    )
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await keewebStatusAction({verbose: false}, ctx)
+
+    expect(captured.exit).toBeNull()
   })
 })

--- a/packages/cli/src/commands/keeweb/status.ts
+++ b/packages/cli/src/commands/keeweb/status.ts
@@ -1,12 +1,10 @@
 import type {goke} from 'goke'
+
+import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
 import type {StatusSummary} from '../status'
 
 import path from 'node:path'
 import {z} from 'zod'
-
-declare const process: {
-  exitCode?: number
-}
 
 const SITE_URL = 'https://kw.igg.ms/'
 const GH_REPO = 'marcusrbrown/infra'
@@ -254,13 +252,13 @@ export async function checkContentHash(verbose: boolean): Promise<CheckResult> {
   }
 }
 
-function printCheckResult(result: CheckResult): void {
-  console.log(`[${levelLabel(result.level)}] ${result.title}`)
-  console.log(`  ${result.summary}`)
+function printCheckResult(result: CheckResult, ctx: ActionCtx): void {
+  ctx.console.log(`[${levelLabel(result.level)}] ${result.title}`)
+  ctx.console.log(`  ${result.summary}`)
 
   if (result.details && result.details.length > 0) {
     for (const detail of result.details) {
-      console.log(`  - ${detail}`)
+      ctx.console.log(`  - ${detail}`)
     }
   }
 }
@@ -286,34 +284,36 @@ export async function getKeewebStatusSummary(verbose: boolean): Promise<StatusSu
   }
 }
 
+export async function keewebStatusAction(options: {verbose?: boolean}, ctx: ActionCtx): Promise<void> {
+  const verbose = options.verbose === true
+
+  ctx.console.log('KeeWeb status')
+  ctx.console.log('')
+
+  const results = await Promise.all([
+    checkHttpReachability(verbose),
+    checkLastDeploy(verbose),
+    checkContentHash(verbose),
+  ])
+
+  for (const result of results) {
+    printCheckResult(result, ctx)
+    ctx.console.log('')
+  }
+
+  const errorCount = results.filter(result => result.level === 'error').length
+  const warningCount = results.filter(result => result.level === 'warning').length
+
+  ctx.console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
+
+  if (errorCount > 0) {
+    ctx.process.exit(1)
+  }
+}
+
 export function registerKeewebStatus(cli: ReturnType<typeof goke>): void {
   cli
     .command('keeweb status', 'Show operational health of the KeeWeb deployment')
     .option('--verbose', 'Enable verbose output for all commands')
-    .action(async options => {
-      const verbose = options.verbose === true
-
-      console.log('KeeWeb status')
-      console.log('')
-
-      const results = await Promise.all([
-        checkHttpReachability(verbose),
-        checkLastDeploy(verbose),
-        checkContentHash(verbose),
-      ])
-
-      for (const result of results) {
-        printCheckResult(result)
-        console.log('')
-      }
-
-      const errorCount = results.filter(result => result.level === 'error').length
-      const warningCount = results.filter(result => result.level === 'warning').length
-
-      console.log(`Summary: ${results.length} checks, ${errorCount} errors, ${warningCount} warnings`)
-
-      if (errorCount > 0) {
-        process.exitCode = 1
-      }
-    })
+    .action(keewebStatusAction)
 }

--- a/packages/cli/src/commands/keeweb/status.ts
+++ b/packages/cli/src/commands/keeweb/status.ts
@@ -1,6 +1,6 @@
 import type {goke} from 'goke'
 
-import type {ActionCtx} from '../../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../../lib/action-ctx'
 import type {StatusSummary} from '../status'
 
 import path from 'node:path'

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tier-1 in-process MCP integration test.
+ *
+ * Uses @modelcontextprotocol/sdk's InMemoryTransport to spin up the MCP server
+ * in-process (no subprocess) and assert the tool list + call contracts.
+ *
+ * // FALLBACK: If InMemoryTransport proves incompatible with @goke/mcp@0.0.10's
+ * // transport injection in a future SDK version, switch to subprocess mode:
+ * //
+ * //   const proc = Bun.spawn(['bun', 'run', 'packages/cli/src/cli.ts', 'mcp'], {
+ * //     stdin: 'pipe',
+ * //     stdout: 'pipe',
+ * //     stderr: 'pipe',
+ * //   })
+ * //   const transport = new StdioClientTransport({
+ * //     readable: proc.stdout,
+ * //     writable: proc.stdin,
+ * //   })
+ * //   const client = new Client({name: 'test-client', version: '1.0.0'}, {capabilities: {}})
+ * //   await client.connect(transport)
+ * //   // ... same assertions below ...
+ * //   await client.close()
+ * //   proc.kill()
+ */
+
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js'
+
+import {createMcpAction} from '@goke/mcp'
+import {Client} from '@modelcontextprotocol/sdk/client'
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js'
+import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js'
+import {afterAll, beforeAll, describe, expect, test} from 'bun:test'
+import {goke} from 'goke'
+
+import {registerCliproxyCommands} from './cliproxy'
+import {registerGatewayCommands} from './gateway'
+import {registerKeewebCommands} from './keeweb'
+import {registerMcp} from './mcp'
+import {registerStatus} from './status'
+
+// ─── Tool name constants (re-derived here, not imported from mcp.ts) ──────────
+
+/** The 10 commands exposed via MCP (MCP_ALLOWLIST), with spaces replaced by underscores. */
+const EXPECTED_TOOLS = [
+  'cliproxy_config_get',
+  'cliproxy_config_set',
+  'cliproxy_keys_add',
+  'cliproxy_keys_list',
+  'cliproxy_keys_remove',
+  'cliproxy_status',
+  'gateway_backup',
+  'gateway_status',
+  'keeweb_status',
+  'status',
+].sort()
+
+/** The 9 CLI-only commands that must NOT appear in the MCP tool list. */
+const CLI_ONLY_TOOLS = [
+  'cliproxy_deploy',
+  'cliproxy_login',
+  'cliproxy_open',
+  'cliproxy_setup',
+  'gateway_deploy',
+  'gateway_logs',
+  'gateway_restore',
+  'keeweb_deploy',
+  'keeweb_open',
+].sort()
+
+/** The MCP allowlist (mirrors mcp.ts — re-declared here to avoid coupling). */
+const MCP_ALLOWLIST = new Set<string>([
+  'gateway status',
+  'gateway backup',
+  'cliproxy status',
+  'cliproxy keys list',
+  'cliproxy keys add',
+  'cliproxy keys remove',
+  'cliproxy config get',
+  'cliproxy config set',
+  'keeweb status',
+  'status',
+])
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildTestCli(): ReturnType<typeof goke> {
+  const cli = goke('infra')
+  cli.option('--verbose', 'Enable verbose output for all commands')
+  registerKeewebCommands(cli)
+  registerCliproxyCommands(cli)
+  registerGatewayCommands(cli)
+  registerStatus(cli)
+  registerMcp(cli)
+  return cli
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('mcp integration (Tier-1, in-process)', () => {
+  let client: Client
+
+  beforeAll(async () => {
+    const cli = buildTestCli()
+
+    // Simulate goke having matched the 'mcp' command so createMcpAction
+    // auto-excludes it from the tool list (it reads cli.matchedCommandName).
+    cli.matchedCommandName = 'mcp'
+
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair()
+
+    // createMcpAction supports a custom createTransport factory (Option A).
+    // We inject the in-memory server transport so no stdio is involved.
+    const mcpAction = createMcpAction({
+      cli,
+      commandFilter: (name: string) => MCP_ALLOWLIST.has(name),
+      createTransport: () => serverTransport,
+    })
+
+    // Start the server (non-blocking — server.connect() resolves once the
+    // transport handshake completes, then the server listens for requests).
+    await mcpAction()
+
+    client = new Client({name: 'test-client', version: '1.0.0'}, {capabilities: {}})
+    await client.connect(clientTransport)
+  })
+
+  afterAll(async () => {
+    await client?.close()
+  })
+
+  // ── tools/list assertions ──────────────────────────────────────────────────
+
+  test('tools/list returns exactly the 10 allowlist tool names', async () => {
+    const result = await client.listTools()
+    const names = result.tools.map((t: {name: string}) => t.name).sort()
+    expect(names).toEqual(EXPECTED_TOOLS)
+  })
+
+  test('cli-only commands are absent from the tool list', async () => {
+    const result = await client.listTools()
+    const names = new Set(result.tools.map((t: {name: string}) => t.name))
+    for (const excluded of CLI_ONLY_TOOLS) {
+      expect(names.has(excluded)).toBe(false)
+    }
+  })
+
+  // ── Mode B contract: gateway_backup ───────────────────────────────────────
+  //
+  // gateway_backup tries to SSH to a real droplet, which is unreachable in CI.
+  // We assert the contract: the tool returns a non-empty CallToolResult.
+  // In CI the result will be an error CallToolResult (isError: true) because
+  // SSH fails — that's fine; the contract is that the MCP layer wraps the
+  // error and returns content rather than throwing.
+
+  test('gateway_backup returns a non-empty CallToolResult (Mode B contract)', async () => {
+    const rawResult = await client.callTool(
+      {
+        name: 'gateway_backup',
+        arguments: {},
+      },
+      CallToolResultSchema,
+    )
+    // Parse through the schema to get a properly typed result.
+    // The tool must return at least one content block (even on SSH failure).
+    const result: CallToolResult = CallToolResultSchema.parse(rawResult)
+    expect(result.content.length).toBeGreaterThan(0)
+  })
+
+  // ── Mode C contract: cliproxy_keys_list ───────────────────────────────────
+  //
+  // Mode C: when a command returns structured data AND prints to stdout,
+  // the CallToolResult must contain BOTH a stdout text block AND a
+  // stringified return-value text block.
+  //
+  // Re-enable after Unit 4 lands (cliproxy keys list refactor to return
+  // structured data alongside ctx-printed text).
+
+  // Re-enable after Unit 4 lands (cliproxy keys list refactor to return
+  // structured data alongside ctx-printed text).
+  test.skip('cliproxy_keys_list returns BOTH stdout block AND structured return block (Mode C contract)', async () => {
+    // TODO(Unit 4): assert result contains BOTH a stdout text block AND a
+    // stringified return-value text block once cliproxy keys list returns
+    // structured data alongside ctx-printed text.
+  })
+})

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -35,24 +35,13 @@ import {goke} from 'goke'
 import {registerCliproxyCommands} from './cliproxy'
 import {registerGatewayCommands} from './gateway'
 import {registerKeewebCommands} from './keeweb'
-import {registerMcp} from './mcp'
+import {MCP_ALLOWLIST, registerMcp} from './mcp'
 import {registerStatus} from './status'
 
-// ─── Tool name constants (re-derived here, not imported from mcp.ts) ──────────
+// ─── Tool name constants ──────────────────────────────────────────────────────
 
-/** The 10 commands exposed via MCP (MCP_ALLOWLIST), with spaces replaced by underscores. */
-const EXPECTED_TOOLS = [
-  'cliproxy_config_get',
-  'cliproxy_config_set',
-  'cliproxy_keys_add',
-  'cliproxy_keys_list',
-  'cliproxy_keys_remove',
-  'cliproxy_status',
-  'gateway_backup',
-  'gateway_status',
-  'keeweb_status',
-  'status',
-].sort()
+/** Derived from the production MCP_ALLOWLIST — spaces replaced by underscores. */
+const EXPECTED_TOOLS = [...MCP_ALLOWLIST].map(name => name.replaceAll(' ', '_')).sort()
 
 /** The 9 CLI-only commands that must NOT appear in the MCP tool list. */
 const CLI_ONLY_TOOLS = [
@@ -66,20 +55,6 @@ const CLI_ONLY_TOOLS = [
   'keeweb_deploy',
   'keeweb_open',
 ].sort()
-
-/** The MCP allowlist (mirrors mcp.ts — re-declared here to avoid coupling). */
-const MCP_ALLOWLIST = new Set<string>([
-  'gateway status',
-  'gateway backup',
-  'cliproxy status',
-  'cliproxy keys list',
-  'cliproxy keys add',
-  'cliproxy keys remove',
-  'cliproxy config get',
-  'cliproxy config set',
-  'keeweb status',
-  'status',
-])
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -177,9 +152,59 @@ describe('mcp integration (Tier-1, in-process)', () => {
 
   // Re-enable after Unit 4 lands (cliproxy keys list refactor to return
   // structured data alongside ctx-printed text).
-  test.skip('cliproxy_keys_list returns BOTH stdout block AND structured return block (Mode C contract)', async () => {
-    // TODO(Unit 4): assert result contains BOTH a stdout text block AND a
-    // stringified return-value text block once cliproxy keys list returns
-    // structured data alongside ctx-printed text.
+  test('cliproxy_keys_list returns BOTH stdout block AND structured return block (Mode C contract)', async () => {
+    const originalFetch = globalThis.fetch
+    const originalKey = process.env.CLIPROXY_MANAGEMENT_KEY
+
+    try {
+      process.env.CLIPROXY_MANAGEMENT_KEY = 'test-management-key'
+
+      globalThis.fetch = (async (_url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+        return new Response(JSON.stringify(['fro-bot-test1', 'fro-bot-test2']), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      }) as typeof fetch
+
+      const rawResult = await client.callTool(
+        {
+          name: 'cliproxy_keys_list',
+          arguments: {},
+        },
+        CallToolResultSchema,
+      )
+
+      const result: CallToolResult = CallToolResultSchema.parse(rawResult)
+
+      // Mode C contract: at least 2 content blocks (stdout text + structured return)
+      expect(result.content.length).toBeGreaterThanOrEqual(2)
+
+      const allText = result.content
+        .filter((block): block is {type: 'text'; text: string} => block.type === 'text')
+        .map(block => block.text)
+        .join('\n')
+
+      // One block must contain the formatted stdout (key names printed by the action)
+      expect(allText).toContain('fro-bot-test1')
+
+      // One block must contain the stringified return value (JSON array of key names)
+      const hasStructuredReturn = result.content.some(block => {
+        if (block.type !== 'text') return false
+        try {
+          const parsed = JSON.parse(block.text) as unknown
+          return Array.isArray(parsed) && parsed.includes('fro-bot-test1') && parsed.includes('fro-bot-test2')
+        } catch {
+          return false
+        }
+      })
+      expect(hasStructuredReturn).toBe(true)
+    } finally {
+      globalThis.fetch = originalFetch
+      if (originalKey === undefined) {
+        delete process.env.CLIPROXY_MANAGEMENT_KEY
+      } else {
+        process.env.CLIPROXY_MANAGEMENT_KEY = originalKey
+      }
+    }
   })
 })

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,8 +1,37 @@
 import type {goke} from 'goke'
 import {createMcpAction} from '@goke/mcp'
 
+/**
+ * Commands intentionally excluded from MCP exposure (not in MCP_ALLOWLIST):
+ *
+ * - `gateway deploy`   — subprocess streaming (Bun.spawn with stdout: 'inherit'), deferred to MCP v2 (#291)
+ * - `cliproxy deploy`  — subprocess streaming, deferred to MCP v2 (#291)
+ * - `keeweb deploy`    — subprocess streaming, deferred to MCP v2 (#291)
+ * - `gateway logs`     — subprocess streaming, deferred to MCP v2 (#291)
+ * - `cliproxy login`   — interactive (OAuth callback URL paste, requires TTY)
+ * - `cliproxy open`    — interactive (SSH TUI session, requires TTY)
+ * - `cliproxy setup`   — interactive (@clack/prompts wizard, requires TTY)
+ * - `gateway restore`  — destructive policy (replaces mitmproxy CA on live gateway, deferred to MCP v2 #292)
+ * - `keeweb open`      — host-machine side effect (spawns local browser, requires user intent)
+ */
+const MCP_ALLOWLIST = new Set<string>([
+  'gateway status',
+  'gateway backup',
+  'cliproxy status',
+  'cliproxy keys list',
+  'cliproxy keys add',
+  'cliproxy keys remove',
+  'cliproxy config get',
+  'cliproxy config set',
+  'keeweb status',
+  'status',
+])
+
 export function registerMcp(cli: ReturnType<typeof goke>): void {
-  cli
-    .command('mcp', 'Start a stdio MCP server exposing all CLI commands as tools for coding agents')
-    .action(createMcpAction({cli}))
+  cli.command('mcp', 'Start a stdio MCP server exposing all CLI commands as tools for coding agents').action(
+    createMcpAction({
+      cli,
+      commandFilter: name => MCP_ALLOWLIST.has(name),
+    }),
+  )
 }

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -14,7 +14,7 @@ import {createMcpAction} from '@goke/mcp'
  * - `gateway restore`  — destructive policy (replaces mitmproxy CA on live gateway, deferred to MCP v2 #292)
  * - `keeweb open`      — host-machine side effect (spawns local browser, requires user intent)
  */
-const MCP_ALLOWLIST = new Set<string>([
+export const MCP_ALLOWLIST: ReadonlySet<string> = new Set([
   'gateway status',
   'gateway backup',
   'cliproxy status',

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -74,6 +74,8 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
       ),
     ).toBe(true)
     expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
+    // Rejection reason must also appear in stderr so MCP consumers can see it
+    expect(captured.stderr.join('')).toContain('keeweb status check failed: Keeweb exploded')
   })
 
   it('prints valid json with all app keys when --json is passed', async () => {

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,139 +1,121 @@
-import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
+import type {StatusSummary} from './status'
+import {describe, expect, it} from 'bun:test'
 import {goke} from 'goke'
+import {createCapturedCtx, expectCapturedToInclude} from '../__test__/mcp-ctx-fixture'
+import {registerStatus, unifiedStatusAction} from './status'
 
-import {registerStatus} from './status'
-
-declare const process: {
-  exitCode?: number
+const healthyKeeweb: StatusSummary = {
+  app: 'keeweb',
+  http: 'OK',
+  lastDeploy: '2026-04-12 10:00',
+  version: '—',
+  contentHash: 'match',
+  usageStats: '—',
 }
 
-describe('top-level status command', () => {
-  let logSpy: {mockRestore: () => void; mock: {calls: unknown[][]}}
+const healthyCliproxy: StatusSummary = {
+  app: 'cliproxy',
+  http: 'OK',
+  lastDeploy: '—',
+  version: 'v1.2.3',
+  contentHash: '—',
+  usageStats: '12 req / 0 fail',
+}
 
-  beforeEach(() => {
-    logSpy = spyOn(console, 'log').mockImplementation(() => undefined)
-    process.exitCode = 0
-  })
+const healthyGateway: StatusSummary = {
+  app: 'gateway',
+  http: 'OK: gateway:running/healthy',
+  lastDeploy: '—',
+  version: '—',
+  contentHash: '—',
+  usageStats: '—',
+}
 
-  afterEach(() => {
-    logSpy.mockRestore()
-    process.exitCode = 0
-  })
-
-  async function runStatusCommand(
-    args: string[],
-    dependencies: Parameters<typeof registerStatus>[1],
-  ): Promise<string[]> {
-    const cli = goke('test')
-    registerStatus(cli, dependencies)
-    cli.parse(['bun', 'test', 'status', ...args], {run: false})
-    await cli.runMatchedCommand()
-
-    return logSpy.mock.calls.map((call: unknown[]) => call.map((value: unknown) => String(value)).join(' '))
+function makeDeps(overrides?: Partial<Parameters<typeof registerStatus>[1]>): Parameters<typeof registerStatus>[1] {
+  return {
+    getKeewebStatusSummary: async () => healthyKeeweb,
+    getCliproxyStatusSummary: async () => healthyCliproxy,
+    getGatewayStatusSummary: async () => healthyGateway,
+    ...overrides,
   }
+}
 
-  it('prints a unified table when both apps are healthy', async () => {
-    const lines = await runStatusCommand([], {
-      getKeewebStatusSummary: async () => ({
-        app: 'keeweb',
-        http: 'OK',
-        lastDeploy: '2026-04-12 10:00',
-        version: '—',
-        contentHash: 'match',
-        usageStats: '—',
-      }),
-      getCliproxyStatusSummary: async () => ({
-        app: 'cliproxy',
-        http: 'OK',
-        lastDeploy: '—',
-        version: 'v1.2.3',
-        contentHash: '—',
-        usageStats: '12 req / 0 fail',
-      }),
-      getGatewayStatusSummary: async () => ({
-        app: 'gateway',
-        http: 'OK: gateway:running/healthy',
-        lastDeploy: '—',
-        version: '—',
-        contentHash: '—',
-        usageStats: '—',
-      }),
-    })
+describe('top-level status command (Tier-2 ctx capture)', () => {
+  it('prints a unified table when all apps are healthy', async () => {
+    const {ctx, captured} = createCapturedCtx()
 
-    expect(lines).toContain('| App | HTTP | Last Deploy | Version | Content Hash | Usage Stats |')
-    expect(lines).toContain('| keeweb | OK | 2026-04-12 10:00 | — | match | — |')
-    expect(lines).toContain('| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')
-    expect(lines).toContain('| gateway | OK: gateway:running/healthy | — | — | — | — |')
+    await unifiedStatusAction({}, ctx, makeDeps())
+
+    expect(
+      expectCapturedToInclude(captured, '| App | HTTP | Last Deploy | Version | Content Hash | Usage Stats |'),
+    ).toBe(true)
+    expect(expectCapturedToInclude(captured, '| keeweb | OK | 2026-04-12 10:00 | — | match | — |')).toBe(true)
+    expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
+    expect(expectCapturedToInclude(captured, '| gateway | OK: gateway:running/healthy | — | — | — | — |')).toBe(true)
   })
 
-  it('shows an error row when one app fails and keeps the other result', async () => {
-    const lines = await runStatusCommand([], {
-      getKeewebStatusSummary: async () => {
-        throw new Error('Keeweb exploded')
-      },
-      getCliproxyStatusSummary: async () => ({
-        app: 'cliproxy',
-        http: 'OK',
-        lastDeploy: '—',
-        version: 'v1.2.3',
-        contentHash: '—',
-        usageStats: '12 req / 0 fail',
-      }),
-      getGatewayStatusSummary: async () => ({
-        app: 'gateway',
-        http: 'OK: gateway:running/healthy',
-        lastDeploy: '—',
-        version: '—',
-        contentHash: '—',
-        usageStats: '—',
-      }),
-    })
+  it('shows an error row when one app fails and keeps the other results', async () => {
+    const {ctx, captured} = createCapturedCtx()
 
-    expect(lines).toContain(
-      '| keeweb | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded |',
+    await unifiedStatusAction(
+      {},
+      ctx,
+      makeDeps({
+        getKeewebStatusSummary: async () => {
+          throw new Error('Keeweb exploded')
+        },
+      }),
     )
-    expect(lines).toContain('| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')
+
+    expect(
+      expectCapturedToInclude(
+        captured,
+        '| keeweb | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded |',
+      ),
+    ).toBe(true)
+    expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
   })
 
-  it('prints valid json with both app keys when --json is passed', async () => {
-    const lines = await runStatusCommand(['--json'], {
-      getKeewebStatusSummary: async () => ({
-        app: 'keeweb',
-        http: 'OK',
-        lastDeploy: '2026-04-12 10:00',
-        version: '—',
-        contentHash: 'match',
-        usageStats: '—',
-      }),
-      getCliproxyStatusSummary: async () => ({
-        app: 'cliproxy',
-        http: 'OK',
-        lastDeploy: '—',
-        version: 'v1.2.3',
-        contentHash: '—',
-        usageStats: '12 req / 0 fail',
-      }),
-      getGatewayStatusSummary: async () => ({
-        app: 'gateway',
-        http: 'OK: gateway:running/healthy',
-        lastDeploy: '—',
-        version: '—',
-        contentHash: '—',
-        usageStats: '—',
-      }),
-    })
+  it('prints valid json with all app keys when --json is passed', async () => {
+    const {ctx, captured} = createCapturedCtx()
 
-    expect(lines).toHaveLength(1)
+    await unifiedStatusAction({json: true}, ctx, makeDeps())
 
-    const [jsonOutput] = lines
+    expect(captured.stdout).toHaveLength(1)
+
+    const [jsonOutput] = captured.stdout
     expect(jsonOutput).toBeDefined()
 
     const parsed = JSON.parse(jsonOutput ?? '{}') as {
       keeweb: {http: string}
       cliproxy: {version: string}
+      gateway: {http: string}
     }
 
     expect(parsed.keeweb.http).toBe('OK')
     expect(parsed.cliproxy.version).toBe('v1.2.3')
+    expect(parsed.gateway.http).toBe('OK: gateway:running/healthy')
+  })
+
+  it('does not write to global console (output is captured via ctx)', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await unifiedStatusAction({}, ctx, makeDeps())
+
+    // Verify output went to ctx capture, not global console
+    expect(captured.stdout.length).toBeGreaterThan(0)
+    expect(expectCapturedToInclude(captured, '| App |')).toBe(true)
+  })
+})
+
+describe('top-level status command (registerStatus wiring)', () => {
+  it('wires through goke without throwing', async () => {
+    const cli = goke('test')
+
+    registerStatus(cli, makeDeps())
+    cli.parse(['bun', 'test', 'status'], {run: false})
+
+    // Verify the command runs without throwing (goke uses its own ctx for output)
+    await expect(cli.runMatchedCommand()).resolves.toBeUndefined()
   })
 })

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,6 +1,6 @@
 import type {goke} from 'goke'
 
-import type {ActionCtx} from '../__test__/mcp-ctx-fixture'
+import type {ActionCtx} from '../lib/action-ctx'
 
 import {z} from 'zod'
 
@@ -94,7 +94,13 @@ export async function unifiedStatusAction(
   const appNames: AppName[] = ['keeweb', 'cliproxy', 'gateway']
   const rows: StatusSummary[] = results.map((result, index) => {
     const app = appNames[index] ?? 'keeweb'
-    return result.status === 'fulfilled' ? result.value : errorSummary(app, result.reason)
+    if (result.status === 'fulfilled') {
+      return result.value
+    }
+    const reason = result.reason
+    const message = reason instanceof Error ? reason.message : String(reason)
+    ctx.console.error(`${app} status check failed: ${message}`)
+    return errorSummary(app, reason)
   })
 
   if (options.json === true) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,5 +1,7 @@
 import type {goke} from 'goke'
 
+import type {ActionCtx} from '../__test__/mcp-ctx-fixture'
+
 import {z} from 'zod'
 
 import {getCliproxyStatusSummary} from './cliproxy/status'
@@ -69,6 +71,43 @@ function formatRow(row: StatusSummary): string {
   return `| ${values.join(' | ')} |`
 }
 
+export async function unifiedStatusAction(
+  options: {json?: boolean; verbose?: boolean},
+  ctx: ActionCtx,
+  dependencies: StatusDependencies = {
+    getKeewebStatusSummary,
+    getCliproxyStatusSummary,
+    getGatewayStatusSummary,
+  },
+): Promise<void> {
+  const verbose = options.verbose === true
+  const cliproxyBaseUrl = stripTrailingSlash(process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
+  const cliproxyKey = process.env.CLIPROXY_MANAGEMENT_KEY ?? ''
+  const gatewayHost = process.env.GATEWAY_HOST ?? ''
+
+  const results = await Promise.allSettled([
+    dependencies.getKeewebStatusSummary(verbose),
+    dependencies.getCliproxyStatusSummary(cliproxyBaseUrl, cliproxyKey, verbose),
+    dependencies.getGatewayStatusSummary(gatewayHost),
+  ])
+
+  const appNames: AppName[] = ['keeweb', 'cliproxy', 'gateway']
+  const rows: StatusSummary[] = results.map((result, index) => {
+    const app = appNames[index] ?? 'keeweb'
+    return result.status === 'fulfilled' ? result.value : errorSummary(app, result.reason)
+  })
+
+  if (options.json === true) {
+    ctx.console.log(JSON.stringify(toJsonPayload(rows)))
+    return
+  }
+
+  ctx.console.log('| App | HTTP | Last Deploy | Version | Content Hash | Usage Stats |')
+  for (const row of rows) {
+    ctx.console.log(formatRow(row))
+  }
+}
+
 export function registerStatus(
   cli: ReturnType<typeof goke>,
   dependencies: StatusDependencies = {
@@ -87,32 +126,5 @@ export function registerStatus(
       '--verbose',
       z.boolean().describe('Include verbose per-app health check details when building the summary rows.'),
     )
-    .action(async options => {
-      const verbose = options.verbose === true
-      const cliproxyBaseUrl = stripTrailingSlash(process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
-      const cliproxyKey = process.env.CLIPROXY_MANAGEMENT_KEY ?? ''
-      const gatewayHost = process.env.GATEWAY_HOST ?? ''
-
-      const results = await Promise.allSettled([
-        dependencies.getKeewebStatusSummary(verbose),
-        dependencies.getCliproxyStatusSummary(cliproxyBaseUrl, cliproxyKey, verbose),
-        dependencies.getGatewayStatusSummary(gatewayHost),
-      ])
-
-      const appNames: AppName[] = ['keeweb', 'cliproxy', 'gateway']
-      const rows: StatusSummary[] = results.map((result, index) => {
-        const app = appNames[index] ?? 'keeweb'
-        return result.status === 'fulfilled' ? result.value : errorSummary(app, result.reason)
-      })
-
-      if (options.json === true) {
-        console.log(JSON.stringify(toJsonPayload(rows)))
-        return
-      }
-
-      console.log('| App | HTTP | Last Deploy | Version | Content Hash | Usage Stats |')
-      for (const row of rows) {
-        console.log(formatRow(row))
-      }
-    })
+    .action((options, ctx) => unifiedStatusAction(options, ctx, dependencies))
 }

--- a/packages/cli/src/lib/action-ctx.ts
+++ b/packages/cli/src/lib/action-ctx.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal `ctx` interface every MCP-capturable action accepts.
+ *
+ * Structural subtype of goke's real `GokeExecutionContext` — actions
+ * consume only `console.{log,error}`, `process.{stdout,stderr}.write`,
+ * and `process.exit`, never the `fs` surface. Source files import this
+ * shape from this module so the action contract is defined in one place.
+ *
+ * The `write` parameter is `string` (narrower than goke's real
+ * `string | Uint8Array`) because every action passes string values;
+ * `CapturedCtx.write(string | Uint8Array)` is still assignable to
+ * `ActionCtx.write(string)` via contravariance, so tests using
+ * `CapturedCtx` satisfy this interface.
+ */
+export interface ActionCtx {
+  console: {
+    log: (...args: unknown[]) => void
+    error: (...args: unknown[]) => void
+  }
+  process: {
+    stdout: {write: (chunk: string) => void}
+    stderr: {write: (chunk: string) => void}
+    exit: (code: number) => never | void
+  }
+}


### PR DESCRIPTION
Calling `bunx @marcusrbrown/infra mcp` and then invoking any tool used to return empty content — humans saw rich formatted output at the terminal, agents saw nothing. This PR makes both consumers see the same content.

## What changed

The 10 read-style commands in the MCP allowlist now thread goke's per-action execution context (`ctx`) through their action bodies and route all output through `ctx.console.log` / `ctx.process.exit` instead of global `console` / `process.exit`. `@goke/mcp` captures the ctx-routed bytes into the `CallToolResult`, so MCP returns the same formatted output operators see at the terminal.

Two commands extend further — they return parseable structured data alongside the formatted text:

- `cliproxy keys list` returns `Promise<string[]>` (the parsed API-key array)
- `cliproxy config get` returns `Promise<unknown>` (the parsed config object — kept loose to match the management API's runtime shape)

`@goke/mcp` packages both the captured stdout AND the stringified return value into the `CallToolResult`, so agents calling these tools can act on the data without re-parsing the formatted output.

The 9 CLI-only commands stay out of MCP via an explicit `commandFilter` allowlist in `packages/cli/src/commands/mcp.ts`:

| Excluded | Reason |
|---|---|
| `gateway deploy`, `cliproxy deploy`, `keeweb deploy`, `gateway logs` | Subprocess streaming — deferred to MCP v2 (#291) |
| `cliproxy login`, `cliproxy open`, `cliproxy setup` | Interactive TTY (OAuth callback paste, SSH TUI, @clack/prompts wizard) |
| `gateway restore` | Destructive policy — replaces mitmproxy CA on live gateway (#292) |
| `keeweb open` | Host-machine side effect (spawns local browser) |

Each exclusion has a one-line reason in the source JSDoc, so adding a new command surfaces an explicit decision rather than an accidental default.

## Test coverage

- **Tier-1 in-process integration test** at `packages/cli/src/commands/mcp.test.ts`: spins up `@goke/mcp`'s real server via `@modelcontextprotocol/sdk`'s `InMemoryTransport` (no subprocess overhead). Asserts the tool list matches the allowlist exactly, the 9 CLI-only commands are absent, the gateway_backup Mode B contract holds (CallToolResult populated even when SSH fails), and the cliproxy_keys_list Mode C contract holds (both formatted-text and structured-data blocks present in the result).
- **Tier-2 ctx-capture unit tests** for every ctx-threaded action, using a shared `createCapturedCtx()` fixture at `packages/cli/src/__test__/mcp-ctx-fixture.ts`. Tests invoke action functions directly and assert on captured stdout/stderr/exit. Each command has a contract-bearing marker assertion (header line, summary footer) so a refactor that drops the captured output flow surfaces as a test failure.
- **504 tests pass, 0 fail**, up from 451 on main.

## Contract documented in source

`packages/cli/AGENTS.md` gets a new MCP FIDELITY section codifying the rules:

- **Allowlist authority** — `MCP_ALLOWLIST` in `mcp.ts` is the single source of truth; tests import it so drift surfaces as test failure
- **Ctx threading** — explicit mapping table for `console`/`process` → `ctx.*` calls
- **Mode C eligibility** — data-shape based, not transport-source based: bounded structured data the agent will parse qualifies regardless of whether it comes from a management API, SSH, file read, or docker query
- **Failure-path parity** — every allowlisted action must catch operational failures and route through `ctx.console.error` before `ctx.process.exit(1)` (doc rule; cliproxy still has some work to do here, tracked in #293)
- **Mutating-tool semantics** — mutating tools must verify the mutation succeeded before reporting success
- **Test bar** — Tier-1 integration via `InMemoryTransport` + Tier-2 ctx capture per command
- **@goke/mcp upgrade discipline** — pre-1.0 means manual review, never automerge

## Type contract

A shared `ActionCtx` interface lives at `packages/cli/src/lib/action-ctx.ts` — a structural subtype of goke's real `GokeExecutionContext` capturing exactly what actions need (`console.{log,error}`, `process.{stdout,stderr}.write`, `process.exit`). Production code imports `ActionCtx` from `lib/`; tests import the full `CapturedCtx` from the fixture.

`@modelcontextprotocol/sdk` was added as a direct devDep on `@marcusrbrown/infra` (it's a transitive dep via `@goke/mcp`, but Bun's `.bun/` symlink layout doesn't expose transitive deps to test imports).

## Follow-up issues filed

Three issues from the ce:review run (`.context/systematic/ce-review/20260523-153515-d58e6ffa/`):

- **#293** — cliproxy MCP error-path parity: wrap cliproxy action bodies in try/catch routing through ctx, add `keys remove` mutation-verification (P1)
- **#294** — Tier-1 MCP test discriminator + positional coverage: gateway_backup assertion is non-discriminating, no Tier-1 coverage for positional commands (P2)
- **#295** — Mode C extension for `gateway_status`: design call — extend to return structured `GatewayStatusResult` per the data-shape criterion, or update the criterion to be more restrictive (P2)

Two prior issues from the design phase remain open for MCP v2:

- **#291** — subprocess streaming for deploys and logs
- **#292** — authentication and approval gating for mutating tools

## Post-Deploy Monitoring & Validation

No production runtime impact — this is a pure CLI refactor. The deployed services (`box.heatvision.co`, `cliproxy.fro.bot`, `gateway.fro.bot`) are unaffected; only the `bunx @marcusrbrown/infra` package behavior changes.

The MCP server contract DOES change observably for MCP consumers (the Fro Bot agent + any future MCP-aware tooling): tools that previously returned empty content now return rich output, and the 9 CLI-only commands are no longer in the `tools/list` response.

Validation:

- After release: trigger a Fro Bot autohealing run and verify the `gateway_status` / `cliproxy_status` / `keeweb_status` calls in the daily report contain real captured output rather than empty placeholders.
- After release: confirm `tools/list` from a fresh `bunx @marcusrbrown/infra@<new> mcp` returns exactly 10 tool names (the allowlist).
- Rollback signal: if Fro Bot autohealing reports return empty content for status checks, the ctx threading regressed somewhere — `git revert` this PR and re-publish the prior version.

## Plan

[docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md](docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md) — 8 implementation units, all R1-R8 requirements met. Plan + brainstorm landed as the first commit on this branch.
