### PR TITLE
chore(cliproxy): harden setup tests and validate smoke-test payloads

### DIFF
--- a/.changeset/cliproxy-setup-smoke-test-validation.md
+++ b/.changeset/cliproxy-setup-smoke-test-validation.md
@@ -1,0 +1,7 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+`cliproxy setup --verify-smoke` tolerates malformed `gh run list` output.
+
+The smoke test now validates the `gh run list` JSON payloads with a schema before reading them. A malformed or unexpected payload degrades to an `unverified` result instead of throwing or misreading run fields, keeping the wizard's smoke-test step on its existing pass/fail/unverified contract.

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -1,10 +1,10 @@
 /// <reference types="bun" />
 
 import type {SpinnerResult} from '@clack/prompts'
+import type {ProviderId} from './setup/providers'
 import {log} from '@clack/prompts'
 import {afterEach, beforeEach, describe, expect, it, mock, spyOn} from 'bun:test'
 import {goke} from 'goke'
-
 import {
   buildNonInteractivePlan,
   redactKey,
@@ -1374,14 +1374,7 @@ describe('runSetupCommand action handler', () => {
     ).resolves.toBeUndefined()
   })
 
-  // ── Interactive R8 ack-key-reuse prompt: redaction + cancel/continue ──────────
-  //
-  // Note: full interactive integration tests are limited by the F16 (issue #311) gap —
-  // buildInteractivePlan calls real @clack/prompts.text() for the key-name and harness
-  // prompts that DI doesn't cover yet. We test the redaction contract directly via
-  // the exported redactKey helper, then a unit test confirms the prompt template uses
-  // the redacted form. Interactive cancel/continue paths are exercised under F16 once
-  // RunSetupDeps covers all prompt sites.
+  // ── Interactive key-reuse confirm prompt: redaction + cancel/continue ──────────
 
   it('redactKey: keys >= 12 chars use first-3 + *** + last-4 shape', () => {
     expect(redactKey('sk-PLAINTEXT-LONGKEY')).toBe('sk-***GKEY')
@@ -1413,20 +1406,16 @@ describe('runSetupCommand action handler', () => {
     expect(promptContext).not.toMatch(/--key \$\{options\.key\}/)
   })
 
-  // The two interactive R8 integration tests below are skipped pending F16 (issue #311):
-  // RunSetupDeps must cover the buildInteractivePlan prompt sites before the interactive
-  // path can be exercised end-to-end with deps mocks alone.
-
-  it.skip('Interactive R8: confirm prompt fires with redacted key (not raw token)', async () => {
+  it('interactive key-reuse confirm shows a redacted key, never the raw token', async () => {
     const {ctx} = makeCtx()
     const PLAINTEXT_KEY = 'sk-PLAINTEXT-LONGKEY-SHOULD-NOT-LEAK'
     const MODELS_FIXTURE = {data: [{id: 'gpt-5.4-mini', owned_by: 'openai'}]}
     const originalFetch = globalThis.fetch
     globalThis.fetch = mock(async () => new Response(JSON.stringify(MODELS_FIXTURE))) as unknown as typeof fetch
 
-    let confirmMessage = ''
+    const confirmMessages: string[] = []
     const captureConfirm = (opts: {message: string}): Promise<boolean | symbol> => {
-      confirmMessage = opts.message
+      confirmMessages.push(opts.message)
       return Promise.resolve(true)
     }
 
@@ -1467,6 +1456,8 @@ describe('runSetupCommand action handler', () => {
             intro: () => {},
             note: () => {},
             outro: () => {},
+            promptForProviders: (): Promise<ProviderId[]> => Promise.resolve(['openai']),
+            promptForModel: (_providers: ProviderId[]): Promise<string> => Promise.resolve('openai/gpt-5.4-mini'),
           },
           smoke: {runSmokeTest: async () => ({kind: 'pass', message: 'ok', runUrl: 'https://example.com/run/1'})},
           validation: {
@@ -1480,18 +1471,19 @@ describe('runSetupCommand action handler', () => {
       globalThis.fetch = originalFetch
     }
 
-    // The R8 confirm prompt must be the one captured (interactive flow has more than one confirm
-    // in some paths; we look for the one containing the verify-bearer language).
-    expect(confirmMessage).toContain('Verify it matches the bearer token')
+    // The key-reuse confirm prompt must appear among the captured confirms (interactive flow
+    // has more than one confirm in some paths; we find the one with the verify-bearer language).
+    const keyReuseMessage = confirmMessages.find(m => m.includes('Verify it matches the bearer token'))
+    expect(keyReuseMessage).toBeDefined()
     // The raw key must NEVER appear in the prompt text — security regression guard.
-    expect(confirmMessage).not.toContain(PLAINTEXT_KEY)
+    expect(keyReuseMessage).not.toContain(PLAINTEXT_KEY)
     // Redacted form must be present (first 3 + last 4 chars per redactKey helper).
-    expect(confirmMessage).toContain('sk-')
-    expect(confirmMessage).toContain('***')
-    expect(confirmMessage).toContain('LEAK')
+    expect(keyReuseMessage).toContain('sk-')
+    expect(keyReuseMessage).toContain('***')
+    expect(keyReuseMessage).toContain('LEAK')
   })
 
-  it.skip('Interactive R8: confirm returns false → cancelAndExit invoked, applyGhValue never called', async () => {
+  it('interactive key-reuse confirm returning false cancels before any GitHub write', async () => {
     const {ctx} = makeCtx()
     const MODELS_FIXTURE = {data: [{id: 'gpt-5.4-mini', owned_by: 'openai'}]}
     const originalFetch = globalThis.fetch
@@ -1546,6 +1538,8 @@ describe('runSetupCommand action handler', () => {
             intro: () => {},
             note: () => {},
             outro: () => {},
+            promptForProviders: (): Promise<ProviderId[]> => Promise.resolve(['openai']),
+            promptForModel: (_providers: ProviderId[]): Promise<string> => Promise.resolve('openai/gpt-5.4-mini'),
           },
           smoke: {runSmokeTest: async () => ({kind: 'pass', message: 'ok', runUrl: 'https://example.com/run/1'})},
           validation: {

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -396,9 +396,9 @@ describe('destructive overwrite UX', () => {
 })
 
 // ── Smoke test runner tests moved to setup/smoke-test.test.ts ─────────────────
-// ── P1 regression tests ───────────────────────────────────────────────────────
+// ── regression tests ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-describe('P1 #1 regression — dry-run early return before mutations', () => {
+describe('dry-run early return before mutations', () => {
   const BASE_URL = 'https://cliproxy.fro.bot'
   const KEY = 'sk-test-key'
 
@@ -445,7 +445,7 @@ describe('P1 #1 regression — dry-run early return before mutations', () => {
   })
 })
 
-describe('P1 #2 regression — --force honored by non-interactive collision gate', () => {
+describe('--force honored by non-interactive collision gate', () => {
   // The collision gate lives in runSetupCommand (not exported), so we test the
   // surrounding logic: buildNonInteractivePlan succeeds with --force, and the
   // collision gate behavior is verified via the error message shape.
@@ -517,7 +517,7 @@ describe('P1 #2 regression — --force honored by non-interactive collision gate
   })
 })
 
-describe('safe_auto #2 regression — /v1/models body Bearer token redaction', () => {
+describe('/v1/models body Bearer token redaction', () => {
   const BASE_URL = 'https://cliproxy.fro.bot'
   const KEY = 'sk-test-key'
 
@@ -1391,8 +1391,8 @@ describe('runSetupCommand action handler', () => {
     expect(redacted.length).toBeLessThan(RAW.length)
   })
 
-  it('Interactive R8 prompt template uses redactKey output, never the raw key (source-level contract)', async () => {
-    // Read the setup.ts source and assert the R8 prompt-message template uses ${redactKey(options.key)}
+  it('interactive key-reuse prompt template uses redactKey output, never the raw key (source-level contract)', async () => {
+    // Read the setup.ts source and assert the key-reuse prompt-message template uses ${redactKey(options.key)}
     // and never `${options.key}` raw. This is a source-level guard so a future refactor that
     // accidentally drops the redaction call fails the test even if integration coverage lags.
     const source = await Bun.file(new URL('./setup.ts', import.meta.url).pathname).text()
@@ -1417,7 +1417,7 @@ describe('runSetupCommand action handler', () => {
     }
 
     // Interactive mode resolves promptValue to the awaited prompt result. Our captureConfirm
-    // returns true, so the wizard proceeds past the R8 gate. We assert on the captured message.
+    // returns true, so the wizard proceeds past the key-reuse gate. We assert on the captured message.
     const interactivePromptValue = async <T>(prompt: Promise<T | symbol>): Promise<T> => {
       const result = await prompt
       return result as T
@@ -1489,6 +1489,17 @@ describe('runSetupCommand action handler', () => {
     let applyGhValueCalled = false
     let exitCode: number | undefined
 
+    // The interactive flow shows a generic "Proceed?" confirm BEFORE the key-reuse
+    // gate. Approve the generic prompt so the run actually reaches the key-reuse
+    // confirm, then reject only that one — otherwise the test would cancel at the
+    // first prompt and never exercise the gate it claims to cover.
+    const confirmMessages: string[] = []
+    const messageAwareConfirm = (opts: {message: string}): Promise<boolean | symbol> => {
+      confirmMessages.push(opts.message)
+      const isKeyReusePrompt = opts.message.includes('Verify it matches the bearer token')
+      return Promise.resolve(!isKeyReusePrompt)
+    }
+
     const interactivePromptValue = async <T>(prompt: Promise<T | symbol>): Promise<T> => {
       const result = await prompt
       return result as T
@@ -1530,8 +1541,8 @@ describe('runSetupCommand action handler', () => {
           },
           prompts: {
             promptValue: interactivePromptValue,
-            // User rejects the R8 confirmation → cancelAndExit fires.
-            confirm: () => Promise.resolve(false) as Promise<boolean | symbol>,
+            // Approve the generic proceed confirm, reject only the key-reuse confirm.
+            confirm: messageAwareConfirm,
             intro: () => {},
             note: () => {},
             outro: () => {},
@@ -1547,7 +1558,7 @@ describe('runSetupCommand action handler', () => {
         },
       )
       // If we get here, cancelAndExit didn't fire. Fail the test.
-      throw new Error('expected cancelAndExit to fire on R8 reject')
+      throw new Error('expected cancelAndExit to fire on key-reuse reject')
     } catch (error) {
       // cancelAndExit throws because we stubbed process.exit to throw.
       expect(error instanceof Error && error.message).toBe('process.exit-stubbed')
@@ -1556,6 +1567,9 @@ describe('runSetupCommand action handler', () => {
       globalThis.fetch = originalFetch
     }
 
+    // Guard against a vacuous pass: the run must have actually reached the
+    // key-reuse confirm, not cancelled at the earlier generic proceed prompt.
+    expect(confirmMessages.some(m => m.includes('Verify it matches the bearer token'))).toBe(true)
     expect(exitCode).toBe(0)
     expect(applyGhValueCalled).toBe(false)
   })
@@ -1794,9 +1808,9 @@ describe('runSetupCommand action handler', () => {
     expect(deleteCalledWith).toBeDefined()
   })
 
-  // ── F5: --dry-run with no --repo/--harness ─────────────────────────────────
+  // ── --dry-run with no --repo/--harness ─────────────────────────────────
 
-  it('F5: --dry-run with no --repo/--harness prints preview and does not throw', async () => {
+  it('--dry-run with no --repo/--harness prints preview and does not throw', async () => {
     const {ctx, logs} = makeCtx()
     await runSetupCommand({dryRun: true}, {ctx})
     const output = logs.map(args => args.join(' ')).join('\n')
@@ -1804,7 +1818,7 @@ describe('runSetupCommand action handler', () => {
     expect(output).toContain('No mutations will be performed.')
   })
 
-  it('F5: --dry-run does not call assertGhInstalled even with no flags', async () => {
+  it('--dry-run does not call assertGhInstalled even with no flags', async () => {
     const {ctx} = makeCtx()
     let ghCalled = false
     await runSetupCommand(
@@ -1828,9 +1842,9 @@ describe('runSetupCommand action handler', () => {
     expect(ghCalled).toBe(false)
   })
 
-  // ── F8: Rollback event-order assertions ────────────────────────────────────
+  // ── Rollback event-order assertions ────────────────────────────────────
 
-  it('F8: applyGhValue fails → deleteManagementApiKey called BEFORE error propagates (event order)', async () => {
+  it('applyGhValue fails → deleteManagementApiKey called BEFORE error propagates (event order)', async () => {
     const {ctx} = makeCtx()
     const events: string[] = []
 
@@ -1879,7 +1893,7 @@ describe('runSetupCommand action handler', () => {
     expect(events).toEqual(['create', 'apply-fail', 'delete'])
   })
 
-  it('F8: assertProxyKeyWorks fails → deleteManagementApiKey called BEFORE error propagates (event order)', async () => {
+  it('assertProxyKeyWorks fails → deleteManagementApiKey called BEFORE error propagates (event order)', async () => {
     const {ctx} = makeCtx()
     const events: string[] = []
 
@@ -1930,9 +1944,9 @@ describe('runSetupCommand action handler', () => {
     expect(events).toEqual(['create', 'apply-success', 'verify-fail', 'delete'])
   })
 
-  // ── F9: --force pre-gate fires before verifyModelsAvailable ────────────────
+  // ── --force pre-gate fires before verifyModelsAvailable ────────────────
 
-  it('F9: missing --force on provider change does not call fetch (verifyModelsAvailable skipped)', async () => {
+  it('missing --force on provider change does not call fetch (verifyModelsAvailable skipped)', async () => {
     let fetchCalled = false
     const originalFetch = globalThis.fetch
     globalThis.fetch = mock(async () => {

--- a/packages/cli/src/commands/cliproxy/setup.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup.test.ts
@@ -578,8 +578,6 @@ describe('safe_auto #2 regression — /v1/models body Bearer token redaction', (
   })
 })
 
-/* eslint-disable @typescript-eslint/no-explicit-any -- spyOn mock return values require `any` casts */
-
 // Fix 3 — dry-run isolation regression tests
 //
 // The action handler in registerCliproxySetup is not exported, so we test the
@@ -608,9 +606,9 @@ describe('cliproxy setup --dry-run is offline-safe (action handler contract)', (
 
   it('dry-run skips gh auth check — Bun.spawn not called during buildNonInteractivePlan', async () => {
     // Spy Bun.spawn to fail hard if called (simulates unauthenticated environment)
-    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: any[]) => {
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((_cmds: string[]) => {
       throw new Error('gh auth status called during dry-run — should be skipped')
-    })
+    }) as unknown as typeof Bun.spawn)
 
     // Should complete without throwing (dry-run early return in buildNonInteractivePlan)
     const plan = await buildNonInteractivePlan({repo: 'owner/repo', harness: 'opencode', dryRun: true}, BASE_URL)
@@ -679,7 +677,6 @@ describe('cliproxy setup --dry-run is offline-safe (action handler contract)', (
     expect(fetchMock.mock.calls.length).toBeGreaterThan(0)
   })
 })
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 // ── runSetupCommand DI boundary tests ─────────────────────────────────
 

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -221,7 +221,7 @@ function extractErrorMessage(error: unknown): string {
 
 // Redact a bearer token for display in interactive prompts — never show raw key values.
 // Exported for direct unit testing of the redaction contract. The redacted form is
-// what gets shown in the interactive R8 prompt; the raw key must never reach the prompt UI.
+// what gets shown in the interactive key-reuse prompt; the raw key must never reach the prompt UI.
 export function redactKey(key: string): string {
   if (key.length < 12) return 'sk-***'
   return `${key.slice(0, 3)}***${key.slice(-4)}`

--- a/packages/cli/src/commands/cliproxy/setup.ts
+++ b/packages/cli/src/commands/cliproxy/setup.ts
@@ -90,6 +90,8 @@ export interface RunSetupDeps {
     intro: typeof intro
     note: typeof note
     outro: typeof outro
+    promptForProviders?: typeof promptForProviders
+    promptForModel?: typeof promptForModel
   }
   smoke?: {
     runSmokeTest: typeof runSmokeTest
@@ -280,8 +282,10 @@ async function buildInteractivePlan(
   let model: string | undefined
 
   if (harness === 'opencode') {
-    providers = await promptForProviders()
-    model = await promptForModel(providers)
+    const doPromptForProviders = promptsImpl.promptForProviders ?? promptForProviders
+    const doPromptForModel = promptsImpl.promptForModel ?? promptForModel
+    providers = await doPromptForProviders()
+    model = await doPromptForModel(providers)
   }
 
   const keyValue = options.key ?? buildApiKeyValue(keyName ?? 'cliproxy')
@@ -379,6 +383,8 @@ const realPrompts: Required<RunSetupDeps>['prompts'] = {
   intro,
   note,
   outro,
+  promptForProviders,
+  promptForModel,
 }
 
 const realSmoke: Required<RunSetupDeps>['smoke'] = {

--- a/packages/cli/src/commands/cliproxy/setup/providers.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup/providers.test.ts
@@ -1,8 +1,22 @@
 /// <reference types="bun" />
 
+import type {MultiSelectOptions, TextOptions} from '@clack/prompts'
 import {describe, expect, it, spyOn} from 'bun:test'
 
 import {parseProviders, promptForModel, promptForProviders} from './providers'
+
+// Type helper: cast a concrete-typed clack implementation to the generic spy type.
+// clack's multiselect/text/select are generic functions; Bun's spyOn preserves the
+// generic signature, so mockImplementation requires the same generic. We provide a
+// concrete instantiation and widen through `unknown` — this is safe because the
+// concrete type is a structural subtype of the generic at the call site.
+function asMultiselectImpl<V>(fn: (opts: MultiSelectOptions<V>) => Promise<V[] | symbol>) {
+  return fn as unknown as <Value>(opts: MultiSelectOptions<Value>) => Promise<Value[] | symbol>
+}
+
+function asTextImpl(fn: (opts: TextOptions) => Promise<string | symbol>) {
+  return fn as unknown as (opts: TextOptions) => Promise<string | symbol>
+}
 
 describe('option parsing', () => {
   describe('parseProviders', () => {
@@ -40,7 +54,6 @@ describe('option parsing', () => {
   })
 })
 
-/* eslint-disable @typescript-eslint/no-explicit-any -- spyOn mock return values require `any` casts */
 describe('interactive provider/model prompts', () => {
   // We spy on @clack/prompts functions directly since Bun's mock.module
   // requires static hoisting. Instead we use spyOn on the imported module.
@@ -60,7 +73,8 @@ describe('interactive provider/model prompts', () => {
   describe('promptForProviders', () => {
     it('happy path: anthropic-only selection returns [anthropic]', async () => {
       const clack = await import('@clack/prompts')
-      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(['anthropic'] as any)
+      // multiselect<Value> returns Promise<Value[] | symbol>; resolved value is string[] | symbol
+      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(['anthropic'])
 
       const result = await promptForProviders()
 
@@ -72,7 +86,7 @@ describe('interactive provider/model prompts', () => {
 
     it('happy path: both providers selected returns [anthropic, openai]', async () => {
       const clack = await import('@clack/prompts')
-      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(['anthropic', 'openai'] as any)
+      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(['anthropic', 'openai'])
 
       const result = await promptForProviders()
 
@@ -84,11 +98,13 @@ describe('interactive provider/model prompts', () => {
     it('edge case: empty selection re-prompts; multiselect called exactly twice', async () => {
       const clack = await import('@clack/prompts')
       let callCount = 0
-      const multiselectSpy = spyOn(clack, 'multiselect').mockImplementation(async () => {
-        callCount++
-        if (callCount === 1) return [] as any
-        return ['anthropic'] as any
-      })
+      const multiselectSpy = spyOn(clack, 'multiselect').mockImplementation(
+        asMultiselectImpl<string>(async () => {
+          callCount++
+          if (callCount === 1) return []
+          return ['anthropic']
+        }),
+      )
 
       const result = await promptForProviders()
 
@@ -101,12 +117,12 @@ describe('interactive provider/model prompts', () => {
     it('edge case: cancel mid-flow causes process.exit(0)', async () => {
       const clack = await import('@clack/prompts')
       const cancelSymbol = Symbol('cancel')
-      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(cancelSymbol as any)
+      const multiselectSpy = spyOn(clack, 'multiselect').mockResolvedValue(cancelSymbol)
       const isCancelSpy = spyOn(clack, 'isCancel').mockImplementation(v => v === cancelSymbol)
       const cancelSpy = spyOn(clack, 'cancel').mockImplementation(() => {})
-      const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      const exitSpy = spyOn(process, 'exit').mockImplementation((_code?: number): never => {
         throw new Error('process.exit called')
-      }) as any)
+      })
 
       await expect(promptForProviders()).rejects.toThrow('process.exit called')
 
@@ -144,7 +160,7 @@ describe('interactive provider/model prompts', () => {
 
     it('happy path: both providers, operator picks openai/gpt-5.4-mini from select', async () => {
       const clack = await import('@clack/prompts')
-      const selectSpy = spyOn(clack, 'select').mockResolvedValue('openai/gpt-5.4-mini' as any)
+      const selectSpy = spyOn(clack, 'select').mockResolvedValue('openai/gpt-5.4-mini')
 
       const result = await promptForModel(['anthropic', 'openai'])
 
@@ -156,7 +172,7 @@ describe('interactive provider/model prompts', () => {
 
     it('happy path: both providers, operator picks anthropic/claude-sonnet-4-6 from select', async () => {
       const clack = await import('@clack/prompts')
-      const selectSpy = spyOn(clack, 'select').mockResolvedValue('anthropic/claude-sonnet-4-6' as any)
+      const selectSpy = spyOn(clack, 'select').mockResolvedValue('anthropic/claude-sonnet-4-6')
 
       const result = await promptForModel(['anthropic', 'openai'])
 
@@ -167,8 +183,8 @@ describe('interactive provider/model prompts', () => {
 
     it('happy path: operator picks "enter custom..." then types openai/gpt-5.4-mini', async () => {
       const clack = await import('@clack/prompts')
-      const selectSpy = spyOn(clack, 'select').mockResolvedValue('__custom__' as any)
-      const textSpy = spyOn(clack, 'text').mockResolvedValue('openai/gpt-5.4-mini' as any)
+      const selectSpy = spyOn(clack, 'select').mockResolvedValue('__custom__')
+      const textSpy = spyOn(clack, 'text').mockResolvedValue('openai/gpt-5.4-mini')
 
       const result = await promptForModel(['anthropic', 'openai'])
 
@@ -181,21 +197,23 @@ describe('interactive provider/model prompts', () => {
 
     it('edge case: custom model entry fails regex then succeeds on second attempt', async () => {
       const clack = await import('@clack/prompts')
-      const selectSpy = spyOn(clack, 'select').mockResolvedValue('__custom__' as any)
+      const selectSpy = spyOn(clack, 'select').mockResolvedValue('__custom__')
       let textCallCount = 0
-      const textSpy = spyOn(clack, 'text').mockImplementation(async (_opts: any) => {
-        textCallCount++
-        // Simulate the validate function being called inline by the mock
-        // The real clack text prompt calls validate internally; here we just
-        // return the value and let the helper's validate logic re-prompt.
-        // Since we can't simulate clack's internal validate loop, we test
-        // that the helper's validate function rejects bad input.
-        if (textCallCount === 1) {
-          // Return a bad value — the helper should detect this and re-prompt
-          return 'bad-model' as any
-        }
-        return 'openai/gpt-5.4-mini' as any
-      })
+      const textSpy = spyOn(clack, 'text').mockImplementation(
+        asTextImpl(async () => {
+          textCallCount++
+          // Simulate the validate function being called inline by the mock
+          // The real clack text prompt calls validate internally; here we just
+          // return the value and let the helper's validate logic re-prompt.
+          // Since we can't simulate clack's internal validate loop, we test
+          // that the helper's validate function rejects bad input.
+          if (textCallCount === 1) {
+            // Return a bad value — the helper should detect this and re-prompt
+            return 'bad-model'
+          }
+          return 'openai/gpt-5.4-mini'
+        }),
+      )
 
       const result = await promptForModel(['anthropic', 'openai'])
 
@@ -209,12 +227,12 @@ describe('interactive provider/model prompts', () => {
     it('edge case: cancel during model select causes process.exit(0)', async () => {
       const clack = await import('@clack/prompts')
       const cancelSymbol = Symbol('cancel')
-      const selectSpy = spyOn(clack, 'select').mockResolvedValue(cancelSymbol as any)
+      const selectSpy = spyOn(clack, 'select').mockResolvedValue(cancelSymbol)
       const isCancelSpy = spyOn(clack, 'isCancel').mockImplementation(v => v === cancelSymbol)
       const cancelSpy = spyOn(clack, 'cancel').mockImplementation(() => {})
-      const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      const exitSpy = spyOn(process, 'exit').mockImplementation((_code?: number): never => {
         throw new Error('process.exit called')
-      }) as any)
+      })
 
       await expect(promptForModel(['anthropic', 'openai'])).rejects.toThrow('process.exit called')
 
@@ -225,4 +243,3 @@ describe('interactive provider/model prompts', () => {
     })
   })
 })
-/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/cli/src/commands/cliproxy/setup/smoke-test.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup/smoke-test.test.ts
@@ -717,6 +717,46 @@ describe('smoke test runner', () => {
     expect(result.kind).toBe('unverified')
   })
 
+  it('poll JSON validation — one malformed entry does not discard a valid matching run', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+    const createdAt = new Date(triggerTime.getTime() + 5000).toISOString()
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        // baseline: valid empty list → createdAt heuristic
+        return makeSmokeChild('[]', '', 0)
+      }
+      if (callIndex === 2) {
+        // trigger succeeds
+        return makeSmokeChild('', '', 0)
+      }
+      if (callIndex === 3) {
+        // poll: one malformed entry (databaseId is a string) PLUS one valid matching
+        // completed-success run. Per-entry validation must drop only the bad row and
+        // keep the good one — whole-batch rejection would lose our run.
+        return makeSmokeChild(
+          `[{"databaseId":"bad","status":"completed","conclusion":"success","url":"https://x","createdAt":"${
+            createdAt
+          }"},{"databaseId":105,"status":"completed","conclusion":"success","url":"${RUN_URL}","createdAt":"${
+            createdAt
+          }"}]`,
+          '',
+          0,
+        )
+      }
+      // log view for the matched run → contains "ack"
+      return makeSmokeChild('some log output with ack in it', '', 0)
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    // The valid entry survives per-entry validation and is matched → pass.
+    expect(result.kind).toBe('pass')
+    expect(result.runUrl).toBe(RUN_URL)
+  })
+
   it('baseline JSON validation — non-array baseline falls back to createdAt heuristic', async () => {
     const triggerTime = new Date('2026-05-25T10:00:00Z')
     const createdAt = new Date(triggerTime.getTime() + 5000).toISOString()

--- a/packages/cli/src/commands/cliproxy/setup/smoke-test.test.ts
+++ b/packages/cli/src/commands/cliproxy/setup/smoke-test.test.ts
@@ -640,4 +640,142 @@ describe('smoke test runner', () => {
     expect(result.kind).toBe('pass')
     expect(result.runUrl).toBe('https://github.com/owner/test-repo/actions/runs/105')
   })
+
+  // ── Zod schema validation hardening ──────────────────────────────────────
+
+  it('poll JSON validation — non-array response degrades to unverified without throwing', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        // baseline: valid empty list
+        return makeSmokeChild('[]', '', 0)
+      }
+      if (callIndex === 2) {
+        // trigger succeeds
+        return makeSmokeChild('', '', 0)
+      }
+      // poll returns a non-array object instead of an array — schema rejects it
+      return makeSmokeChild('{"error":"unexpected"}', '', 0)
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    // Schema validation fails → pollRuns stays [] → no candidates → all polls exhaust → unverified
+    expect(result.kind).toBe('unverified')
+  })
+
+  it('poll JSON validation — missing required databaseId field degrades gracefully', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        return makeSmokeChild('[]', '', 0)
+      }
+      if (callIndex === 2) {
+        return makeSmokeChild('', '', 0)
+      }
+      // poll returns array entries missing databaseId — schema rejects it
+      return makeSmokeChild(
+        '[{"status":"completed","conclusion":"success","url":"https://x","createdAt":"2026-05-25T10:00:05Z"}]',
+        '',
+        0,
+      )
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    expect(result.kind).toBe('unverified')
+  })
+
+  it('poll JSON validation — wrong type for databaseId (string instead of number) degrades gracefully', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        return makeSmokeChild('[]', '', 0)
+      }
+      if (callIndex === 2) {
+        return makeSmokeChild('', '', 0)
+      }
+      // databaseId is a string, not a number — schema rejects it
+      return makeSmokeChild(
+        '[{"databaseId":"not-a-number","status":"completed","conclusion":"success","url":"https://x","createdAt":"2026-05-25T10:00:05Z"}]',
+        '',
+        0,
+      )
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    expect(result.kind).toBe('unverified')
+  })
+
+  it('baseline JSON validation — non-array baseline falls back to createdAt heuristic', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+    const createdAt = new Date(triggerTime.getTime() + 5000).toISOString()
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        // baseline returns a non-array object — schema rejects it, baselineId stays null
+        return makeSmokeChild('{"databaseId":100}', '', 0)
+      }
+      if (callIndex === 2) {
+        return makeSmokeChild('', '', 0)
+      }
+      if (callIndex === 3) {
+        return makeSmokeChild(
+          makeSmokeRunList([{databaseId: 1, status: 'completed', conclusion: 'success', url: RUN_URL, createdAt}]),
+          '',
+          0,
+        )
+      }
+      return makeSmokeChild('ack', '', 0)
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    // Schema rejects non-array → baselineId stays null → createdAt heuristic → run found → pass
+    expect(result.kind).toBe('pass')
+    expect(result.runUrl).toBe(RUN_URL)
+  })
+
+  it('baseline JSON validation — missing databaseId in baseline entry falls back to createdAt heuristic', async () => {
+    const triggerTime = new Date('2026-05-25T10:00:00Z')
+    const createdAt = new Date(triggerTime.getTime() + 5000).toISOString()
+
+    let callIndex = 0
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      callIndex++
+      if (callIndex === 1) {
+        // baseline entry missing databaseId — schema rejects it, baselineId stays null
+        return makeSmokeChild('[{"id":100}]', '', 0)
+      }
+      if (callIndex === 2) {
+        return makeSmokeChild('', '', 0)
+      }
+      if (callIndex === 3) {
+        return makeSmokeChild(
+          makeSmokeRunList([{databaseId: 1, status: 'completed', conclusion: 'success', url: RUN_URL, createdAt}]),
+          '',
+          0,
+        )
+      }
+      return makeSmokeChild('ack', '', 0)
+    })
+
+    const result = await runSmokeTest(REPO, MODEL, {_testDelayMs: 0, _testTriggerTime: triggerTime})
+
+    // Schema rejects missing databaseId → baselineId stays null → createdAt heuristic → run found → pass
+    expect(result.kind).toBe('pass')
+    expect(result.runUrl).toBe(RUN_URL)
+  })
 })

--- a/packages/cli/src/commands/cliproxy/setup/smoke-test.ts
+++ b/packages/cli/src/commands/cliproxy/setup/smoke-test.ts
@@ -18,8 +18,6 @@ const ghRunEntrySchema = z.object({
   createdAt: z.string(),
 })
 
-const pollRunListSchema = z.array(ghRunEntrySchema)
-
 // Exported for tests only.
 export type GhRunEntry = z.infer<typeof ghRunEntrySchema>
 
@@ -133,11 +131,17 @@ export async function runSmokeTest(
         pollChild.exited,
       ])
       if (pollExit === 0) {
-        const parseResult = pollRunListSchema.safeParse(JSON.parse(pollStdout))
-        if (parseResult.success) {
-          pollRuns = parseResult.data
+        const rawParsed: unknown = JSON.parse(pollStdout)
+        if (Array.isArray(rawParsed)) {
+          // Validate each entry independently so a single malformed row does not
+          // discard the whole batch — dropping a legitimate matching run would be
+          // worse than skipping the bad entry.
+          pollRuns = rawParsed.flatMap(entry => {
+            const entryResult = ghRunEntrySchema.safeParse(entry)
+            return entryResult.success ? [entryResult.data] : []
+          })
         }
-        // If schema validation fails, pollRuns stays [] — retry on next poll
+        // Non-array payload or all entries malformed → pollRuns stays [] — retry on next poll
       }
     } catch {
       // Parse/network error — retry on next poll

--- a/packages/cli/src/commands/cliproxy/setup/smoke-test.ts
+++ b/packages/cli/src/commands/cliproxy/setup/smoke-test.ts
@@ -1,18 +1,27 @@
 /// <reference types="bun" />
 
+import {z} from 'zod'
+
 export type SmokeResult =
   | {kind: 'pass'; message: string; runUrl: string}
   | {kind: 'fail'; message: string; runUrl: string}
   | {kind: 'unverified'; message: string; runUrl?: string}
 
+// Zod schemas for gh CLI JSON output — single source of truth.
+const baselineRunSchema = z.array(z.object({databaseId: z.number()}))
+
+const ghRunEntrySchema = z.object({
+  databaseId: z.number(),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+  url: z.string(),
+  createdAt: z.string(),
+})
+
+const pollRunListSchema = z.array(ghRunEntrySchema)
+
 // Exported for tests only.
-export interface GhRunEntry {
-  databaseId: number
-  status: string
-  conclusion: string | null
-  url: string
-  createdAt: string
-}
+export type GhRunEntry = z.infer<typeof ghRunEntrySchema>
 
 // Exported for tests only. Override poll delays and trigger time.
 export interface SmokeTestInternals {
@@ -66,10 +75,11 @@ export async function runSmokeTest(
       baselineChild.exited,
     ])
     if (baselineExit === 0) {
-      const parsed = JSON.parse(baselineStdout) as {databaseId: number}[]
-      if (parsed.length > 0 && parsed[0]) {
-        baselineId = parsed[0].databaseId
+      const parseResult = baselineRunSchema.safeParse(JSON.parse(baselineStdout))
+      if (parseResult.success && parseResult.data.length > 0 && parseResult.data[0]) {
+        baselineId = parseResult.data[0].databaseId
       }
+      // If schema validation fails, baselineId stays null — we'll use createdAt heuristic
     }
     // If baseline call fails, baselineId stays null — we'll use createdAt heuristic
   } catch {
@@ -123,7 +133,11 @@ export async function runSmokeTest(
         pollChild.exited,
       ])
       if (pollExit === 0) {
-        pollRuns = JSON.parse(pollStdout) as GhRunEntry[]
+        const parseResult = pollRunListSchema.safeParse(JSON.parse(pollStdout))
+        if (parseResult.success) {
+          pollRuns = parseResult.data
+        }
+        // If schema validation fails, pollRuns stays [] — retry on next poll
       }
     } catch {
       // Parse/network error — retry on next poll


### PR DESCRIPTION
## What

Three type-safety and reliability follow-ups for `cliproxy setup`, closing the next batch of items tracked in #311.

### Injectable interactive plan

The interactive setup wizard builds its plan through `buildInteractivePlan`, which called the provider and model prompts directly. That left two key-reuse confirmation behaviors untestable, so they were skipped. The provider/model prompts now route through the same injectable seam the rest of the wizard already uses, and the two behaviors are covered:

- The key-reuse confirmation shows a redacted key, never the raw token.
- Declining the key-reuse confirmation cancels before any GitHub write.

### Typed test doubles

The setup test files mocked `@clack/prompts` spies with `as any` under an eslint-disable header. Those are replaced with properly typed mock implementations — no `as any`, no disable headers.

### Validated smoke-test payloads

The smoke test parsed `gh run list` output with unchecked casts. It now validates each run entry against a schema. A malformed entry is dropped individually rather than discarding the whole batch, so one bad row never hides a legitimate matching run, and a fully unexpected payload degrades to an `unverified` result instead of misreading fields.

## Tests

789 pass, 0 fail. New coverage: the two interactive key-reuse behaviors, individually-validated poll entries (one malformed entry alongside a valid matching run), and malformed/missing-field payload degradation.
