### PR TITLE
fix(cliproxy): harden setup gates with post-write readback + concurrency caveat

### DIFF
--- a/.changeset/cliproxy-setup-gate-reliability.md
+++ b/.changeset/cliproxy-setup-gate-reliability.md
@@ -1,5 +1,5 @@
 ---
-'@marcusrbrown/infra': minor
+'@marcusrbrown/infra': patch
 ---
 
 `cliproxy setup` verifies its GitHub writes landed and warns about concurrent runs.

--- a/.changeset/cliproxy-setup-gate-reliability.md
+++ b/.changeset/cliproxy-setup-gate-reliability.md
@@ -1,0 +1,9 @@
+---
+'@marcusrbrown/infra': minor
+---
+
+`cliproxy setup` now verifies its GitHub writes landed and warns about concurrent runs.
+
+After writing secrets and variables, setup re-lists the repo's secret and variable names and warns if a just-written name is not visible. An empty secret list from a successful `gh` call — a scope-limited token or replication lag — otherwise looks identical to a fresh repo and silently disables the ack-key-reuse and collision gates. The readback distinguishes a verified mismatch (the name is provably absent, so the token's list view is unreliable and the gates may have been bypassed) from a cannot-verify case (the readback call itself failed). It never throws and never rolls back a successfully created key.
+
+The non-interactive `--force` overwrite warning now states that concurrent setup runs against the same repo resolve last-write-wins. `packages/cli/AGENTS.md` gains an Operational Limitations section covering the concurrency boundary and the transient-empty gate bypass.

--- a/.changeset/cliproxy-setup-gate-reliability.md
+++ b/.changeset/cliproxy-setup-gate-reliability.md
@@ -2,8 +2,8 @@
 '@marcusrbrown/infra': minor
 ---
 
-`cliproxy setup` now verifies its GitHub writes landed and warns about concurrent runs.
+`cliproxy setup` verifies its GitHub writes landed and warns about concurrent runs.
 
 After writing secrets and variables, setup re-lists the repo's secret and variable names and warns if a just-written name is not visible. An empty secret list from a successful `gh` call — a scope-limited token or replication lag — otherwise looks identical to a fresh repo and silently disables the ack-key-reuse and collision gates. The readback distinguishes a verified mismatch (the name is provably absent, so the token's list view is unreliable and the gates may have been bypassed) from a cannot-verify case (the readback call itself failed). It never throws and never rolls back a successfully created key.
 
-The non-interactive `--force` overwrite warning now states that concurrent setup runs against the same repo resolve last-write-wins. `packages/cli/AGENTS.md` gains an Operational Limitations section covering the concurrency boundary and the transient-empty gate bypass.
+The non-interactive `--force` overwrite warning states that concurrent setup runs against the same repo resolve last-write-wins. `packages/cli/AGENTS.md` gains an Operational Limitations section covering the concurrency boundary and the transient-empty gate bypass.

--- a/docs/plans/2026-05-27-001-fix-cliproxy-setup-gate-reliability-plan.md
+++ b/docs/plans/2026-05-27-001-fix-cliproxy-setup-gate-reliability-plan.md
@@ -1,0 +1,376 @@
+---
+title: 'fix: cliproxy setup gate reliability (F3 concurrency, F4 transient-empty)'
+type: fix
+status: completed
+date: 2026-05-27
+origin: 'GitHub issue #311 (ce:review run 20260527-094713-8fe918ca)'
+---
+
+# fix: cliproxy setup gate reliability (F3 concurrency, F4 transient-empty)
+
+## Overview
+
+The `cliproxy setup` command reads a repo's existing GitHub secret/variable names
+(`listExistingGhNames`) and uses that list to drive two safety gates before writing:
+
+1. The **ack-key-reuse gate** — fires when `existingSecrets.includes('OPENCODE_AUTH_JSON')`.
+2. The **collision gate** — `collectCollisions` blocks (non-interactive) or prompts
+   (interactive) when a write would overwrite an existing name.
+
+Both gates trust the pre-write list. The ce:review of PR #312 surfaced two reliability
+findings against that trust:
+
+- **F4** — When `gh secret list` returns an empty list on a *successful* (zero-exit)
+  invocation that is nonetheless unreliable — token scope blindness, eventual-consistency
+  lag — both gates silently disable themselves and the destructive write proceeds with no
+  acknowledgment. (The hard-failure path is already safe: `listExistingGhNames` throws on
+  non-zero `gh` exit, so a network error or auth failure fails closed today.)
+- **F3** — Two operators running `setup` against the same repo concurrently both read a
+  stale/empty list, both pass the gates, both write `OPENCODE_AUTH_JSON`, last-write-wins.
+  GitHub's secrets API is write-only and offers no lock or compare-and-swap, so there is no
+  primitive to make this safe.
+
+This plan closes the practical F4 window with a post-write readback verification and
+treats F3 as an accepted, documented limitation with a targeted warning where a destructive
+overwrite is already being flagged.
+
+## Problem Frame
+
+Origin: issue #311, the consolidated ce:review follow-up hub for the cliproxy setup
+refactor. F3 and F4 are the two P1 reliability items the issue flags for individual
+treatment. Research (repo-research-analyst + learnings-researcher, 2026-05-27) narrowed both:
+
+- **F4's catastrophic path already fails closed.** `listExistingGhNames`
+  (`packages/cli/src/commands/cliproxy/setup/gh.ts`) runs `gh <kind> list --repo <repo>
+  --json name`; on non-zero exit it throws `Unable to list existing GitHub ${kind}s`. The
+  residual risk is exclusively the **zero-exit-empty** case: `gh` succeeds but the returned
+  list does not reflect reality (scope-limited token, replication lag).
+- **F4's readback can catch the token-scope-blindness sub-case but not the
+  pre-existing-clobber sub-case.** After we write `OPENCODE_AUTH_JSON`, re-listing and not
+  seeing it proves the token's list view is unreliable (it cannot see a secret we just
+  wrote) — so the pre-write empty that disabled the gates was untrustworthy. It cannot prove
+  whether a *different* value existed before our write (the name is present on readback
+  either way). The readback materially shrinks the window without claiming to close it.
+- **F3 has no clean primitive.** Write-only secrets, no lock/CAS. Post-write readback cannot
+  detect a concurrent clobber because after our write the value is ours and values are not
+  readable. Last-write-wins is inherent. Learnings search found zero prior art on optimistic
+  concurrency for GitHub secrets.
+
+The strongest local precedent is the F1 fix already shipped in PR #312:
+`parseManagementKeyList` in `packages/cli/src/commands/cliproxy/shared.ts` — "never returns
+`[]` on malformed input; mutating callers must fail loud." F4 applies the same philosophy at
+the GitHub-list boundary: an empty list that drives a destructive decision must be
+corroborated, not blindly trusted.
+
+## Requirements Trace
+
+- R1. (F4) After a successful write, verify the written names are visible on a fresh
+  `listExistingGhNames` readback — for BOTH secrets (`plan.template.secrets`) and variables
+  (`plan.template.variables`), since both gates rely on the same list view. When one or more
+  written names are absent on a *successful* readback (verified mismatch), emit a loud,
+  actionable warning that the token's list view is unreliable and the pre-write safety gates
+  may have been bypassed — directing the operator to verify manually. Distinguish this from
+  the *cannot-verify* case (the readback `gh` call itself failed), which emits a softer
+  "could not verify written values are visible" warning — a weaker signal than a confirmed
+  mismatch.
+- R2. (F4) The entire post-write verification block — readback calls, set-difference
+  computation, AND warning emission — must not throw and must not trigger the key-creation
+  rollback path. The writes already succeeded; any failure inside verification is a warning,
+  never a destructive unwind. Guarding only the `gh` call is insufficient: a throw during
+  diff computation or log formatting would still reach the `mutationError` rollback.
+- R3. (F4) The happy path (readback confirms all written names present) emits no new output
+  and does not alter existing success messaging.
+- R4. (F3) The non-interactive `--force` overwrite warning states that concurrent `setup`
+  runs against the same repo are not coordinated and resolve last-write-wins.
+- R5. (F3) `packages/cli/AGENTS.md` documents the concurrency boundary AND is explicit that
+  the overwrite-site warning only covers the *detected-collision* path — the fresh-run race
+  (two concurrent runs both seeing an empty list, neither detecting a collision) produces NO
+  runtime signal and is mitigated solely by operator coordination. The docs must not imply
+  the warning protects fresh concurrent runs. The transient-empty caveat is documented as a
+  known limitation that Unit 1's post-write readback surfaces as a warning.
+
+## Scope Boundaries
+
+- No locking, mutex, or compare-and-swap for GitHub secret writes — the API offers none.
+- No pre-write token-scope probe (the post-write readback covers the same blindness more
+  cheaply and after the fact, which is sufficient for a warning).
+- No change to the hard-error path of `listExistingGhNames` — it already throws and
+  fails closed.
+- No change to the ack-key-reuse gate or collision gate decision logic themselves — F4 adds
+  a *post-write corroboration*, it does not move the gates.
+- No new CLI flags. (The `--fresh-repo` acknowledgment flag considered during planning was
+  rejected: it burdens every genuine fresh-repo `--key` setup to cover a rare window the
+  readback already surfaces.)
+
+### Deferred to Separate Tasks
+
+- F11/F15/F16 (type-safety + DI hardening): separate `ce:work` bundle, tracked in #311.
+- F17/F24 (advisory docs): separate small docs PR, tracked in #311.
+- F13/F23 (smoke-test misattribution, rollback orphan-key hint): comments-only per #311;
+  not in this plan.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/cli/src/commands/cliproxy/setup.ts` — `runSetupCommand`. The pre-write list read
+  is `gh.withGhRetry('Checking existing GitHub secrets and variables', () =>
+  Promise.all([listExistingGhNames(repo,'secret'), listExistingGhNames(repo,'variable')]))`.
+  The write loop is `gh.withGhRetry('Writing GitHub secrets and variables', ...)` iterating
+  `plan.template.secrets` / `plan.template.variables` through `applyGhValue`. The
+  non-interactive `--force` overwrite warning is `log.warn('Overwriting existing GitHub
+  values: ...')`.
+- `packages/cli/src/commands/cliproxy/setup/gh.ts` — `listExistingGhNames(repo, kind)` throws
+  on non-zero exit (`gh.ts:173-176`); `withGhRetry` retries only rate-limit errors
+  (`gh.ts:97-114`). `applyGhValue` pipes secret bytes via stdin.
+- `packages/cli/src/commands/cliproxy/shared.ts` — `parseManagementKeyList` (the F1
+  fail-closed precedent): strict parse, never coerces unknown shapes to `[]`.
+- `packages/cli/src/commands/cliproxy/setup.test.ts` — `runSetupCommand` action-handler tests
+  with the DI surface (`gh`, `prompts`, `smoke`, `validation`, `ctx`). `makeCtx()` returns
+  `{ctx, logs, errors}`. `makeSpinner()` and `autoPromptValue` helpers exist.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md` — for
+  `gh secret set`, verify the stored value structurally rather than trusting a success
+  signal; don't "just retry" when the real problem is data the command can't see. Directly
+  endorses the F4 write→readback approach.
+- `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md` — guards must
+  not silently pass on bad data; missing/unreliable inputs should fail loudly rather than
+  degrade into a misleading "nothing to do" state.
+
+### External References
+
+- None. Internal gate control flow over the `gh` CLI and our own helpers; strong local
+  pattern (`parseManagementKeyList`). External research skipped per Phase 1.2.
+
+## Key Technical Decisions
+
+- **Post-write readback over pre-write probe (F4):** Re-list secret and variable names after
+  the write and confirm every written name is present. Cheaper than a pre-write token-scope
+  probe and catches the same token-blindness failure mode, after the write, as a warning.
+  Rationale: the write is idempotent and presumed correct; the only thing in doubt is our
+  *visibility*, which a readback measures directly.
+- **Warning, not throw; no rollback (F4):** The readback runs after secrets are written. A
+  visibility failure must not throw (which would trigger the `keyCreatedByThisRun` rollback
+  and delete a key whose secrets are correctly written). Wrap the readback so its own
+  `gh`-failure also degrades to the same warning.
+- **Verify all written names, secrets AND variables, not just `OPENCODE_AUTH_JSON` (F4):** A
+  missing-any signal is strictly stronger and costs nothing extra — we already hold
+  `plan.template.secrets` and `plan.template.variables`. The collision gate uses both lists,
+  so corroborating only secrets would leave the variable side of the gate uncorroborated.
+- **Distinguish "verified mismatch" from "cannot verify" (F4):** A successful readback that
+  omits a written name is a strong signal (the token's list view is provably unreliable). A
+  readback whose `gh` call fails is a weaker "could not verify" signal. Both warn and neither
+  throws, but the wording differs so the operator can gauge severity.
+- **F3 warning does NOT cover the fresh-run race (F3):** Attaching the concurrency note to the
+  overwrite-warning site only surfaces it when a collision is already detected. The actual
+  race — two fresh runs both seeing an empty list, neither detecting a collision — fires no
+  overwrite warning and therefore no runtime signal. This is an accepted limitation, not a
+  mitigation; the plan documents it honestly rather than implying the warning guards fresh
+  concurrent runs. A per-run advisory was rejected as noise on every clean run; the residual
+  fresh-run race is mitigated solely by operator coordination (documented in AGENTS.md).
+- **F3 is accept + document, with the warning placed where overwrite is already flagged:**
+  Rather than a per-run advisory (noise on every clean run), extend the existing
+  non-interactive `--force` overwrite `log.warn` to name the concurrency hazard, and document
+  the full boundary in AGENTS.md. A destructive overwrite is the exact moment the operator
+  should hear "this is last-write-wins; don't run two at once."
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should F4 add a `--fresh-repo` acknowledgment flag? No — rejected as over-burdensome for a
+  rare window the post-write readback already surfaces. (See Scope Boundaries.)
+- Should F3 get post-write reconciliation / concurrent-writer detection? No — readback cannot
+  detect a concurrent clobber on write-only secrets; detection would be heuristic and weak.
+  Accept + document.
+- Where does the F4 readback live? After the "Writing GitHub secrets and variables"
+  `withGhRetry` block, before `assertProxyKeyWorks`, inside its own try/catch that degrades
+  to a warning.
+
+### Deferred to Implementation
+
+- Exact helper name and signature for the readback verification (inline vs. small named
+  helper in `setup.ts`). Decide when touching the code; favor a named helper for testability.
+- Whether the readback reuses the injected `gh.listExistingGhNames` (it should, for DI
+  testability) — confirm the `RunSetupDeps.gh` surface already exposes it (it does).
+
+## Implementation Units
+
+- [x] **Unit 1: F4 post-write readback verification**
+
+**Goal:** After a successful write, re-list secret AND variable names and warn loudly if any
+written name is not visible, signaling an unreliable token list view that may have bypassed
+the pre-write gates. Distinguish a verified mismatch (readback succeeded, name absent) from a
+cannot-verify case (readback call failed).
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None (builds on the shipped PR #312 structure).
+
+**Files:**
+- Modify: `packages/cli/src/commands/cliproxy/setup.ts`
+- Test: `packages/cli/src/commands/cliproxy/setup.test.ts`
+
+**Approach:**
+- After the `gh.withGhRetry('Writing GitHub secrets and variables', ...)` block and before
+  `assertProxyKeyWorks`, add a readback step (favor a small named helper for testability,
+  e.g. `verifyWrittenSecretsVisible`).
+- Compute written names from `plan.template.secrets.map(s => s.name)` and
+  `plan.template.variables.map(v => v.name)`. Re-list via the injected
+  `gh.listExistingGhNames(plan.repo, 'secret')` and `gh.listExistingGhNames(plan.repo,
+  'variable')`. Compute the per-kind set difference. Verifying both kinds matters because the
+  collision gate uses both lists — corroborating only secrets leaves the variable side
+  uncorroborated.
+- Verified mismatch (readback succeeded, a written name absent): emit a loud warning naming
+  the absent names per kind, directing the operator to verify manually (`gh secret list
+  --repo <repo>` / `gh variable list --repo <repo>`), and stating the pre-write gates rely on
+  the same list view and may have been bypassed. Use `log.warn` (warning, not failure — do
+  NOT throw).
+- Cannot verify (a readback `gh` call failed): emit a softer, distinctly-worded "could not
+  verify written values are visible" warning so the operator can gauge that this is weaker
+  than a confirmed mismatch.
+- The non-throw guard must wrap the ENTIRE verification block — both readback calls, the
+  set-difference computation, AND warning emission — not just the `gh` calls. A throw during
+  diff or log formatting would otherwise reach the `mutationError` rollback and wrongly delete
+  a key whose secrets are written. Guarding only the `gh` call is insufficient.
+- Do not alter the existing success messaging on the happy path.
+
+**Patterns to follow:**
+- `parseManagementKeyList` fail-loud philosophy in
+  `packages/cli/src/commands/cliproxy/shared.ts`.
+- The existing `withGhRetry` / `log.warn` usage already in `runSetupCommand`.
+- DI via `RunSetupDeps.gh.listExistingGhNames` for test injection.
+
+**Test scenarios:**
+- Happy path: pre-write list `[]`, write succeeds, post-write readback returns all written
+  secret AND variable names → no new warning emitted; success path unchanged.
+- Token-scope blindness (secret): pre-write `[]`, write succeeds, secret readback still
+  missing `OPENCODE_AUTH_JSON` → "verified mismatch" warning; assert the text names the absent
+  secret, mentions manual verification (`gh secret list`), and states the gates may have been
+  bypassed.
+- Token-scope blindness (variable): secret readback shows all written secrets, but the
+  variable readback is missing a written variable name (e.g., `FRO_BOT_MODEL`) → "verified
+  mismatch" warning lists the absent variable. (Covers the variable-side gate gap.)
+- Partial visibility: readback shows some but not all written names → warning lists exactly
+  the absent names per kind.
+- Cannot-verify (secret readback gh-fails): injected `listExistingGhNames` throws on the
+  post-write secret call → "could not verify" warning (distinct wording from verified
+  mismatch), command does NOT throw, `deleteManagementApiKey` NOT called (assert via spy).
+- Whole-block guard: a throw is injected during warning emission / diff path (not just the
+  `gh` call) → still degrades to a warning, command does NOT throw, rollback NOT fired.
+- Existing-secret + acknowledged path unaffected: pre-write list shows `OPENCODE_AUTH_JSON`,
+  `--ack-key-reuse` supplied, write succeeds, readback shows all names → no new warning.
+
+**Verification:**
+- Verified-mismatch warning fires only when a written secret or variable name is absent on a
+  successful readback; cannot-verify warning fires only when a readback `gh` call fails.
+- The command never throws or rolls back due to any readback outcome (including a throw in the
+  diff/warning path, not just the `gh` call).
+- Full suite green; happy-path snapshot/output unchanged.
+
+- [x] **Unit 2: F3 concurrency caveat — warning extension + AGENTS.md documentation**
+
+**Goal:** Surface the last-write-wins concurrency hazard where a destructive overwrite is
+already flagged, and document the concurrency + transient-empty boundaries as known
+operational limitations.
+
+**Requirements:** R4, R5
+
+**Dependencies:** None (independent of Unit 1; can land in the same PR).
+
+**Files:**
+- Modify: `packages/cli/src/commands/cliproxy/setup.ts`
+- Modify: `packages/cli/AGENTS.md`
+- Test: `packages/cli/src/commands/cliproxy/setup.test.ts`
+
+**Approach:**
+- Extend the existing non-interactive `--force` overwrite warning (`log.warn('Overwriting
+  existing GitHub values: ...')`) to add one sentence: concurrent `setup` runs against the
+  same repo are not coordinated and resolve last-write-wins. Keep it to the existing warning
+  site — do not add a per-run advisory that would fire on clean runs.
+- In `packages/cli/AGENTS.md`, add a short "Operational limitations" note under the cliproxy
+  setup section (or extend the existing migration-recipe area): (a) `setup` is not
+  concurrency-safe — don't run it against the same repo from two places at once
+  (last-write-wins, no GitHub locking primitive); (b) crucially, state that the overwrite-site
+  warning only fires on the *detected-collision* path — the fresh-run race (two concurrent
+  runs both seeing an empty list, neither detecting a collision) produces NO runtime signal
+  and is mitigated solely by operator coordination. Do not imply the warning protects fresh
+  concurrent runs; (c) the transient-empty caveat — a zero-exit empty list can disable the
+  safety gates, which Unit 1's post-write readback surfaces as a warning.
+
+**Patterns to follow:**
+- Present-tense, current-behavior documentation voice (no "previously/now" framing) per repo
+  docs conventions.
+- The existing AGENTS.md migration-recipe section added in PR #312.
+
+**Test scenarios:**
+- Non-interactive `--force` with collisions present → assert the overwrite warning text now
+  includes the concurrency/last-write-wins sentence.
+- Non-interactive `--force` with no collisions → assert the concurrency sentence is NOT
+  emitted (warning only fires on actual overwrite, no new noise on clean runs). This is the
+  fresh-run race path that produces no signal — the test documents that the warning does NOT
+  cover it.
+
+**Verification:**
+- Overwrite warning carries the concurrency caveat only when an overwrite is actually
+  flagged.
+- AGENTS.md documents both limitations in present-tense operational language.
+
+## System-Wide Impact
+
+- **Interaction graph:** Unit 1 adds two post-write read-only invocations per setup run
+  (`gh secret list` + `gh variable list`). They sit between the write loop and
+  `assertProxyKeyWorks`. No effect on the workflow-wiring check or smoke test.
+- **Error propagation:** The readback must be a terminal warning, never a thrown error — a
+  throw post-write would enter the `catch (mutationError)` rollback and delete the
+  just-created key. This is the single most important correctness constraint in the plan.
+- **State lifecycle risks:** None added. Secrets are already written before readback; readback
+  is observational.
+- **API surface parity:** `cliproxy setup` only. No other command reads-then-writes GitHub
+  secrets (confirmed by research — `listExistingGhNames` has exactly one caller).
+- **Gate coverage parity:** The collision gate uses BOTH secret and variable name lists, so
+  the F4 readback corroborates both — verifying only secrets would leave the variable side of
+  the gate uncorroborated.
+- **F3 fresh-run-race honesty:** The overwrite-site warning fires only on the
+  detected-collision path. The fresh-run race (two concurrent runs both seeing an empty list)
+  produces no collision and therefore no warning — an accepted, documented limitation, not a
+  mitigation. Operator coordination is the only control.
+- **Integration coverage:** The readback uses the injected `gh.listExistingGhNames`, so the
+  rollback-not-fired assertion must use the DI spy on `deleteManagementApiKey`.
+- **Unchanged invariants:** The ack-key-reuse gate and collision gate decision logic are
+  unchanged. The hard-error fail-closed behavior of `listExistingGhNames` is unchanged. The
+  happy-path output and the dual-provider/anthropic-only byte-identical secret values shipped
+  in 0.8.0 are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Readback throw (anywhere in the block, not just the `gh` call) triggers key-deletion rollback | Wrap the ENTIRE verification block — readback calls, diff computation, warning emission — in one try/catch that degrades any failure to a cannot-verify warning; explicit test injects a throw in the warning/diff path and asserts `deleteManagementApiKey` not called. |
+| New warning adds noise to legitimate fresh-repo setups | Warning fires only when a written name is absent on a successful readback — a genuine fresh repo readback shows the just-written names, so no warning. |
+| Variable-side transient-empty bypasses the collision gate uncorroborated | F4 readback verifies variables as well as secrets; dedicated test covers a stale variable-side list. |
+| Operators read the F3 warning as protecting fresh concurrent runs | AGENTS.md states explicitly that the warning only covers the detected-collision path; the fresh-run race has no runtime signal and relies on operator coordination. |
+| F4 readback gives false reassurance (cannot detect pre-existing clobber via name presence) | Documented explicitly in AGENTS.md (Unit 2) and in the plan's Problem Frame: readback catches token-scope blindness, not pre-existing-value clobber. The ack-key-reuse gate remains the primary guard for the visible-secret case. |
+| F3 fundamentally unsolvable with current GitHub API | Accepted and documented; warning placed at the overwrite site; no false promise of safety. |
+
+## Documentation / Operational Notes
+
+- A **minor changeset** lands with the PR: Unit 1 adds a new user-facing warning to a shipped
+  command (`packages/cli/src/` runtime change). Unit 2's AGENTS.md change alone would not
+  warrant a changeset, but it ships in the same PR. Changeset describes the F4 readback
+  warning and the F3 concurrency caveat in present-tense, current-behavior voice — no plan-ID
+  or session taxonomy in the changeset or commit messages.
+- Update issue #311: check off F4 and F3 with a one-line note pointing at the merge PR.
+
+## Sources & References
+
+- **Origin:** GitHub issue #311 — cliproxy setup refactor ce:review follow-ups (consolidated).
+- ce:review run `20260527-094713-8fe918ca` (synthesis, gitignored).
+- Related code: `packages/cli/src/commands/cliproxy/setup.ts`,
+  `packages/cli/src/commands/cliproxy/setup/gh.ts`,
+  `packages/cli/src/commands/cliproxy/shared.ts`.
+- Related learnings: `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md`,
+  `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md`.
+- Shipped precedent: PR #312 (`parseManagementKeyList` fail-closed parser).

--- a/docs/plans/2026-05-27-001-fix-cliproxy-setup-gate-reliability-plan.md
+++ b/docs/plans/2026-05-27-001-fix-cliproxy-setup-gate-reliability-plan.md
@@ -357,9 +357,10 @@ operational limitations.
 
 ## Documentation / Operational Notes
 
-- A **minor changeset** lands with the PR: Unit 1 adds a new user-facing warning to a shipped
-  command (`packages/cli/src/` runtime change). Unit 2's AGENTS.md change alone would not
-  warrant a changeset, but it ships in the same PR. Changeset describes the F4 readback
+- A **patch changeset** lands with the PR: this is a `fix` that hardens an existing command's
+  write path (a new `log.warn` on an existing flow) with no new flag, command, or machine
+  contract. Unit 2's AGENTS.md change alone would not warrant a changeset, but it ships in the
+  same PR. Changeset describes the F4 readback
   warning and the F3 concurrency caveat in present-tense, current-behavior voice — no plan-ID
   or session taxonomy in the changeset or commit messages.
 - Update issue #311: check off F4 and F3 with a one-line note pointing at the merge PR.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -122,6 +122,13 @@ bunx @marcusrbrown/infra cliproxy setup \
 
 GitHub's secrets API is write-only, so the CLI cannot verify `--key` matches the bearer token inside the existing `OPENCODE_AUTH_JSON`. Verify the match before running with `--ack-key-reuse`. Interactive mode prompts for the same confirmation instead of requiring the flag.
 
+## OPERATIONAL LIMITATIONS
+
+`cliproxy setup` drives its ack-key-reuse and collision gates off a pre-write list of the repo's existing GitHub secret/variable names. Two limitations follow from how GitHub exposes that data:
+
+- **Not concurrency-safe.** Don't run `cliproxy setup` against the same repo from two places at once. GitHub secrets are write-only with no lock or compare-and-swap, so concurrent runs resolve last-write-wins. The `--force` overwrite warning carries a concurrency note, but it only fires on the *detected-collision* path: two fresh concurrent runs that both see an empty secret list detect no collision, so neither prints a warning. That fresh-run race has no runtime signal and is mitigated solely by operator coordination — the warning does not protect against it.
+- **Transient-empty gate bypass.** A `gh secret list` that returns empty on a successful (zero-exit) call — scope-limited token, replication lag — looks identical to a genuinely fresh repo and silently disables both gates. After writing, setup re-lists secret and variable names and warns if a just-written name is not visible (the token's list view is unreliable, so the pre-write gates may have been bypassed). This readback catches token-scope blindness; it cannot detect whether a *different* value was overwritten, since the written name is present on readback either way.
+
 ## ANTI-PATTERNS
 
 - Never use `bundledDependencies` — Bun's `.bun/` symlinks create `../../` paths that npm rejects with E415.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -2148,6 +2148,73 @@ describe('post-write readback verification', () => {
     expect(deleteCalledWith).toBeUndefined()
   })
 
+  it('createKey:true path — post-write readback throws → command resolves, key created, rollback suppressed', async () => {
+    // This test drives the createKey:true path (no --key supplied, wizard mints a key).
+    // The post-write readback throws after the key is created and secrets are written.
+    // Asserts: (1) createManagementApiKey WAS called, (2) command resolves, (3) deleteManagementApiKey NOT called.
+    const {ctx} = makeCtx()
+
+    let createCalled = false
+    let deleteCalled = false
+    let listCallCount = 0
+
+    await runSetupCommand(
+      {
+        // No --key → createKey=true
+        repo: 'owner/repo',
+        harness: 'claude-code',
+        force: true,
+      },
+      {
+        interactive: true,
+        baseUrl: BASE_URL,
+        ctx,
+        resolveManagementKey: () => 'mgmt-test-key',
+        gh: {
+          assertGhInstalled: async () => {},
+          assertGhAuthenticated: async () => {},
+          assertRepoAccess: async () => {},
+          listExistingGhNames: async (_repo, _kind) => {
+            listCallCount++
+            if (listCallCount <= 2) return [] // Pre-write calls succeed (empty repo)
+            // Post-write readback throws
+            throw new Error('gh: post-write readback failed')
+          },
+          createManagementApiKey: async () => {
+            createCalled = true
+          },
+          deleteManagementApiKey: async () => {
+            deleteCalled = true
+          },
+          applyGhValue: async () => {},
+          withGhRetry: async (_label, fn) => fn(makeSpinner()),
+        },
+        prompts: {
+          promptValue: autoPromptValue,
+          confirm: () => Promise.resolve(true) as Promise<boolean | symbol>,
+          intro: () => {},
+          note: () => {},
+          outro: () => {},
+        },
+        smoke: {
+          runSmokeTest: async () => ({kind: 'pass' as const, message: 'ok', runUrl: 'https://example.com/run/1'}),
+        },
+        validation: {
+          assertProxyReachable: async () => {},
+          assertProxyKeyWorks: async () => {},
+          verifyModelsAvailable: async () => {},
+        },
+      },
+    )
+
+    // Key was created this run
+    expect(createCalled).toBe(true)
+    // Command resolved (did not throw)
+    // (implicit — if it threw, the test would fail above)
+    // Rollback must NOT have fired — post-write readback failure must not trigger key deletion
+    expect(deleteCalled).toBe(false)
+  })
+
   it('whole-block guard: throw during diff/warning path → command does NOT throw, rollback NOT fired', async () => {
     // Simulate a throw that occurs after the gh calls succeed but during processing.
     // We do this by making the post-write secret readback return a value that causes

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -1,7 +1,8 @@
 /// <reference types="bun" />
 
 import type {SpinnerResult} from '@clack/prompts'
-import {afterEach, describe, expect, it, mock, spyOn} from 'bun:test'
+import {log} from '@clack/prompts'
+import {afterEach, beforeEach, describe, expect, it, mock, spyOn} from 'bun:test'
 import {goke} from 'goke'
 
 import {
@@ -1957,5 +1958,253 @@ describe('runSetupCommand action handler', () => {
     }
 
     expect(fetchCalled).toBe(false)
+  })
+})
+
+// ── post-write readback verification ──────────────────────────────────────────
+
+describe('post-write readback verification', () => {
+  const BASE_URL = 'https://cliproxy.fro.bot'
+  const KEY = 'sk-test-key'
+
+  // Capture log.warn calls from @clack/prompts
+  let warnSpy: ReturnType<typeof spyOn>
+  let warnMessages: string[]
+
+  // Standard DI deps for a successful non-interactive setup run.
+  // listExistingGhNames is overridden per-test to control readback behavior.
+  function makeDeps(
+    listExistingGhNames: (repo: string, kind: 'secret' | 'variable') => Promise<string[]>,
+    deleteManagementApiKey?: () => Promise<void>,
+  ) {
+    const {ctx} = makeCtx()
+    return {
+      ctx,
+      deps: {
+        interactive: false,
+        baseUrl: BASE_URL,
+        ctx,
+        gh: {
+          assertGhInstalled: async () => {},
+          assertGhAuthenticated: async () => {},
+          assertRepoAccess: async () => {},
+          listExistingGhNames,
+          createManagementApiKey: async () => {},
+          deleteManagementApiKey: deleteManagementApiKey ?? (async () => {}),
+          applyGhValue: async () => {},
+          withGhRetry: async (_label, fn) => fn(makeSpinner()),
+        },
+        prompts: {
+          promptValue: autoPromptValue,
+          confirm: () => Promise.resolve(true) as Promise<boolean | symbol>,
+          intro: () => {},
+          note: () => {},
+          outro: () => {},
+        },
+        smoke: {
+          runSmokeTest: async () => ({kind: 'pass' as const, message: 'ok', runUrl: 'https://example.com/run/1'}),
+        },
+        validation: {
+          assertProxyReachable: async () => {},
+          assertProxyKeyWorks: async () => {},
+          verifyModelsAvailable: async () => {},
+        },
+      } satisfies Parameters<typeof runSetupCommand>[1],
+    }
+  }
+
+  // Standard options for a non-interactive anthropic-only setup (no --force needed)
+  const baseOptions = {
+    key: KEY,
+    repo: 'owner/repo',
+    harness: 'opencode' as const,
+  }
+
+  beforeEach(() => {
+    warnMessages = []
+    warnSpy = spyOn(log, 'warn').mockImplementation((msg: string) => {
+      warnMessages.push(msg)
+    })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('happy path: readback returns all written names → no new warning emitted', async () => {
+    // Pre-write list is empty; post-write readback returns all written names
+    // The opencode harness writes: OPENCODE_AUTH_JSON, OPENCODE_CONFIG, OMO_PROVIDERS (secrets)
+    // and FRO_BOT_MODEL (variable)
+    let callCount = 0
+    const {deps} = makeDeps(async (_repo, kind) => {
+      callCount++
+      if (callCount <= 2) {
+        // Pre-write calls: return empty (fresh repo)
+        return []
+      }
+      // Post-write readback: return all written names
+      if (kind === 'secret') return ['OPENCODE_AUTH_JSON', 'OPENCODE_CONFIG', 'OMO_PROVIDERS']
+      return ['FRO_BOT_MODEL']
+    })
+
+    await runSetupCommand(baseOptions, deps)
+
+    // No verified-mismatch or cannot-verify warning should have been emitted
+    const readbackWarnings = warnMessages.filter(
+      m => m.includes('not visible') || m.includes('could not verify') || m.includes('may have been bypassed'),
+    )
+    expect(readbackWarnings).toHaveLength(0)
+  })
+
+  it('verified mismatch (secret): readback succeeds but written secret absent → loud warning naming absent secret', async () => {
+    // Pre-write: empty. Post-write secret readback: missing OPENCODE_AUTH_JSON
+    let callCount = 0
+    const {deps} = makeDeps(async (_repo, kind) => {
+      callCount++
+      if (callCount <= 2) return []
+      // Post-write: secret readback missing OPENCODE_AUTH_JSON
+      if (kind === 'secret') return ['OPENCODE_CONFIG', 'OMO_PROVIDERS']
+      return ['FRO_BOT_MODEL']
+    })
+
+    await runSetupCommand(baseOptions, deps)
+
+    const mismatchWarnings = warnMessages.filter(m => m.includes('may have been bypassed'))
+    expect(mismatchWarnings.length).toBeGreaterThan(0)
+    // Must name the absent secret
+    expect(mismatchWarnings.some(m => m.includes('OPENCODE_AUTH_JSON'))).toBe(true)
+    // Must direct operator to manual verification
+    expect(mismatchWarnings.some(m => m.includes('gh secret list'))).toBe(true)
+  })
+
+  it('verified mismatch (variable): secret readback complete but variable absent → warning lists absent variable', async () => {
+    // Pre-write: empty. Post-write: all secrets present, but FRO_BOT_MODEL missing from variables
+    let callCount = 0
+    const {deps} = makeDeps(async (_repo, kind) => {
+      callCount++
+      if (callCount <= 2) return []
+      if (kind === 'secret') return ['OPENCODE_AUTH_JSON', 'OPENCODE_CONFIG', 'OMO_PROVIDERS']
+      // Variable readback missing FRO_BOT_MODEL
+      return []
+    })
+
+    await runSetupCommand(baseOptions, deps)
+
+    const mismatchWarnings = warnMessages.filter(m => m.includes('may have been bypassed'))
+    expect(mismatchWarnings.length).toBeGreaterThan(0)
+    expect(mismatchWarnings.some(m => m.includes('FRO_BOT_MODEL'))).toBe(true)
+    expect(mismatchWarnings.some(m => m.includes('gh variable list'))).toBe(true)
+  })
+
+  it('partial visibility: readback shows some but not all written names → warning lists exactly the absent names', async () => {
+    // Post-write: OPENCODE_CONFIG and OMO_PROVIDERS present, OPENCODE_AUTH_JSON absent
+    let callCount = 0
+    const {deps} = makeDeps(async (_repo, kind) => {
+      callCount++
+      if (callCount <= 2) return []
+      if (kind === 'secret') return ['OPENCODE_CONFIG', 'OMO_PROVIDERS'] // OPENCODE_AUTH_JSON absent
+      return ['FRO_BOT_MODEL']
+    })
+
+    await runSetupCommand(baseOptions, deps)
+
+    const mismatchWarnings = warnMessages.filter(m => m.includes('may have been bypassed'))
+    expect(mismatchWarnings.length).toBeGreaterThan(0)
+    // Must name OPENCODE_AUTH_JSON (absent)
+    expect(mismatchWarnings.some(m => m.includes('OPENCODE_AUTH_JSON'))).toBe(true)
+    // Must NOT name OPENCODE_CONFIG or OMO_PROVIDERS (they ARE present)
+    expect(mismatchWarnings.some(m => m.includes('OPENCODE_CONFIG'))).toBe(false)
+    expect(mismatchWarnings.some(m => m.includes('OMO_PROVIDERS'))).toBe(false)
+  })
+
+  it('cannot verify: listExistingGhNames throws on post-write call → softer warning, command does NOT throw, rollback NOT fired', async () => {
+    let deleteCalledWith: string | undefined
+    let callCount = 0
+
+    const {deps} = makeDeps(
+      async (_repo, _kind) => {
+        callCount++
+        if (callCount <= 2) return [] // Pre-write calls succeed
+        // Post-write readback throws
+        throw new Error('gh: command failed')
+      },
+      async () => {
+        deleteCalledWith = 'called'
+      },
+    )
+
+    // Command must NOT throw
+    await expect(runSetupCommand(baseOptions, deps)).resolves.toBeUndefined()
+
+    // Must emit the cannot-verify warning (softer wording)
+    const cannotVerifyWarnings = warnMessages.filter(m => m.includes('could not verify'))
+    expect(cannotVerifyWarnings.length).toBeGreaterThan(0)
+
+    // Must NOT emit the verified-mismatch warning
+    const mismatchWarnings = warnMessages.filter(m => m.includes('may have been bypassed'))
+    expect(mismatchWarnings).toHaveLength(0)
+
+    // Rollback must NOT have fired (key was not created by this run since --key was supplied)
+    expect(deleteCalledWith).toBeUndefined()
+  })
+
+  it('whole-block guard: throw during diff/warning path → command does NOT throw, rollback NOT fired', async () => {
+    // Simulate a throw that occurs after the gh calls succeed but during processing.
+    // We do this by making the post-write secret readback return a value that causes
+    // an error in the diff computation — specifically, we inject a non-iterable value
+    // by making listExistingGhNames return a Proxy that throws on iteration.
+    let deleteCalledWith: string | undefined
+    let callCount = 0
+
+    const {deps} = makeDeps(
+      async (_repo, _kind) => {
+        callCount++
+        if (callCount <= 2) return []
+        // Return a value that will cause an error during set-difference computation:
+        // a Proxy that throws when iterated
+        const throwingArray = new Proxy([] as string[], {
+          get(target, prop) {
+            if (prop === 'includes' || prop === Symbol.iterator || prop === 'forEach') {
+              throw new Error('injected-diff-error')
+            }
+            return Reflect.get(target, prop)
+          },
+        })
+        return throwingArray
+      },
+      async () => {
+        deleteCalledWith = 'called'
+      },
+    )
+
+    // Command must NOT throw
+    await expect(runSetupCommand(baseOptions, deps)).resolves.toBeUndefined()
+
+    // Rollback must NOT have fired
+    expect(deleteCalledWith).toBeUndefined()
+  })
+
+  it('existing secret + ack-key-reuse: readback shows all names → no new warning', async () => {
+    // Pre-write: OPENCODE_AUTH_JSON already exists (triggers ack-key-reuse path)
+    // Post-write readback: all names present
+    let callCount = 0
+    const {deps} = makeDeps(async (_repo, kind) => {
+      callCount++
+      if (callCount <= 2) {
+        // Pre-write: OPENCODE_AUTH_JSON exists
+        if (kind === 'secret') return ['OPENCODE_AUTH_JSON']
+        return []
+      }
+      // Post-write readback: all names present
+      if (kind === 'secret') return ['OPENCODE_AUTH_JSON', 'OPENCODE_CONFIG', 'OMO_PROVIDERS']
+      return ['FRO_BOT_MODEL']
+    })
+
+    await runSetupCommand({...baseOptions, ackKeyReuse: true, force: true}, deps)
+
+    const readbackWarnings = warnMessages.filter(
+      m => m.includes('not visible') || m.includes('could not verify') || m.includes('may have been bypassed'),
+    )
+    expect(readbackWarnings).toHaveLength(0)
   })
 })

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -2208,3 +2208,88 @@ describe('post-write readback verification', () => {
     expect(readbackWarnings).toHaveLength(0)
   })
 })
+
+// ── concurrency caveat on the non-interactive overwrite warning ─────────────────
+
+describe('non-interactive overwrite warning concurrency caveat', () => {
+  const BASE_URL = 'https://cliproxy.fro.bot'
+  const KEY = 'sk-test-key'
+
+  let warnSpy: ReturnType<typeof spyOn>
+  let warnMessages: string[]
+
+  function makeDeps(listExistingGhNames: (repo: string, kind: 'secret' | 'variable') => Promise<string[]>) {
+    const {ctx} = makeCtx()
+    return {
+      interactive: false,
+      baseUrl: BASE_URL,
+      ctx,
+      gh: {
+        assertGhInstalled: async () => {},
+        assertGhAuthenticated: async () => {},
+        assertRepoAccess: async () => {},
+        listExistingGhNames,
+        createManagementApiKey: async () => {},
+        deleteManagementApiKey: async () => {},
+        applyGhValue: async () => {},
+        withGhRetry: async (_label, fn) => fn(makeSpinner()),
+      },
+      prompts: {
+        promptValue: autoPromptValue,
+        confirm: () => Promise.resolve(true) as Promise<boolean | symbol>,
+        intro: () => {},
+        note: () => {},
+        outro: () => {},
+      },
+      smoke: {
+        runSmokeTest: async () => ({kind: 'pass' as const, message: 'ok', runUrl: 'https://example.com/run/1'}),
+      },
+      validation: {
+        assertProxyReachable: async () => {},
+        assertProxyKeyWorks: async () => {},
+        verifyModelsAvailable: async () => {},
+      },
+    } satisfies Parameters<typeof runSetupCommand>[1]
+  }
+
+  beforeEach(() => {
+    warnMessages = []
+    warnSpy = spyOn(log, 'warn').mockImplementation((msg: string) => {
+      warnMessages.push(msg)
+    })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('--force overwrite with a collision present → warning carries the last-write-wins concurrency caveat', async () => {
+    // OPENCODE_AUTH_JSON already exists → collision on the opencode secret set → overwrite warning fires.
+    const deps = makeDeps(async (_repo, kind) => {
+      if (kind === 'secret') return ['OPENCODE_AUTH_JSON', 'OPENCODE_CONFIG', 'OMO_PROVIDERS']
+      return ['FRO_BOT_MODEL']
+    })
+
+    await runSetupCommand({key: KEY, repo: 'owner/repo', harness: 'opencode', ackKeyReuse: true, force: true}, deps)
+
+    const overwriteWarnings = warnMessages.filter(m => m.includes('Overwriting existing GitHub values'))
+    expect(overwriteWarnings.length).toBeGreaterThan(0)
+    expect(overwriteWarnings.some(m => m.includes('last-write-wins'))).toBe(true)
+    expect(overwriteWarnings.some(m => m.includes('two places at once'))).toBe(true)
+  })
+
+  it('--force with no collision → no overwrite warning, so no concurrency caveat (fresh-run race has no signal)', async () => {
+    // Fresh repo: empty pre-write list → no collision → overwrite warning never fires.
+    // This documents that the concurrency caveat does NOT cover the fresh-run race.
+    const deps = makeDeps(async (_repo, kind) => {
+      // Pre-write empty; post-write readback returns all written names (no readback warning either).
+      if (kind === 'secret') return []
+      return []
+    })
+
+    await runSetupCommand({key: KEY, repo: 'owner/repo', harness: 'opencode', force: true}, deps)
+
+    const concurrencyWarnings = warnMessages.filter(m => m.includes('last-write-wins'))
+    expect(concurrencyWarnings).toHaveLength(0)
+  })
+})

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -105,6 +105,91 @@ function resolveBaseUrl(input?: string): string {
   return stripTrailingSlash(input ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
 }
 
+/**
+ * After a successful write, re-list secret and variable names and warn if any written name
+ * is absent on readback — signaling an unreliable token list view that may have bypassed
+ * the pre-write safety gates.
+ *
+ * Distinguishes:
+ * - Verified mismatch: readback succeeded but a written name is absent (strong signal).
+ * - Cannot verify: the readback gh call itself failed (weaker signal).
+ *
+ * NEVER throws. The entire body is wrapped in a single try/catch so any failure — including
+ * errors during diff computation or warning emission — degrades to the cannot-verify warning.
+ * A throw here would propagate to the mutationError rollback and wrongly delete a key whose
+ * secrets are already written.
+ */
+async function verifyWrittenValuesVisible(
+  repo: string,
+  writtenSecretNames: string[],
+  writtenVariableNames: string[],
+  listExistingGhNames: typeof import('./setup/gh').listExistingGhNames,
+): Promise<void> {
+  try {
+    let secretReadback: string[]
+    let variableReadback: string[]
+    let readbackFailed = false
+
+    try {
+      secretReadback = await listExistingGhNames(repo, 'secret')
+    } catch {
+      readbackFailed = true
+      secretReadback = []
+    }
+
+    if (readbackFailed) {
+      variableReadback = []
+    } else {
+      try {
+        variableReadback = await listExistingGhNames(repo, 'variable')
+      } catch {
+        readbackFailed = true
+        variableReadback = []
+      }
+    }
+
+    if (readbackFailed) {
+      log.warn(
+        `Post-write readback: could not verify written values are visible in ${repo}. ` +
+          `The GitHub list call failed. Re-run 'infra cliproxy setup' later to confirm, or inspect directly.`,
+      )
+      return
+    }
+
+    const absentSecrets = writtenSecretNames.filter(name => !secretReadback.includes(name))
+    const absentVariables = writtenVariableNames.filter(name => !variableReadback.includes(name))
+
+    if (absentSecrets.length === 0 && absentVariables.length === 0) {
+      // Happy path: all written names are visible. Emit nothing.
+      return
+    }
+
+    const lines: string[] = [
+      `Post-write readback: the following written names are not visible in ${repo} — ` +
+        `the token's list view may be unreliable and the pre-write safety gates may have been bypassed.`,
+    ]
+
+    if (absentSecrets.length > 0) {
+      lines.push(`  Absent secrets: ${absentSecrets.join(', ')}`)
+      lines.push(`  Verify manually: gh secret list --repo ${repo}`)
+    }
+
+    if (absentVariables.length > 0) {
+      lines.push(`  Absent variables: ${absentVariables.join(', ')}`)
+      lines.push(`  Verify manually: gh variable list --repo ${repo}`)
+    }
+
+    log.warn(lines.join('\n'))
+  } catch {
+    // Any failure in the entire verification block (readback, diff, or warning emission)
+    // degrades to this softer cannot-verify warning. Never re-throw.
+    log.warn(
+      `Post-write readback: could not verify written values are visible in ${repo}. ` +
+        `The GitHub list call failed. Re-run 'infra cliproxy setup' later to confirm, or inspect directly.`,
+    )
+  }
+}
+
 function extractErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -484,6 +569,13 @@ export async function runSetupCommand(options: SetupOptions, deps: RunSetupDeps 
           }
         },
         interactive,
+      )
+
+      await verifyWrittenValuesVisible(
+        plan.repo,
+        plan.template.secrets.map(s => s.name),
+        plan.template.variables.map(v => v.name),
+        gh.listExistingGhNames,
       )
 
       await withSpinner('Verifying the new key through the proxy', async () => {

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -106,6 +106,35 @@ function resolveBaseUrl(input?: string): string {
 }
 
 /**
+ * Emit a warning without ever throwing. Used inside verifyWrittenNamesVisible so that a
+ * failure in warning emission itself cannot escape to the outer write catch and wrongly
+ * roll back a key whose secrets are already written.
+ */
+function safeWarn(message: string): void {
+  try {
+    log.warn(message)
+  } catch {
+    // Warning emission must never escape the post-write readback — a throw here would
+    // reach the outer write catch and wrongly roll back a key whose secrets are written.
+  }
+}
+
+function buildCannotVerifyMessage(repo: string, writtenSecretNames: string[], writtenVariableNames: string[]): string {
+  const secretPart =
+    writtenSecretNames.length > 0
+      ? `gh secret list --repo ${repo} (expect: ${writtenSecretNames.join(', ')})`
+      : `gh secret list --repo ${repo}`
+  const variablePart =
+    writtenVariableNames.length > 0
+      ? `gh variable list --repo ${repo} (expect: ${writtenVariableNames.join(', ')})`
+      : `gh variable list --repo ${repo}`
+  return (
+    `Post-write readback: could not verify the written names are visible in ${repo} ` +
+    `(the GitHub list call failed). Verify manually: ${secretPart}; ${variablePart}.`
+  )
+}
+
+/**
  * After a successful write, re-list secret and variable names and warn if any written name
  * is absent on readback — signaling an unreliable token list view that may have bypassed
  * the pre-write safety gates.
@@ -119,7 +148,7 @@ function resolveBaseUrl(input?: string): string {
  * A throw here would propagate to the mutationError rollback and wrongly delete a key whose
  * secrets are already written.
  */
-async function verifyWrittenValuesVisible(
+async function verifyWrittenNamesVisible(
   repo: string,
   writtenSecretNames: string[],
   writtenVariableNames: string[],
@@ -149,10 +178,7 @@ async function verifyWrittenValuesVisible(
     }
 
     if (readbackFailed) {
-      log.warn(
-        `Post-write readback: could not verify written values are visible in ${repo}. ` +
-          `The GitHub list call failed. Re-run 'infra cliproxy setup' later to confirm, or inspect directly.`,
-      )
+      safeWarn(buildCannotVerifyMessage(repo, writtenSecretNames, writtenVariableNames))
       return
     }
 
@@ -179,14 +205,11 @@ async function verifyWrittenValuesVisible(
       lines.push(`  Verify manually: gh variable list --repo ${repo}`)
     }
 
-    log.warn(lines.join('\n'))
+    safeWarn(lines.join('\n'))
   } catch {
     // Any failure in the entire verification block (readback, diff, or warning emission)
     // degrades to this softer cannot-verify warning. Never re-throw.
-    log.warn(
-      `Post-write readback: could not verify written values are visible in ${repo}. ` +
-        `The GitHub list call failed. Re-run 'infra cliproxy setup' later to confirm, or inspect directly.`,
-    )
+    safeWarn(buildCannotVerifyMessage(repo, writtenSecretNames, writtenVariableNames))
   }
 }
 
@@ -574,7 +597,7 @@ export async function runSetupCommand(options: SetupOptions, deps: RunSetupDeps 
         interactive,
       )
 
-      await verifyWrittenValuesVisible(
+      await verifyWrittenNamesVisible(
         plan.repo,
         plan.template.secrets.map(s => s.name),
         plan.template.variables.map(v => v.name),

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -522,7 +522,10 @@ export async function runSetupCommand(options: SetupOptions, deps: RunSetupDeps 
       }
 
       if (!interactive && options.force) {
-        log.warn(`Overwriting existing GitHub values: ${collisions.join(', ')}`)
+        log.warn(
+          `Overwriting existing GitHub values: ${collisions.join(', ')}. ` +
+            `Concurrent setup runs against the same repo are not coordinated and resolve last-write-wins — don't run setup against this repo from two places at once.`,
+        )
         // proceed
       }
 


### PR DESCRIPTION
## What

`cliproxy setup` reads the repo's existing GitHub secret and variable names to drive two safety gates — the ack-key-reuse confirmation and the collision check — before it writes. This hardens that path against two ways the pre-write list can mislead the gates.

### Post-write readback

A `gh secret list` that returns empty on a successful call — a scope-limited token, replication lag — looks identical to a genuinely fresh repo and silently disables both gates. After writing, setup re-lists secret and variable names and warns if a just-written name is not visible:

- **Verified mismatch** (the name is provably absent): a loud warning naming the absent names per kind, the manual-verification commands, and that the gates rely on the same list view and may have been bypassed.
- **Cannot verify** (the readback call itself failed): a softer, distinctly-worded warning with the same manual commands and expected names, so the operator can gauge it as weaker than a confirmed mismatch.
- **All names visible**: no new output.

The readback checks names, not values — GitHub secrets are write-only. Every warning routes through a wrapper that can never throw: the readback runs inside the write block whose failure path rolls back a freshly created proxy key, so a warning that escaped would wrongly delete a key whose secrets are already written.

### Concurrency caveat

The non-interactive `--force` overwrite warning states that concurrent runs against the same repo resolve last-write-wins. That warning only fires when a collision is detected; two fresh concurrent runs that both see an empty list detect no collision and emit nothing, so that race has no runtime signal and relies on operator coordination. `packages/cli/AGENTS.md` documents both the concurrency boundary and the transient-empty gate bypass.

## Tests

781 pass, 2 skip, 0 fail. New coverage: happy path, verified mismatch (secret and variable), partial visibility, cannot-verify, a throw in the diff/warning path, and the key-creating path where a readback failure must not roll back the minted key.
