### PR TITLE
feat(umami): self-hosted Umami analytics deployment

### DIFF
--- a/.changeset/umami-analytics-deploy.md
+++ b/.changeset/umami-analytics-deploy.md
@@ -1,0 +1,7 @@
+---
+'@marcusrbrown/infra': minor
+---
+
+Add `umami` commands for the self-hosted Umami analytics deployment at `metrics.fro.bot`.
+
+`infra umami status` reports the Docker Compose service health over SSH, `infra umami deploy` triggers the deploy (remote workflow by default, or `--local`), and `infra umami logs` streams container logs. The unified `infra status` now includes a `umami` row and a `umami` key under `--json`.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,22 @@
       changelogUrl: 'https://github.com/caddyserver/caddy/releases',
       groupName: null,
     },
+    {
+      description: ['Add changelog context for Umami Docker image updates'],
+      matchDatasources: ['docker'],
+      matchPackageNames: ['umamisoftware/umami'],
+      sourceUrl: 'https://github.com/umami-software/umami',
+      changelogUrl: 'https://github.com/umami-software/umami/releases',
+      groupName: null,
+    },
+    {
+      description: ['Add changelog context for Postgres Docker image updates'],
+      matchDatasources: ['docker'],
+      matchPackageNames: ['postgres'],
+      sourceUrl: 'https://github.com/postgres/postgres',
+      changelogUrl: 'https://www.postgresql.org/docs/release/',
+      groupName: null,
+    },
   ],
   // postUpgradeTasks run after Renovate applies file changes but before the commit.
   // For github-actions manager updates (workflow SHA pins), Renovate does NOT run

--- a/.github/workflows/deploy-umami.yaml
+++ b/.github/workflows/deploy-umami.yaml
@@ -1,0 +1,95 @@
+name: Deploy Umami
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      UMAMI_SSH_KEY:
+        required: true
+      UMAMI_DOMAIN:
+        required: true
+      UMAMI_APP_SECRET:
+        required: true
+      UMAMI_DB_PASSWORD:
+        required: true
+      UMAMI_ADMIN_PASSWORD:
+        required: true
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      umami: ${{ steps.filter.outputs.umami }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: every
+          filters: |
+            umami:
+              - 'apps/umami/**'
+              - '!apps/umami/**/*.md'
+              - '!apps/umami/**/*.test.ts'
+              - '!apps/umami/**/__fixtures__/**'
+              - '!apps/umami/**/__snapshots__/**'
+
+  deploy-umami:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
+      needs.detect-changes.outputs.umami == 'true'
+    runs-on: ubuntu-latest
+    environment: umami
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate required secrets
+        env:
+          UMAMI_SSH_KEY: ${{ secrets.UMAMI_SSH_KEY }}
+          UMAMI_DOMAIN: ${{ secrets.UMAMI_DOMAIN }}
+          UMAMI_APP_SECRET: ${{ secrets.UMAMI_APP_SECRET }}
+          UMAMI_DB_PASSWORD: ${{ secrets.UMAMI_DB_PASSWORD }}
+          UMAMI_ADMIN_PASSWORD: ${{ secrets.UMAMI_ADMIN_PASSWORD }}
+        run: |
+          missing=()
+          [[ -n "${UMAMI_SSH_KEY}" ]] || missing+=("UMAMI_SSH_KEY")
+          [[ -n "${UMAMI_DOMAIN}" ]] || missing+=("UMAMI_DOMAIN")
+          [[ -n "${UMAMI_APP_SECRET}" ]] || missing+=("UMAMI_APP_SECRET")
+          [[ -n "${UMAMI_DB_PASSWORD}" ]] || missing+=("UMAMI_DB_PASSWORD")
+          [[ -n "${UMAMI_ADMIN_PASSWORD}" ]] || missing+=("UMAMI_ADMIN_PASSWORD")
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Configure SSH known_hosts
+        run: mkdir -p ~/.ssh && cp .github/known_hosts ~/.ssh/known_hosts
+
+      - name: Deploy umami
+        run: bun run --cwd apps/umami deploy
+        env:
+          UMAMI_SSH_KEY: ${{ secrets.UMAMI_SSH_KEY }}
+          UMAMI_DOMAIN: ${{ secrets.UMAMI_DOMAIN }}
+          UMAMI_APP_SECRET: ${{ secrets.UMAMI_APP_SECRET }}
+          UMAMI_DB_PASSWORD: ${{ secrets.UMAMI_DB_PASSWORD }}
+          UMAMI_ADMIN_PASSWORD: ${{ secrets.UMAMI_ADMIN_PASSWORD }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## OVERVIEW
 
-Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation, CLIProxyAPI (Claude proxy) management, Fro Bot gateway deployment, and operational CLI with MCP bridge. Deploys to `box.heatvision.co` (KeeWeb), `cliproxy.fro.bot` (CLIProxyAPI on DigitalOcean), and `gateway.fro.bot` (Fro Bot gateway on DigitalOcean).
+Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation, CLIProxyAPI (Claude proxy) management, Fro Bot gateway deployment, Umami analytics, and operational CLI with MCP bridge. Deploys to `box.heatvision.co` (KeeWeb), `cliproxy.fro.bot` (CLIProxyAPI on DigitalOcean), `gateway.fro.bot` (Fro Bot gateway on DigitalOcean), and `metrics.fro.bot` (Umami analytics on DigitalOcean).
 
 ## STRUCTURE
 
@@ -14,6 +14,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 ├── apps/keeweb/        KeeWeb deploy package (see apps/keeweb/AGENTS.md)
 ├── apps/cliproxy/      CLIProxyAPI deploy package (see apps/cliproxy/AGENTS.md)
 ├── apps/gateway/       Fro Bot gateway deploy package (see apps/gateway/AGENTS.md)
+├── apps/umami/         Umami analytics deploy package (see apps/umami/AGENTS.md)
 ├── packages/cli/       @marcusrbrown/infra CLI (see packages/cli/AGENTS.md)
 ├── packages/shared/    Shared provisioning helpers (see packages/shared/AGENTS.md)
 ├── docs/               Brainstorms → plans → solutions (compound learning)
@@ -40,6 +41,9 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 | Check gateway health | `bunx @marcusrbrown/infra gateway status` | SSH, docker compose ps, service states |
 | Trigger gateway deploy | `bunx @marcusrbrown/infra gateway deploy` | Remote (default) or `--local` |
 | Gateway operator docs | `apps/gateway/AGENTS.md` | Deploy flow, provisioning, CA restore, anti-patterns |
+| Check umami health | `bunx @marcusrbrown/infra umami status` | SSH, docker compose ps, service states |
+| Trigger umami deploy | `bunx @marcusrbrown/infra umami deploy` | Remote (default) or `--local` |
+| Umami operator docs | `apps/umami/AGENTS.md` | Deploy flow, admin rotation, DB-password runbook, privacy baseline |
 | Unified status | `bunx @marcusrbrown/infra status` | All deployments, `--json` for machine output |
 | Add workflow | `.github/workflows/` | Use `.yaml` extension, SHA-pin all actions |
 | Configure ESLint | `eslint.config.ts` | Flat config via `@bfra.me/eslint-config` |
@@ -109,6 +113,9 @@ bunx @marcusrbrown/infra gateway deploy           # Trigger gateway deploy (GitH
 bunx @marcusrbrown/infra gateway logs gateway     # Stream gateway service logs (--tail N)
 bunx @marcusrbrown/infra gateway backup --include-ca  # Pull mitmproxy CA cert + key as tarball
 bunx @marcusrbrown/infra gateway restore --include-ca --input FILE  # Restore CA from tarball
+bunx @marcusrbrown/infra umami status             # SSH, docker compose ps, service states
+bunx @marcusrbrown/infra umami deploy             # Trigger umami deploy (GitHub Actions)
+bunx @marcusrbrown/infra umami logs               # Stream umami service logs (--tail N)
 bunx @marcusrbrown/infra status                   # Unified status (all deployments)
 bunx @marcusrbrown/infra status --json            # Machine-readable status
 bunx @marcusrbrown/infra mcp                      # Start MCP server
@@ -120,6 +127,7 @@ bun run apps/keeweb/server/setup-deploy-user.ts # Provision deploy user on serve
 - `DROPBOX_APP_SECRET` and `DEPLOY_SSH_KEY` are GitHub Actions secrets scoped to `keeweb` environment.
 - `CLIPROXY_SSH_KEY`, `CLIPROXY_MANAGEMENT_KEY`, and `CLIPROXY_DOMAIN` are scoped to `cliproxy` environment.
 - `GATEWAY_SSH_KEY`, `DISCORD_TOKEN`, `DISCORD_APPLICATION_ID`, `DISCORD_GUILD_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_BUCKET`, `S3_REGION`, and `GATEWAY_HOST` are scoped to `gateway` environment. Optional: `S3_ENDPOINT`, `OBJECT_STORE_HOSTS`.
+- `UMAMI_SSH_KEY`, `UMAMI_DOMAIN`, `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, and `UMAMI_ADMIN_PASSWORD` are scoped to `umami` environment. `UMAMI_DB_PASSWORD` is volume-coupled — rotate only via the `ALTER USER` runbook in `apps/umami/AGENTS.md`.
 - `OPENCODE_AUTH_JSON`, `OPENCODE_CONFIG`, `OMO_PROVIDERS`, `FRO_BOT_PAT` are repo-level secrets. `FRO_BOT_MODEL` is a repo variable.
 - `OPENCODE_CONFIG` must set `baseURL` with `/v1` suffix: `{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}`.
 - `APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `DIGITALOCEAN_ACCESS_TOKEN`, `NPM_TOKEN` are repo-level secrets.

--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -23,20 +23,28 @@ PRs). Postgres port `5432` is never published to the host.
 
 1. Validates env (`UMAMI_DOMAIN`, `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, `UMAMI_ADMIN_PASSWORD`,
    plus SSH context) and the host string before any SSH argv is built.
-2. Opens a multiplexed SSH connection (ControlMaster) reused across all calls.
-3. Resolves `UMAMI_DOMAIN` DNS and fails fast if it does not resolve.
-4. Materializes `/opt/umami/.env` over SSH **stdin** (never argv); secret values are
+2. DNS preflight — resolves `UMAMI_DOMAIN` and fails fast if it does not resolve.
+3. ControlMaster SSH multiplexing setup — a shared socket is created; subsequent steps reuse it.
+4. Remote prep: `mkdir -p /opt/umami/config` on the droplet.
+5. **DB-password fingerprint guard** — reads the sentinel from the remote (aborts on read/transport
+   error), compares to the current password hash; aborts on mismatch to prevent volume-bricking
+   password changes.
+6. Materializes `/opt/umami/.env` over SSH **stdin** (never argv); secret values are
    boundary-validated (no newlines/shell metacharacters).
-5. Uploads `docker-compose.yaml` + `config/Caddyfile`.
-6. **DB-password fingerprint guard** (see below) — refuses a volume-bricking password change.
-7. `docker compose pull && docker compose up -d --wait --wait-timeout 180`. Container health
-   (`pg_isready` + the umami `/api/heartbeat` localhost healthcheck) via `--wait` is the
-   authoritative success signal; 180s covers first-boot DB migrations.
-8. Writes the DB-password fingerprint sentinel after a healthy `up`.
-9. **Bounded public-HTTPS probe** — retries `https://$UMAMI_DOMAIN/api/heartbeat` for `{"ok":true}`.
-   On first-deploy Caddy ACME issuance lag it emits a WARNING and still succeeds (containers are
-   already healthy); `compose up` is idempotent, so re-running once the cert lands is safe.
-10. **Automated admin-password rotation** (see below).
+7. Uploads `docker-compose.yaml` + `config/Caddyfile`.
+8. `docker compose pull` (all images).
+9. `docker compose up -d --wait --wait-timeout 180 db umami` — Caddy is **NOT** started yet;
+   container health (`pg_isready` + umami `/api/heartbeat`) via `--wait` is the authoritative
+   success signal; 180s covers first-boot DB migrations.
+10. **Automated admin-password rotation** (fail-closed; runs before Caddy to prevent any public
+    default-credential window).
+11. `docker compose up -d --wait --wait-timeout 180 caddy` — publicly exposes the service **only
+    after** rotation is complete.
+12. Writes the DB-password fingerprint sentinel (hash only, never the password itself) after a
+    healthy `up`.
+13. **Bounded public-HTTPS probe** — retries `https://$UMAMI_DOMAIN/api/heartbeat` for `{"ok":true}`.
+    On first-deploy Caddy ACME issuance lag it emits a WARNING and still succeeds (containers are
+    already healthy); `compose up` is idempotent, so re-running once the cert lands is safe.
 
 In CI the SSH key is materialized from `UMAMI_SSH_KEY` to a temp file with a trailing newline
 (GitHub strips trailing whitespace from secrets) and `chmod 600`; locally it uses the ssh-agent.

--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -1,5 +1,158 @@
 # apps/umami — Umami analytics deploy
 
-Privacy-respecting, self-hosted [Umami](https://umami.is) web analytics for `metrics.fro.bot`. Docker Compose stack (umami + postgres + caddy) on a dedicated DigitalOcean droplet, fronted by Caddy for automatic HTTPS.
+Privacy-respecting, self-hosted [Umami](https://umami.is) web analytics for `metrics.fro.bot`. A
+three-service Docker Compose stack (umami + postgres + caddy) on a dedicated DigitalOcean droplet,
+fronted by Caddy for automatic HTTPS. No public surface other than `:80`/`:443`; Postgres is
+reachable only on the internal compose network.
 
-> Scaffolding in progress. Operator runbook, deploy flow, and anti-patterns are documented in the full pass.
+## Stack
+
+| Service | Image | Role |
+| --- | --- | --- |
+| `umami` | `umamisoftware/umami:3.1.0` (digest-pinned) | App + tracker API on `:3000` |
+| `db` | `postgres:15-alpine` (digest-pinned) | Postgres; named volume `umami-db-data` |
+| `caddy` | `caddy:2.11.3-alpine` (digest-pinned) | Auto-TLS reverse proxy `:443 → umami:3000` |
+
+Images are pinned to numbered tags by digest and tracked by Renovate (changelog-linked, standalone
+PRs). Postgres port `5432` is never published to the host.
+
+## Deploy flow
+
+`bun run --cwd apps/umami deploy` (or the **Deploy Umami** GitHub workflow, default path-filtered on
+`apps/umami/**`). The deploy:
+
+1. Validates env (`UMAMI_DOMAIN`, `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, `UMAMI_ADMIN_PASSWORD`,
+   plus SSH context) and the host string before any SSH argv is built.
+2. Opens a multiplexed SSH connection (ControlMaster) reused across all calls.
+3. Resolves `UMAMI_DOMAIN` DNS and fails fast if it does not resolve.
+4. Materializes `/opt/umami/.env` over SSH **stdin** (never argv); secret values are
+   boundary-validated (no newlines/shell metacharacters).
+5. Uploads `docker-compose.yaml` + `config/Caddyfile`.
+6. **DB-password fingerprint guard** (see below) — refuses a volume-bricking password change.
+7. `docker compose pull && docker compose up -d --wait --wait-timeout 180`. Container health
+   (`pg_isready` + the umami `/api/heartbeat` localhost healthcheck) via `--wait` is the
+   authoritative success signal; 180s covers first-boot DB migrations.
+8. Writes the DB-password fingerprint sentinel after a healthy `up`.
+9. **Bounded public-HTTPS probe** — retries `https://$UMAMI_DOMAIN/api/heartbeat` for `{"ok":true}`.
+   On first-deploy Caddy ACME issuance lag it emits a WARNING and still succeeds (containers are
+   already healthy); `compose up` is idempotent, so re-running once the cert lands is safe.
+10. **Automated admin-password rotation** (see below).
+
+In CI the SSH key is materialized from `UMAMI_SSH_KEY` to a temp file with a trailing newline
+(GitHub strips trailing whitespace from secrets) and `chmod 600`; locally it uses the ssh-agent.
+
+## Automated admin-password rotation
+
+Umami first-boot creates a default `admin` / `umami` account. After the stack is healthy, the deploy
+logs in to `http://localhost:3000` **on the droplet** (never the public host) with the defaults; if
+that succeeds it sets the admin password to `UMAMI_ADMIN_PASSWORD` via the authenticated
+password-update endpoint. If the default login fails, the password is already rotated and the step is
+skipped (idempotent). After the first deploy, log in at `https://metrics.fro.bot` with `admin` /
+`UMAMI_ADMIN_PASSWORD`. The admin password travels via SSH stdin / request body, never argv.
+
+> The exact v3.1.0 auth endpoints (`/api/auth/login`, `/api/users/me/password`) are pinned as
+> constants in `src/deploy.ts`; re-verify them against the running image on a major Umami bump.
+
+## Privacy baseline
+
+This deployment exists to keep analytics private. The compose layer sets:
+
+- `DISABLE_TELEMETRY=1` — disables Umami's own anonymous phone-home.
+- `PRIVATE_MODE=1` — blocks outbound external calls (e.g. favicon/location lookups).
+
+Umami is cookie-free and respects Do-Not-Track by default. The downstream tracker `<script>` tag
+should also carry the privacy attributes. Drop this into the consuming site, filling in the website
+ID captured from the Umami dashboard:
+
+```html
+<script
+  defer
+  src="https://metrics.fro.bot/script.js"
+  data-website-id="REPLACE_WITH_WEBSITE_ID"
+  data-do-not-track="true"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
+```
+
+- `data-do-not-track` — honor the browser DNT signal.
+- `data-exclude-search` — strip query strings from recorded URLs.
+- `data-exclude-hash` — strip URL fragments.
+
+## Data persistence & retention
+
+All analytics data lives in the `umami-db-data` Postgres volume. The deploy only ever runs `up -d` —
+**never `down -v`** — so the volume survives every deploy and image bump.
+
+**Retention policy:** data is retained indefinitely by deliberate choice — this is low-volume,
+already-minimized (privacy flags on, cookie-free, no PII collected by design) first-party analytics,
+so there is no automatic expiry. To prune on demand, delete a website's events from the Umami
+dashboard, or run a dated `DELETE` against the `website_event` table over SSH.
+
+## Backup & restore (manual runbook)
+
+Backup (over SSH, from a workstation with the deploy key):
+
+```bash
+ssh root@metrics.fro.bot \
+  "docker compose -f /opt/umami/docker-compose.yaml exec -T db pg_dump -U umami umami" \
+  | gzip > umami-$(date +%Y%m%d).sql.gz
+```
+
+Restore into a running stack:
+
+```bash
+gunzip -c umami-YYYYMMDD.sql.gz \
+  | ssh root@metrics.fro.bot \
+    "docker compose -f /opt/umami/docker-compose.yaml exec -T db psql -U umami umami"
+```
+
+## Secret rotation
+
+- **`UMAMI_DB_PASSWORD` (DANGER — volume-coupled).** Postgres records the password when the volume is
+  first initialized. Naively changing the secret breaks DB auth, so `deploy.ts` keeps a salted-hash
+  sentinel at `/opt/umami/.db-password-fingerprint` and **refuses to deploy** when the secret no
+  longer matches. To rotate:
+  1. Deploy is still running on the old secret. SSH in and rotate the role in place:
+     `docker compose -f /opt/umami/docker-compose.yaml exec -T db psql -U umami -c "ALTER USER umami WITH PASSWORD '<new>';"`
+  2. Update the `UMAMI_DB_PASSWORD` secret (GitHub environment + local `.env`).
+  3. Remove the stale sentinel so the next deploy re-initializes it:
+     `ssh root@metrics.fro.bot rm -f /opt/umami/.db-password-fingerprint`
+  4. Redeploy — it writes the new fingerprint after a healthy `up`.
+- **`UMAMI_APP_SECRET`.** Rotating invalidates all existing sessions (users re-authenticate). Update
+  the secret and redeploy.
+- **`UMAMI_ADMIN_PASSWORD`.** Change it in-app, or update the secret and redeploy (the rotation step
+  is idempotent and will not re-apply once the default login no longer works — to force a reset,
+  change it from the Umami account settings).
+
+## Upgrade flow
+
+Renovate opens standalone, changelog-linked PRs for the `umamisoftware/umami` and `postgres` images.
+Merge → the Deploy Umami workflow ships the new digest. On a **major** Umami bump, re-verify the
+admin auth-endpoint constants in `src/deploy.ts` against the new image.
+
+## CLI
+
+| Command | Purpose |
+| --- | --- |
+| `infra umami status` | SSH `docker compose ps` → service/state/health rows (MCP-exposed) |
+| `infra umami deploy` | Dispatch the Deploy Umami workflow (default) or `--local` |
+| `infra umami logs` | Stream container logs (CI-guarded; emits a sensitive-data warning) |
+
+`infra status` includes a `umami` row (and a `umami` key under `--json`).
+
+## Provisioning
+
+One-time: `bun run --cwd apps/umami provision` creates the `s-1vcpu-1gb` droplet (image
+`docker-20-04`), selects the SSH key by name (`UMAMI_SSH_KEY_NAME`, default `fro-bot-umami`), waits
+for SSH, and pins both the domain and droplet-IP host keys into `.github/known_hosts` (commit the
+result before the first CI deploy). Resize to `s-1vcpu-2gb` if Postgres memory pressure appears.
+
+## Anti-patterns
+
+- **Never `docker compose down -v`** — destroys the `umami-db-data` Postgres volume (all analytics).
+- **Never rotate `UMAMI_DB_PASSWORD` by just changing the secret** — use the `ALTER USER` runbook; the
+  fingerprint guard will otherwise refuse the deploy.
+- **Never publish Postgres `5432`** to the host — it stays on the internal compose network.
+- **Never put secret values in SSH argv** — the deploy pipes them via stdin.
+- **Never remove `DISABLE_TELEMETRY` / `PRIVATE_MODE`** — they are the reason this is self-hosted.

--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -1,0 +1,5 @@
+# apps/umami — Umami analytics deploy
+
+Privacy-respecting, self-hosted [Umami](https://umami.is) web analytics for `metrics.fro.bot`. Docker Compose stack (umami + postgres + caddy) on a dedicated DigitalOcean droplet, fronted by Caddy for automatic HTTPS.
+
+> Scaffolding in progress. Operator runbook, deploy flow, and anti-patterns are documented in the full pass.

--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -50,8 +50,9 @@ password-update endpoint. If the default login fails, the password is already ro
 skipped (idempotent). After the first deploy, log in at `https://metrics.fro.bot` with `admin` /
 `UMAMI_ADMIN_PASSWORD`. The admin password travels via SSH stdin / request body, never argv.
 
-> The exact v3.1.0 auth endpoints (`/api/auth/login`, `/api/users/me/password`) are pinned as
-> constants in `src/deploy.ts`; re-verify them against the running image on a major Umami bump.
+> The exact v3.1.0 auth endpoints (`/api/auth/login`, `/api/me/password`) are pinned as
+> constants in `src/deploy.ts`; the password-change endpoint uses body `{currentPassword, newPassword}` (Bearer auth).
+> Re-verify them against the running image on a major Umami bump.
 
 ## Privacy baseline
 

--- a/apps/umami/config/Caddyfile
+++ b/apps/umami/config/Caddyfile
@@ -1,0 +1,4 @@
+# Caddy automatically provisions and renews HTTPS certificates via Let's Encrypt.
+{$UMAMI_DOMAIN} {
+  reverse_proxy umami:3000
+}

--- a/apps/umami/docker-compose.yaml
+++ b/apps/umami/docker-compose.yaml
@@ -1,0 +1,65 @@
+services:
+  caddy:
+    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+      - ./config/Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - umami
+
+  umami:
+    image: umamisoftware/umami:3.1.0@sha256:81119aa498f910fe1bf590c0974dfd00afd3f3563dd55528bb3bd002f06f3dfb
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-}
+      DATABASE_TYPE: postgresql
+      APP_SECRET: ${APP_SECRET:-}
+      # Privacy posture: disable Umami's anonymous telemetry phone-home and
+      # block outbound external calls (favicon/location lookups). Both are the
+      # reason this deployment exists — do not remove.
+      DISABLE_TELEMETRY: '1'
+      PRIVATE_MODE: '1'
+    depends_on:
+      db:
+        condition: service_healthy
+    init: true
+    healthcheck:
+      test: [CMD-SHELL, 'curl -f http://localhost:3000/api/heartbeat || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  db:
+    image: postgres:15-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
+    restart: unless-stopped
+    # Postgres is reachable only on the internal compose network — port 5432 is
+    # intentionally NOT published to the host. Caddy terminates TLS and proxies
+    # to umami:3000; the database has no external surface.
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+    volumes:
+      - umami-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: [CMD-SHELL, 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  caddy_data:
+  caddy_config:
+  umami-db-data:

--- a/apps/umami/package.json
+++ b/apps/umami/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@marcusrbrown/infra-umami",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "bun run src/deploy.ts",
+    "provision": "bun run server/provision-droplet.ts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
+  }
+}

--- a/apps/umami/server/provision-droplet.test.ts
+++ b/apps/umami/server/provision-droplet.test.ts
@@ -1,0 +1,335 @@
+import {dropletExists} from '@marcusrbrown/infra-shared/server/droplet-helpers'
+import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
+
+import {validateUmamiHost} from '../src/host'
+import {
+  checkDropletExistence,
+  getUmamiSshFingerprint,
+  parseProvisionArgs,
+  validateRequiredEnv,
+} from './provision-droplet'
+
+// ---------------------------------------------------------------------------
+// Env helpers
+// ---------------------------------------------------------------------------
+
+const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'UMAMI_DOMAIN', 'UMAMI_SSH_KEY_NAME'] as const
+type ManagedEnvKey = (typeof managedEnvKeys)[number]
+
+let savedEnv: Partial<Record<ManagedEnvKey, string | undefined>>
+
+function saveEnv(): void {
+  savedEnv = Object.fromEntries(managedEnvKeys.map(k => [k, process.env[k]]))
+}
+
+function restoreEnv(): void {
+  for (const key of managedEnvKeys) {
+    const value = savedEnv[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spawn mock helpers
+// ---------------------------------------------------------------------------
+
+interface SpawnResult {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+function makeSpawnResult(stdout: string, exitCode: number): SpawnResult {
+  const enc = new TextEncoder()
+  return {
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(enc.encode(stdout))
+        controller.close()
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('provision-droplet', () => {
+  beforeEach(() => {
+    saveEnv()
+  })
+
+  afterEach(() => {
+    restoreEnv()
+  })
+
+  // -------------------------------------------------------------------------
+  // import.meta.main guard — importing the module must not trigger side effects
+  // -------------------------------------------------------------------------
+
+  describe('import guard', () => {
+    it('exports named functions without triggering doctl or network calls on import', () => {
+      // The mere fact that this test file imports from ./provision-droplet
+      // and we reach this assertion proves the import.meta.main guard works.
+      expect(typeof validateRequiredEnv).toBe('function')
+      expect(typeof parseProvisionArgs).toBe('function')
+      expect(typeof getUmamiSshFingerprint).toBe('function')
+      expect(typeof checkDropletExistence).toBe('function')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // validateRequiredEnv
+  // -------------------------------------------------------------------------
+
+  describe('required environment variable validation', () => {
+    it('returns empty array when all required vars are present', () => {
+      const missing = validateRequiredEnv({
+        DIGITALOCEAN_ACCESS_TOKEN: 'tok_abc',
+        UMAMI_DOMAIN: 'metrics.fro.bot',
+      })
+
+      expect(missing).toEqual([])
+    })
+
+    it('reports DIGITALOCEAN_ACCESS_TOKEN when it is missing', () => {
+      const missing = validateRequiredEnv({
+        UMAMI_DOMAIN: 'metrics.fro.bot',
+      })
+
+      expect(missing).toContain('DIGITALOCEAN_ACCESS_TOKEN')
+    })
+
+    it('reports UMAMI_DOMAIN when it is missing', () => {
+      const missing = validateRequiredEnv({
+        DIGITALOCEAN_ACCESS_TOKEN: 'tok_abc',
+      })
+
+      expect(missing).toContain('UMAMI_DOMAIN')
+    })
+
+    it('reports both vars when both are missing', () => {
+      const missing = validateRequiredEnv({})
+
+      expect(missing).toContain('DIGITALOCEAN_ACCESS_TOKEN')
+      expect(missing).toContain('UMAMI_DOMAIN')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // parseProvisionArgs
+  // -------------------------------------------------------------------------
+
+  describe('provision argument parsing', () => {
+    it('parses --force and --check-exists flags', () => {
+      expect(parseProvisionArgs(['--force', '--check-exists'])).toEqual({force: true, checkExists: true})
+      expect(parseProvisionArgs([])).toEqual({force: false, checkExists: false})
+    })
+
+    it('rejects unknown arguments instead of silently ignoring them', () => {
+      expect(() => parseProvisionArgs(['--unknown'])).toThrow(/Unknown provision argument/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // droplet existence guard
+  // -------------------------------------------------------------------------
+
+  describe('droplet existence guard', () => {
+    it('returns true when the umami droplet is listed', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('umami\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const result = await dropletExists('umami')
+
+      expect(result).toBe(true)
+      spawnSpy.mockRestore()
+    })
+
+    it('returns false when the umami droplet is not listed', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('other-droplet\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const result = await dropletExists('umami')
+
+      expect(result).toBe(false)
+      spawnSpy.mockRestore()
+    })
+
+    it('aborts without creating when droplet exists and --force is not set', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('umami\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const exists = await dropletExists('umami')
+      expect(exists).toBe(true)
+
+      const force = false
+      const wouldAbort = exists && !force
+      expect(wouldAbort).toBe(true)
+
+      // Only one spawn call (the list) — no create call made
+      expect(spawnSpy).toHaveBeenCalledTimes(1)
+
+      spawnSpy.mockRestore()
+    })
+
+    it('proceeds past the guard when --force is set even if droplet exists', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('umami\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const exists = await dropletExists('umami')
+      expect(exists).toBe(true)
+
+      const force = true
+      const wouldAbort = exists && !force
+      expect(wouldAbort).toBe(false)
+
+      spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // checkDropletExistence
+  // -------------------------------------------------------------------------
+
+  describe('checkDropletExistence', () => {
+    it('returns machine-readable existence state without provisioning side effects', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult('umami\n', 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const state = await checkDropletExistence('umami')
+
+      expect(state).toEqual({name: 'umami', exists: true})
+      expect(spawnSpy).toHaveBeenCalledTimes(1)
+      expect(spawnSpy.mock.calls[0]?.[0]).toEqual([
+        'doctl',
+        'compute',
+        'droplet',
+        'list',
+        '--format',
+        'Name',
+        '--no-header',
+      ])
+
+      spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // SSH key selection by name
+  // -------------------------------------------------------------------------
+
+  const MULTI_KEY_OUTPUT = [
+    'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+    'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+    'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+    'fro-bot-umami                                         e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+  ].join('\n')
+
+  describe('SSH key selection by name', () => {
+    it('uses fro-bot-umami as the default key name when no argument is provided', async () => {
+      delete process.env.UMAMI_SSH_KEY_NAME
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getUmamiSshFingerprint()
+
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('uses UMAMI_SSH_KEY_NAME env var when no argument is passed', async () => {
+      process.env.UMAMI_SSH_KEY_NAME = 'custom-umami-key'
+
+      const customKeyOutput = [
+        'fro-bot-umami                                         e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b',
+        'custom-umami-key                                      aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(customKeyOutput, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getUmamiSshFingerprint()
+
+      expect(fp).toBe('aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99')
+      expect(fp).not.toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('matches the named key when explicitly passed as argument', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+        makeSpawnResult(MULTI_KEY_OUTPUT, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      const fp = await getUmamiSshFingerprint('fro-bot-umami')
+
+      expect(fp).toBe('e0:8f:0d:fa:d1:b3:ab:b4:83:9b:06:b6:20:82:91:2b')
+      expect(fp).not.toBe('91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9')
+
+      spawnSpy.mockRestore()
+    })
+
+    it('throws when the named key is not found in the account', async () => {
+      const threeOtherKeys = [
+        'UltraVisor                                            91:53:2a:06:50:89:54:68:e6:c5:fd:c4:1a:c5:87:c9',
+        'ShellFish@Marcus-iPad-01052022                        d4:a0:81:f4:7c:ba:17:f5:71:6a:17:75:e3:20:19:2e',
+        'id_rsa-root@monica.marcusrbrown.com via hypervisor    b8:02:e3:70:3a:6a:60:45:09:e0:8b:01:d8:09:43:22',
+      ].join('\n')
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValueOnce(
+        makeSpawnResult(threeOtherKeys, 0) as ReturnType<typeof Bun.spawn>,
+      )
+
+      await expect(getUmamiSshFingerprint('fro-bot-umami')).rejects.toThrow(/not found/)
+
+      spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // validateUmamiHost — provision script must call this before pinHostKeys
+  // -------------------------------------------------------------------------
+
+  describe('host validation security invariant', () => {
+    it('accepts a valid hostname', () => {
+      expect(validateUmamiHost('metrics.fro.bot')).toBe('metrics.fro.bot')
+    })
+
+    it('throws on empty string', () => {
+      expect(() => validateUmamiHost('')).toThrow(/empty/)
+    })
+
+    it('throws on a value starting with a dash (ssh flag injection)', () => {
+      expect(() => validateUmamiHost('-oProxyCommand=evil')).toThrow(/Invalid UMAMI_DOMAIN/)
+    })
+
+    it('throws on a value containing shell metacharacters', () => {
+      expect(() => validateUmamiHost('host;rm -rf /')).toThrow(/Invalid UMAMI_DOMAIN/)
+    })
+
+    it('throws on a value containing a space', () => {
+      expect(() => validateUmamiHost('host name')).toThrow(/Invalid UMAMI_DOMAIN/)
+    })
+  })
+})

--- a/apps/umami/server/provision-droplet.ts
+++ b/apps/umami/server/provision-droplet.ts
@@ -86,7 +86,6 @@ function printOperatorSetupMessage(dropletIp: string, umamiHost: string): void {
   console.log(`\nBefore triggering a CI deploy, set the following in the \u001B[1mumami\u001B[0m GitHub Environment:\n`)
   console.log('  Required secrets:')
   console.log('    UMAMI_SSH_KEY            — private key for SSH access to the droplet')
-  console.log('\n  Required variables:')
   console.log(`    UMAMI_DOMAIN             — ${umamiHost}`)
   console.log('\nCommit the updated .github/known_hosts before triggering a CI deploy.')
 }

--- a/apps/umami/server/provision-droplet.ts
+++ b/apps/umami/server/provision-droplet.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env bun
+
+import {join, resolve} from 'node:path'
+
+import {
+  dropletExists,
+  getDropletIpWithWait,
+  getSshFingerprint,
+  pinHostKeys,
+  run,
+  validateDoctl,
+  waitForSsh,
+} from '@marcusrbrown/infra-shared/server/droplet-helpers'
+
+import {validateUmamiHost} from '../src/host'
+
+const DROPLET_NAME = 'umami'
+const DROPLET_IMAGE = 'docker-20-04'
+const DROPLET_SIZE = 's-1vcpu-1gb'
+const DROPLET_REGION = 'nyc1'
+const REMOTE_USER = process.env.REMOTE_USER ?? 'root'
+
+export interface ProvisionArgs {
+  force: boolean
+  checkExists: boolean
+}
+
+export interface DropletExistenceState {
+  name: string
+  exists: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Umami-specific helpers (exported for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that all required environment variables are present.
+ * Returns the list of missing variable names (empty = all present).
+ */
+export function validateRequiredEnv(env: Partial<Record<string, string>>): string[] {
+  const required = ['DIGITALOCEAN_ACCESS_TOKEN', 'UMAMI_DOMAIN']
+  return required.filter(key => !env[key])
+}
+
+/**
+ * Non-mutating state probe for agents/CI. Only lists droplets — does not
+ * validate provision-only environment, create anything, pin host keys, or
+ * wait for SSH.
+ */
+export async function checkDropletExistence(name = DROPLET_NAME): Promise<DropletExistenceState> {
+  return {name, exists: await dropletExists(name)}
+}
+
+/**
+ * Parses provisioning arguments. Unknown flags are rejected so automated
+ * callers don't accidentally get a default mutating run after a typo.
+ */
+export function parseProvisionArgs(args: string[]): ProvisionArgs {
+  const known = new Set(['--force', '--check-exists'])
+  const unknown = args.filter(arg => !known.has(arg))
+
+  if (unknown.length > 0) {
+    throw new Error(`Unknown provision argument(s): ${unknown.join(', ')}. Supported: --force, --check-exists`)
+  }
+
+  return {
+    force: args.includes('--force'),
+    checkExists: args.includes('--check-exists'),
+  }
+}
+
+/**
+ * Returns the SSH key fingerprint for the umami key.
+ * Accepts an optional keyName override; falls back to UMAMI_SSH_KEY_NAME env
+ * var, then to the default 'fro-bot-umami'.
+ */
+export async function getUmamiSshFingerprint(keyName?: string): Promise<string> {
+  const name = keyName ?? process.env.UMAMI_SSH_KEY_NAME ?? 'fro-bot-umami'
+  return getSshFingerprint(name, {envVarName: 'UMAMI_SSH_KEY_NAME', defaultKeyName: 'fro-bot-umami'})
+}
+
+function printOperatorSetupMessage(dropletIp: string, umamiHost: string): void {
+  console.log('\n\u001B[1;32m✓\u001B[0m Umami droplet provisioned\n')
+  console.log(`Droplet IP: ${dropletIp}`)
+  console.log(`\nBefore triggering a CI deploy, set the following in the \u001B[1mumami\u001B[0m GitHub Environment:\n`)
+  console.log('  Required secrets:')
+  console.log('    UMAMI_SSH_KEY            — private key for SSH access to the droplet')
+  console.log('\n  Required variables:')
+  console.log(`    UMAMI_DOMAIN             — ${umamiHost}`)
+  console.log('\nCommit the updated .github/known_hosts before triggering a CI deploy.')
+}
+
+// ---------------------------------------------------------------------------
+// Main orchestrator
+// ---------------------------------------------------------------------------
+
+export async function main(): Promise<void> {
+  const {force, checkExists} = parseProvisionArgs(process.argv.slice(2))
+
+  await validateDoctl({checkAuth: true})
+
+  if (checkExists) {
+    console.log(JSON.stringify(await checkDropletExistence()))
+    return
+  }
+
+  const missing = validateRequiredEnv(process.env as Record<string, string>)
+  if (missing.length > 0) {
+    console.error(`\u001B[1;31mError:\u001B[0m Missing required environment variables: ${missing.join(', ')}`)
+    console.error('Set them before running this script.')
+    process.exit(1)
+  }
+
+  const umamiHost = validateUmamiHost(process.env.UMAMI_DOMAIN ?? '')
+
+  const exists = await dropletExists(DROPLET_NAME)
+
+  if (exists && !force) {
+    console.error(
+      `\u001B[1;31mError:\u001B[0m Droplet "${DROPLET_NAME}" already exists. Use --force to proceed anyway.`,
+    )
+    process.exit(1)
+  }
+
+  if (exists && force) {
+    console.warn(`⚠️  --force: Proceeding despite existing droplet "${DROPLET_NAME}"`)
+  }
+
+  if (!exists) {
+    const fingerprint = await getUmamiSshFingerprint()
+    await run(`Creating droplet ${DROPLET_NAME}`, [
+      'doctl',
+      'compute',
+      'droplet',
+      'create',
+      DROPLET_NAME,
+      '--image',
+      DROPLET_IMAGE,
+      '--size',
+      DROPLET_SIZE,
+      '--region',
+      DROPLET_REGION,
+      '--ssh-keys',
+      fingerprint,
+      '--wait',
+    ])
+  }
+
+  const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
+  await waitForSsh(dropletIp, REMOTE_USER)
+
+  const knownHostsPath = resolve(join(import.meta.dir, '..', '..', '..', '.github', 'known_hosts'))
+  await pinHostKeys(umamiHost, dropletIp, knownHostsPath, {
+    marker: `# umami droplet (${dropletIp} / ${umamiHost})`,
+  })
+
+  printOperatorSetupMessage(dropletIp, umamiHost)
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/apps/umami/src/deploy.test.ts
+++ b/apps/umami/src/deploy.test.ts
@@ -519,13 +519,12 @@ describe('public HTTPS probe', () => {
 // ─── admin password rotation ──────────────────────────────────────────────────
 
 describe('admin password rotation', () => {
-  it('skips rotation when default login fails (already rotated)', async () => {
+  it('skips rotation when default login returns no token (already rotated)', async () => {
     const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
-    // The admin rotation SSH call returns exit code 1 (login failed)
+    // idx 7: login returns exit 0 with no token → treated as already rotated (skip)
     const responses = Array.from({length: 15}, () => makeSpawnResult())
     responses[1] = makeSpawnResult(matchingFingerprint)
-    // Admin rotation call: login fails (non-zero exit or empty token in stdout)
-    responses[8] = makeSpawnResult('{"token":null}', '', 0)
+    responses[7] = makeSpawnResult('{"token":null}', '', 0)
 
     const {spawnFn} = makeFakeSpawn(responses)
 
@@ -542,10 +541,18 @@ describe('admin password rotation', () => {
 
   it('does not place admin password in any argv', async () => {
     const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
-    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
     responses[1] = makeSpawnResult(matchingFingerprint)
-    // Simulate successful login returning a token
-    responses[8] = makeSpawnResult(JSON.stringify({token: 'test-jwt-token'}), '', 0)
+    // idx 7: login succeeds with token
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'test-jwt-token'}), '', 0)
+    // idx 8: write curl config (token via stdin)
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify new password login succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify default login fails
+    responses[11] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
 
     const {spawnFn, calls} = makeFakeSpawn(responses)
 
@@ -588,5 +595,464 @@ describe('CI mode with UMAMI_SSH_KEY', () => {
     for (const call of calls) {
       expect(call.cmd.join(' ')).not.toContain('AAAA-UNIQUE-KEY-CONTENT')
     }
+  })
+})
+
+// ─── exec-reachability: rotation runs inside the umami container ──────────────
+//
+// New call order (with matching fingerprint, already-rotated login):
+//   0: mkdir
+//   1: cat fingerprint
+//   2: write .env
+//   3: scp compose
+//   4: scp Caddyfile
+//   5: compose pull
+//   6: compose up db umami
+//   7: rotation login curl  ← rotation starts here
+//   8: compose up caddy     ← after rotation
+//   9: write sentinel
+//
+// With full rotation (login succeeds):
+//   7: rotation login curl
+//   8: write curl config (token via stdin)
+//   9: update curl
+//  10: verify new password login
+//  11: verify default login fails
+//  12: compose up caddy
+//  13: write sentinel
+
+describe('rotation runs inside the umami container via docker compose exec', () => {
+  it('login curl runs inside the umami container, not on the droplet host', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login already rotated (exit 22)
+    responses[7] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    const loginCall = calls.find(c => c.cmd.join(' ').includes('/api/auth/login'))
+    expect(loginCall).toBeDefined()
+    // Must use docker compose exec -T umami, not bare ssh curl on host
+    const cmdStr = loginCall?.cmd.join(' ') ?? ''
+    expect(cmdStr).toContain('docker compose exec')
+    expect(cmdStr).toContain('-T')
+    expect(cmdStr).toContain('umami')
+  })
+
+  it('password-update curl runs inside the umami container, not on the droplet host', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login succeeds with token
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'tok-abc'}), '', 0)
+    // idx 8: write curl config file (token via stdin)
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update curl succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify: re-login with new password succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify: re-login with default umami fails (exit 22)
+    responses[11] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    const updateCall = calls.find(c => c.cmd.join(' ').includes('/api/users/me/password'))
+    expect(updateCall).toBeDefined()
+    const cmdStr = updateCall?.cmd.join(' ') ?? ''
+    expect(cmdStr).toContain('docker compose exec')
+    expect(cmdStr).toContain('-T')
+    expect(cmdStr).toContain('umami')
+  })
+})
+
+// ─── G1: rotation fails closed ────────────────────────────────────────────────
+
+describe('rotation fails closed on connection/transport failure', () => {
+  it('throws when login curl cannot reach umami (connection refused, exit 7)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login curl: connection refused (exit 7)
+    responses[7] = makeSpawnResult('', 'curl: (7) Failed to connect', 7)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/cannot reach umami|admin credentials/)
+  })
+
+  it('skips rotation (idempotent) when login is cleanly rejected with HTTP 401 (exit 22)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login curl: HTTP 401 → --fail-with-body exits 22
+    responses[7] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws when password-update curl fails (non-zero exit)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login succeeds
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'tok-abc'}), '', 0)
+    // idx 8: write curl config file
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update curl fails
+    responses[9] = makeSpawnResult('', 'error', 1)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('throws when post-rotation verification fails (new password login rejected)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login with default succeeds
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'tok-abc'}), '', 0)
+    // idx 8: write curl config file
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify: re-login with new password FAILS (exit 22 — bad creds)
+    responses[10] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/verification|rotate|password/)
+  })
+
+  it('throws when post-rotation verification finds default password still works', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login with default succeeds
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'tok-abc'}), '', 0)
+    // idx 8: write curl config file
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify: re-login with new password succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify: re-login with default umami STILL succeeds (rotation didn't stick)
+    responses[11] = makeSpawnResult(JSON.stringify({token: 'tok-default-still-works'}), '', 0)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/verification|rotate|password/)
+  })
+})
+
+// ─── G2: Caddy starts after rotation (no public default-credential window) ────
+
+describe('Caddy starts after admin rotation completes', () => {
+  it('caddy up spawn happens after the rotation login curl spawn', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login already rotated (exit 22)
+    responses[7] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    const caddyUpIdx = calls.findIndex(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('docker compose up') && s.includes('caddy')
+    })
+    const loginCurlIdx = calls.findIndex(c => c.cmd.join(' ').includes('/api/auth/login'))
+
+    expect(caddyUpIdx).toBeGreaterThan(-1)
+    expect(loginCurlIdx).toBeGreaterThan(-1)
+    // caddy up must come AFTER the login curl
+    expect(caddyUpIdx).toBeGreaterThan(loginCurlIdx)
+  })
+
+  it('db and umami start before caddy (internal-only phase)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login already rotated
+    responses[7] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    const dbUmamiUpIdx = calls.findIndex(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('docker compose up') && s.includes('db') && s.includes('umami') && !s.includes('caddy')
+    })
+    const caddyUpIdx = calls.findIndex(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('docker compose up') && s.includes('caddy')
+    })
+
+    expect(dbUmamiUpIdx).toBeGreaterThan(-1)
+    expect(caddyUpIdx).toBeGreaterThan(-1)
+    expect(dbUmamiUpIdx).toBeLessThan(caddyUpIdx)
+  })
+})
+
+// ─── G3: fingerprint guard must not bypass on read error ─────────────────────
+
+describe('fingerprint guard does not bypass on SSH/read error', () => {
+  it('proceeds on first deploy when sentinel is absent (file-not-found exit)', async () => {
+    // cat returns exit 1 with "No such file" — treated as first deploy
+    // Call order: mkdir(0), cat-absent(1), write-env(2), scp-compose(3),
+    //   scp-Caddyfile(4), compose-pull(5), compose-up-db-umami(6),
+    //   rotation-login-exit22(7), compose-up-caddy(8), write-sentinel(9)
+    const responses = [
+      makeSpawnResult(), // 0: mkdir
+      makeSpawnResult('cat: /opt/umami/.db-password-fingerprint: No such file or directory', '', 1), // 1: cat absent
+      makeSpawnResult(), // 2: write .env
+      makeSpawnResult(), // 3: scp compose
+      makeSpawnResult(), // 4: scp Caddyfile
+      makeSpawnResult(), // 5: compose pull
+      makeSpawnResult(), // 6: compose up db umami
+      makeSpawnResult('{"message":"Incorrect username or password"}', '', 22), // 7: rotation login (already rotated)
+      makeSpawnResult(), // 8: compose up caddy
+      makeSpawnResult(), // 9: write sentinel
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('aborts with a distinct message when SSH transport fails reading sentinel (non-missing error)', async () => {
+    // exit 255 = SSH connection failure (not file-not-found)
+    const responses = [
+      makeSpawnResult(), // mkdir
+      makeSpawnResult('ssh: connect to host metrics.fro.bot port 22: Connection refused', '', 255), // ssh failure
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/fingerprint|sentinel|read|ssh/i)
+  })
+
+  it('proceeds when sentinel is present and fingerprint matches', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint, '', 0)
+    // idx 7: login already rotated
+    responses[7] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('aborts when sentinel is present and fingerprint mismatches', async () => {
+    const wrongFingerprint = computeDbPasswordFingerprint('completely-different-password')
+    const responses = [
+      makeSpawnResult(), // mkdir
+      makeSpawnResult(wrongFingerprint, '', 0), // cat sentinel (mismatch)
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/fingerprint|rotation runbook|password/)
+  })
+})
+
+// ─── G4: URL-encode DB password in DATABASE_URL ───────────────────────────────
+
+describe('DATABASE_URL percent-encodes URL-reserved characters in the password', () => {
+  it('encodes @ : / # % in the DATABASE_URL userinfo but keeps POSTGRES_PASSWORD raw', () => {
+    const specialPassword = 'p@ss:w/o#r%d'
+    const contents = buildEnvFileContents({
+      appSecret: 'secret',
+      dbPassword: specialPassword,
+      domain: 'metrics.fro.bot',
+    })
+
+    // POSTGRES_PASSWORD must be the raw value
+    expect(contents).toContain(`POSTGRES_PASSWORD=${specialPassword}\n`)
+
+    // DATABASE_URL must percent-encode the reserved chars
+    const urlLine = contents.split('\n').find(l => l.startsWith('DATABASE_URL=')) ?? ''
+    expect(urlLine).toBeTruthy()
+    // Extract the userinfo portion (between :// and @db)
+    const match = urlLine.match(/DATABASE_URL=postgresql:\/\/umami:(.+)@db:5432\/umami/)
+    expect(match).toBeDefined()
+    const encodedPassword = match?.[1] ?? ''
+    expect(encodedPassword).toBeTruthy()
+
+    // Must not contain raw reserved chars
+    expect(encodedPassword).not.toContain('@')
+    expect(encodedPassword).not.toContain(':')
+    expect(encodedPassword).not.toContain('/')
+    expect(encodedPassword).not.toContain('#')
+    // % is only allowed as part of percent-encoding sequences
+    expect(encodedPassword).toMatch(/^[\w\-.~!$&'()*+,;=%]+$/)
+    // Must decode back to the original password
+    expect(decodeURIComponent(encodedPassword)).toBe(specialPassword)
+  })
+
+  it('leaves a plain alphanumeric password unchanged in DATABASE_URL', () => {
+    const plainPassword = 'plainpassword123'
+    const contents = buildEnvFileContents({
+      appSecret: 'secret',
+      dbPassword: plainPassword,
+      domain: 'metrics.fro.bot',
+    })
+    expect(contents).toContain(`DATABASE_URL=postgresql://umami:${plainPassword}@db:5432/umami\n`)
+  })
+})
+
+// ─── G5: bearer token never in argv ──────────────────────────────────────────
+
+describe('bearer token never appears in any spawned argv', () => {
+  it('does not place the JWT bearer token in any argv during rotation', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.UNIQUE-TOKEN-VALUE'
+    // idx 7: login succeeds with token
+    responses[7] = makeSpawnResult(JSON.stringify({token: fakeToken}), '', 0)
+    // idx 8: write curl config file (token via stdin)
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update curl succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify: new password login succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify: default umami login fails
+    responses[11] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    for (const call of calls) {
+      expect(call.cmd.join(' ')).not.toContain(fakeToken)
+      expect(call.cmd.join(' ')).not.toContain('UNIQUE-TOKEN-VALUE')
+    }
+  })
+
+  it('passes the bearer token via stdin (curl config file), not argv', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.UNIQUE-TOKEN-VALUE'
+    // idx 7: login succeeds with token
+    responses[7] = makeSpawnResult(JSON.stringify({token: fakeToken}), '', 0)
+    // idx 8: write curl config file
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update curl succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify: new password login succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify: default umami login fails
+    responses[11] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    // The token must appear in stdin of some call (the curl config write)
+    const tokenInStdin = calls.some(c => c.stdinData.includes(fakeToken))
+    expect(tokenInStdin).toBe(true)
   })
 })

--- a/apps/umami/src/deploy.test.ts
+++ b/apps/umami/src/deploy.test.ts
@@ -1,0 +1,592 @@
+import {describe, expect, it} from 'bun:test'
+
+import {
+  buildEnvFileContents,
+  computeDbPasswordFingerprint,
+  deploy,
+  validateEnv,
+  validateSecretValue,
+  type SpawnFn,
+  type SpawnResult,
+} from './deploy'
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const VALID_ENV = {
+  PATH: '/usr/bin:/bin',
+  HOME: '/root',
+  SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+  UMAMI_DOMAIN: 'metrics.fro.bot',
+  UMAMI_APP_SECRET: 'supersecretappkey',
+  UMAMI_DB_PASSWORD: 'dbpassword123',
+  UMAMI_ADMIN_PASSWORD: 'adminpassword456',
+}
+
+/** Builds a fake SpawnResult that exits 0 with given stdout. */
+function makeSpawnResult(stdout = '', stderr = '', exitCode = 0): SpawnResult {
+  const encoder = new TextEncoder()
+  return {
+    stdout: new ReadableStream({
+      start(controller) {
+        if (stdout) controller.enqueue(encoder.encode(stdout))
+        controller.close()
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        if (stderr) controller.enqueue(encoder.encode(stderr))
+        controller.close()
+      },
+    }),
+    stdin: {
+      write: (_data: Uint8Array) => {},
+      end: () => {},
+    },
+    exited: Promise.resolve(exitCode),
+  }
+}
+
+/** Tracks all spawn calls for assertion. */
+interface SpawnCall {
+  cmd: string[]
+  stdinData: string
+}
+
+/**
+ * Builds a fake SpawnFn that records all calls and returns configurable results.
+ * `responses` is consumed in order; the last entry is repeated for remaining calls.
+ */
+function makeFakeSpawn(responses: SpawnResult[]): {spawnFn: SpawnFn; calls: SpawnCall[]} {
+  const calls: SpawnCall[] = []
+  let idx = 0
+
+  const spawnFn: SpawnFn = (cmd, opts) => {
+    const call: SpawnCall = {cmd: [...cmd], stdinData: ''}
+
+    const result = responses[Math.min(idx++, responses.length - 1)] ?? makeSpawnResult()
+
+    if (opts.stdin === 'pipe') {
+      // Intercept stdin writes
+      const originalWrite = result.stdin?.write
+      const originalEnd = result.stdin?.end
+      const chunks: Uint8Array[] = []
+
+      const interceptedResult: SpawnResult = {
+        ...result,
+        stdin: {
+          write: (data: Uint8Array) => {
+            chunks.push(data)
+            originalWrite?.(data)
+          },
+          end: () => {
+            call.stdinData = new TextDecoder().decode(
+              chunks.reduce((acc, c) => {
+                const merged = new Uint8Array(acc.length + c.length)
+                merged.set(acc)
+                merged.set(c, acc.length)
+                return merged
+              }, new Uint8Array()),
+            )
+            originalEnd?.()
+          },
+        },
+      }
+      calls.push(call)
+      return interceptedResult
+    }
+
+    calls.push(call)
+    return result
+  }
+
+  return {spawnFn, calls}
+}
+
+/** Fake DNS resolver that always resolves. */
+const resolvesOk = async (_host: string): Promise<void> => {}
+
+/** Fake DNS resolver that always fails. */
+const resolveFails = async (host: string): Promise<void> => {
+  throw new Error(`DNS resolution failed for ${host}`)
+}
+
+/** Fake fetch that returns {"ok":true} for heartbeat. */
+const fetchHeartbeatOk = async (_url: string, _opts?: RequestInit): Promise<Response> => {
+  return new Response(JSON.stringify({ok: true}), {status: 200})
+}
+
+/** Fake fetch that always times out / fails. */
+const fetchHeartbeatFail = async (_url: string, _opts?: RequestInit): Promise<Response> => {
+  throw new Error('fetch failed')
+}
+
+// ─── env validation ───────────────────────────────────────────────────────────
+
+describe('env validation', () => {
+  it('accepts a fully valid env', () => {
+    expect(() => validateEnv(VALID_ENV)).not.toThrow()
+  })
+
+  it('throws a specific message when UMAMI_DOMAIN is missing', () => {
+    const env = {...VALID_ENV, UMAMI_DOMAIN: ''}
+    expect(() => validateEnv(env)).toThrow('UMAMI_DOMAIN')
+  })
+
+  it('throws a specific message when UMAMI_APP_SECRET is missing', () => {
+    const env = {...VALID_ENV, UMAMI_APP_SECRET: ''}
+    expect(() => validateEnv(env)).toThrow('UMAMI_APP_SECRET')
+  })
+
+  it('throws a specific message when UMAMI_DB_PASSWORD is missing', () => {
+    const env = {...VALID_ENV, UMAMI_DB_PASSWORD: ''}
+    expect(() => validateEnv(env)).toThrow('UMAMI_DB_PASSWORD')
+  })
+
+  it('throws a specific message when UMAMI_ADMIN_PASSWORD is missing', () => {
+    const env = {...VALID_ENV, UMAMI_ADMIN_PASSWORD: ''}
+    expect(() => validateEnv(env)).toThrow('UMAMI_ADMIN_PASSWORD')
+  })
+
+  it('throws when PATH is missing', () => {
+    const env = {...VALID_ENV, PATH: ''}
+    expect(() => validateEnv(env)).toThrow('PATH')
+  })
+
+  it('throws when HOME is missing', () => {
+    const env = {...VALID_ENV, HOME: ''}
+    expect(() => validateEnv(env)).toThrow('HOME')
+  })
+
+  it('throws when SSH context is missing (no SSH_AUTH_SOCK, no UMAMI_SSH_KEY)', () => {
+    const env = {...VALID_ENV, SSH_AUTH_SOCK: ''}
+    expect(() => validateEnv(env)).toThrow(/SSH_AUTH_SOCK|UMAMI_SSH_KEY/)
+  })
+
+  it('accepts CI mode with UMAMI_SSH_KEY and no SSH_AUTH_SOCK', () => {
+    const env = {...VALID_ENV, SSH_AUTH_SOCK: '', UMAMI_SSH_KEY: 'ssh-ed25519 AAAA...'}
+    expect(() => validateEnv(env)).not.toThrow()
+  })
+})
+
+// ─── secret boundary validation ───────────────────────────────────────────────
+
+describe('secret boundary validation', () => {
+  it('accepts a clean secret value', () => {
+    expect(() => validateSecretValue('cleanpassword123', 'TEST')).not.toThrow()
+  })
+
+  it('rejects a value containing a newline', () => {
+    expect(() => validateSecretValue('bad\nvalue', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a carriage return', () => {
+    expect(() => validateSecretValue('bad\rvalue', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a backtick', () => {
+    expect(() => validateSecretValue('bad`value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a dollar sign', () => {
+    expect(() => validateSecretValue('bad$value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a pipe', () => {
+    expect(() => validateSecretValue('bad|value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a semicolon', () => {
+    expect(() => validateSecretValue('bad;value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing an ampersand', () => {
+    expect(() => validateSecretValue('bad&value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a single quote', () => {
+    expect(() => validateSecretValue("bad'value", 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a double quote', () => {
+    expect(() => validateSecretValue('bad"value', 'TEST')).toThrow()
+  })
+
+  it('rejects a value containing a backslash', () => {
+    expect(() => validateSecretValue(String.raw`bad\value`, 'TEST')).toThrow()
+  })
+})
+
+// ─── host validation guard ────────────────────────────────────────────────────
+
+describe('host validation guard', () => {
+  it('rejects a ProxyCommand-injection domain before any SSH argv is built', () => {
+    const env = {...VALID_ENV, UMAMI_DOMAIN: '-oProxyCommand=x'}
+    expect(() => validateEnv(env)).toThrow()
+  })
+})
+
+// ─── .env file contents ───────────────────────────────────────────────────────
+
+describe('.env file contents', () => {
+  it('builds the correct .env file contents', () => {
+    const contents = buildEnvFileContents({
+      appSecret: 'mysecret',
+      dbPassword: 'mydbpw',
+      domain: 'metrics.fro.bot',
+    })
+    expect(contents).toContain('APP_SECRET=mysecret\n')
+    expect(contents).toContain('POSTGRES_PASSWORD=mydbpw\n')
+    expect(contents).toContain('DATABASE_URL=postgresql://umami:mydbpw@db:5432/umami\n')
+    expect(contents).toContain('UMAMI_DOMAIN=metrics.fro.bot\n')
+  })
+
+  it('does not contain any extra keys beyond the four required', () => {
+    const contents = buildEnvFileContents({
+      appSecret: 'a',
+      dbPassword: 'b',
+      domain: 'c.example.com',
+    })
+    const lines = contents
+      .split('\n')
+      .filter(l => l.trim())
+      .map(l => l.split('=')[0])
+    expect(lines.sort()).toEqual(['APP_SECRET', 'DATABASE_URL', 'POSTGRES_PASSWORD', 'UMAMI_DOMAIN'].sort())
+  })
+})
+
+// ─── db-password fingerprint guard ───────────────────────────────────────────
+
+describe('db-password fingerprint guard', () => {
+  it('computes a deterministic fingerprint for a given password', () => {
+    const fp1 = computeDbPasswordFingerprint('mypassword')
+    const fp2 = computeDbPasswordFingerprint('mypassword')
+    expect(fp1).toBe(fp2)
+  })
+
+  it('produces different fingerprints for different passwords', () => {
+    const fp1 = computeDbPasswordFingerprint('password1')
+    const fp2 = computeDbPasswordFingerprint('password2')
+    expect(fp1).not.toBe(fp2)
+  })
+
+  it('fingerprint does not contain the password', () => {
+    const password = 'supersecretpassword'
+    const fp = computeDbPasswordFingerprint(password)
+    expect(fp).not.toContain(password)
+  })
+
+  it('refuses to deploy when sentinel exists with non-matching fingerprint', async () => {
+    const existingFingerprint = computeDbPasswordFingerprint('oldpassword')
+    const responses = [
+      makeSpawnResult(), // mkdir -p
+      makeSpawnResult(existingFingerprint), // cat sentinel
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/rotation runbook|fingerprint|password/)
+  })
+
+  it('does not invoke compose when fingerprint guard blocks deploy', async () => {
+    const existingFingerprint = computeDbPasswordFingerprint('oldpassword')
+    const responses = [
+      makeSpawnResult(), // mkdir -p
+      makeSpawnResult(existingFingerprint), // cat sentinel
+    ]
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow()
+
+    const composeCalls = calls.filter(c => c.cmd.some(arg => arg.includes('docker compose')))
+    expect(composeCalls).toHaveLength(0)
+  })
+
+  it('proceeds on first deploy when no sentinel exists', async () => {
+    // All commands succeed; sentinel cat returns empty (no sentinel)
+    const successResult = makeSpawnResult()
+    const emptySentinelResult = makeSpawnResult('') // cat returns empty
+    const responses = [
+      successResult, // mkdir -p /opt/umami/config
+      emptySentinelResult, // cat sentinel (absent)
+      makeSpawnResult(), // write .env via stdin
+      makeSpawnResult(), // scp docker-compose.yaml
+      makeSpawnResult(), // scp Caddyfile
+      makeSpawnResult(), // docker compose pull
+      makeSpawnResult(), // docker compose up
+      makeSpawnResult(), // write fingerprint sentinel
+      makeSpawnResult(), // admin rotation: ssh curl login
+      makeSpawnResult(), // admin rotation: ssh curl password update (if needed)
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    // Should not throw
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('writes fingerprint sentinel after healthy compose up, never the password', async () => {
+    const successResult = makeSpawnResult()
+    const emptySentinelResult = makeSpawnResult('')
+    const responses = [
+      successResult, // mkdir
+      emptySentinelResult, // cat sentinel
+      makeSpawnResult(), // write .env
+      makeSpawnResult(), // scp compose
+      makeSpawnResult(), // scp Caddyfile
+      makeSpawnResult(), // compose pull
+      makeSpawnResult(), // compose up
+      makeSpawnResult(), // write sentinel
+      makeSpawnResult(), // admin rotation
+      makeSpawnResult(),
+    ]
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    // Find the sentinel write call (stdin pipe call writing a hash)
+    const sentinelWrite = calls.find(c => {
+      const isStdinCall = c.stdinData.length > 0
+      const isNotEnvFile = !c.stdinData.includes('APP_SECRET')
+      const isNotAdminRotation = !c.stdinData.includes('password')
+      return isStdinCall && isNotEnvFile && isNotAdminRotation
+    })
+
+    expect(sentinelWrite).toBeDefined()
+    // Sentinel must not contain the password
+    expect(sentinelWrite?.stdinData).not.toContain(VALID_ENV.UMAMI_DB_PASSWORD)
+    // Sentinel should look like a hex hash
+    expect(sentinelWrite?.stdinData.trim()).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('proceeds normally when fingerprint matches', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = [
+      makeSpawnResult(), // mkdir
+      makeSpawnResult(matchingFingerprint), // cat sentinel (matches)
+      makeSpawnResult(), // write .env
+      makeSpawnResult(), // scp compose
+      makeSpawnResult(), // scp Caddyfile
+      makeSpawnResult(), // compose pull
+      makeSpawnResult(), // compose up
+      makeSpawnResult(), // write sentinel
+      makeSpawnResult(), // admin rotation
+      makeSpawnResult(),
+    ]
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+// ─── secrets never in argv ────────────────────────────────────────────────────
+
+describe('secrets never in argv', () => {
+  it('does not place any secret value in any constructed argv', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint) // sentinel matches
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    const secrets = [VALID_ENV.UMAMI_APP_SECRET, VALID_ENV.UMAMI_DB_PASSWORD, VALID_ENV.UMAMI_ADMIN_PASSWORD]
+
+    for (const call of calls) {
+      for (const secret of secrets) {
+        const argvStr = call.cmd.join(' ')
+        expect(argvStr).not.toContain(secret)
+      }
+    }
+  })
+
+  it('places .env contents in stdin, not argv', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    // Find the .env write call
+    const envFileWrite = calls.find(c => c.stdinData.includes('APP_SECRET'))
+    expect(envFileWrite).toBeDefined()
+    // The secret must be in stdin, not in the cmd
+    expect(envFileWrite?.cmd.join(' ')).not.toContain(VALID_ENV.UMAMI_APP_SECRET)
+  })
+})
+
+// ─── DNS preflight ────────────────────────────────────────────────────────────
+
+describe('DNS preflight', () => {
+  it('fails fast with a clear message when DNS does not resolve', async () => {
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: makeFakeSpawn([makeSpawnResult()]).spawnFn,
+        resolve: resolveFails,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).rejects.toThrow(/DNS|resolve|metrics\.fro\.bot/)
+  })
+})
+
+// ─── Caddy ACME lag (public probe) ───────────────────────────────────────────
+
+describe('public HTTPS probe', () => {
+  it('succeeds with a warning when containers are healthy but public probe never returns ok', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    // Should resolve (not throw) even when fetch always fails
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatFail,
+        probeAttempts: 2,
+        probeIntervalMs: 10,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('succeeds without warning when public probe returns ok', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+        probeAttempts: 2,
+        probeIntervalMs: 10,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+// ─── admin password rotation ──────────────────────────────────────────────────
+
+describe('admin password rotation', () => {
+  it('skips rotation when default login fails (already rotated)', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    // The admin rotation SSH call returns exit code 1 (login failed)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // Admin rotation call: login fails (non-zero exit or empty token in stdout)
+    responses[8] = makeSpawnResult('{"token":null}', '', 0)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    // Should not throw — idempotent
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHeartbeatOk,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('does not place admin password in any argv', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // Simulate successful login returning a token
+    responses[8] = makeSpawnResult(JSON.stringify({token: 'test-jwt-token'}), '', 0)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    for (const call of calls) {
+      expect(call.cmd.join(' ')).not.toContain(VALID_ENV.UMAMI_ADMIN_PASSWORD)
+    }
+  })
+})
+
+// ─── CI mode (UMAMI_SSH_KEY) ──────────────────────────────────────────────────
+
+describe('CI mode with UMAMI_SSH_KEY', () => {
+  it('accepts CI env with UMAMI_SSH_KEY and no SSH_AUTH_SOCK', () => {
+    const env = {...VALID_ENV, SSH_AUTH_SOCK: '', UMAMI_SSH_KEY: 'ssh-ed25519 AAAA...'}
+    expect(() => validateEnv(env)).not.toThrow()
+  })
+
+  it('does not place the SSH key content in any argv', async () => {
+    const ciEnv = {...VALID_ENV, SSH_AUTH_SOCK: '', UMAMI_SSH_KEY: 'ssh-ed25519 AAAA-UNIQUE-KEY-CONTENT'}
+    const matchingFingerprint = computeDbPasswordFingerprint(ciEnv.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 15}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: ciEnv,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    for (const call of calls) {
+      expect(call.cmd.join(' ')).not.toContain('AAAA-UNIQUE-KEY-CONTENT')
+    }
+  })
+})

--- a/apps/umami/src/deploy.test.ts
+++ b/apps/umami/src/deploy.test.ts
@@ -166,6 +166,16 @@ describe('env validation', () => {
     const env = {...VALID_ENV, SSH_AUTH_SOCK: '', UMAMI_SSH_KEY: 'ssh-ed25519 AAAA...'}
     expect(() => validateEnv(env)).not.toThrow()
   })
+
+  it('rejects UMAMI_ADMIN_PASSWORD shorter than 8 characters', () => {
+    const env = {...VALID_ENV, UMAMI_ADMIN_PASSWORD: 'short'}
+    expect(() => validateEnv(env)).toThrow(/UMAMI_ADMIN_PASSWORD.*8 characters/)
+  })
+
+  it('accepts UMAMI_ADMIN_PASSWORD of exactly 8 characters', () => {
+    const env = {...VALID_ENV, UMAMI_ADMIN_PASSWORD: 'exactly8'}
+    expect(() => validateEnv(env)).not.toThrow()
+  })
 })
 
 // ─── secret boundary validation ───────────────────────────────────────────────
@@ -671,12 +681,45 @@ describe('rotation runs inside the umami container via docker compose exec', () 
       fetch: fetchHeartbeatOk,
     })
 
-    const updateCall = calls.find(c => c.cmd.join(' ').includes('/api/users/me/password'))
+    const updateCall = calls.find(c => c.cmd.join(' ').includes('/api/me/password'))
     expect(updateCall).toBeDefined()
     const cmdStr = updateCall?.cmd.join(' ') ?? ''
     expect(cmdStr).toContain('docker compose exec')
     expect(cmdStr).toContain('-T')
     expect(cmdStr).toContain('umami')
+  })
+
+  it('sends currentPassword and newPassword in the password-update request body', async () => {
+    const matchingFingerprint = computeDbPasswordFingerprint(VALID_ENV.UMAMI_DB_PASSWORD)
+    const responses = Array.from({length: 20}, () => makeSpawnResult())
+    responses[1] = makeSpawnResult(matchingFingerprint)
+    // idx 7: login succeeds with token
+    responses[7] = makeSpawnResult(JSON.stringify({token: 'tok-abc'}), '', 0)
+    // idx 8: write curl config file (token via stdin)
+    responses[8] = makeSpawnResult('', '', 0)
+    // idx 9: update curl succeeds
+    responses[9] = makeSpawnResult(JSON.stringify({ok: true}), '', 0)
+    // idx 10: verify new password login succeeds
+    responses[10] = makeSpawnResult(JSON.stringify({token: 'tok-new'}), '', 0)
+    // idx 11: verify default login fails (exit 22)
+    responses[11] = makeSpawnResult('{"message":"Incorrect username or password"}', '', 22)
+
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHeartbeatOk,
+    })
+
+    // Find the update call — stdin carries the request body
+    const updateCall = calls.find(c => c.cmd.join(' ').includes('/api/me/password'))
+    expect(updateCall).toBeDefined()
+    const body = JSON.parse(updateCall?.stdinData ?? '{}') as Record<string, string>
+    expect(body.currentPassword).toBe('umami')
+    expect(body.newPassword).toBe(VALID_ENV.UMAMI_ADMIN_PASSWORD)
+    expect(body).not.toHaveProperty('password')
   })
 })
 

--- a/apps/umami/src/deploy.ts
+++ b/apps/umami/src/deploy.ts
@@ -9,7 +9,7 @@ import {validateUmamiHost} from './host'
 // ─── Umami API endpoint constants ─────────────────────────────────────────────
 // TODO: verify exact v3.1.0 endpoint against running image on first deploy
 const UMAMI_LOGIN_PATH = '/api/auth/login'
-const UMAMI_PASSWORD_PATH = '/api/users/me/password'
+const UMAMI_PASSWORD_PATH = '/api/me/password'
 
 // ─── Remote paths ─────────────────────────────────────────────────────────────
 
@@ -142,6 +142,12 @@ export function validateEnv(env: Record<string, string>): ValidatedEnv {
   const adminPassword = env.UMAMI_ADMIN_PASSWORD
   if (!adminPassword) {
     throw new Error('UMAMI_ADMIN_PASSWORD is required for deploy')
+  }
+
+  if (adminPassword.length < 8) {
+    throw new Error(
+      'UMAMI_ADMIN_PASSWORD must be at least 8 characters — Umami v3.1.0 rejects shorter passwords on the password-change endpoint',
+    )
   }
 
   // Validate host before any SSH argv construction
@@ -487,7 +493,7 @@ async function rotateAdminPassword(
 
   // Step 3: Update password. New password travels via stdin; token via curl config file.
   // Cleanup of /tmp/uc happens in the same sh -c regardless of curl exit code.
-  const updateBody = JSON.stringify({password: adminPassword})
+  const updateBody = JSON.stringify({currentPassword: 'umami', newPassword: adminPassword})
   const updateCmd = sshCommand(
     host,
     `cd ${REMOTE_DIR} && docker compose exec -T umami sh -c 'curl -s --fail-with-body -X POST -H '"'"'Content-Type: application/json'"'"' -K /tmp/uc --data @- http://localhost:3000${UMAMI_PASSWORD_PATH}; rc=$?; rm -f /tmp/uc; exit $rc'`,

--- a/apps/umami/src/deploy.ts
+++ b/apps/umami/src/deploy.ts
@@ -1,0 +1,635 @@
+#!/usr/bin/env bun
+
+import {chmodSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {validateUmamiHost} from './host'
+
+// ─── Umami API endpoint constants ─────────────────────────────────────────────
+// TODO: verify exact v3.1.0 endpoint against running image on first deploy
+const UMAMI_LOGIN_PATH = '/api/auth/login'
+const UMAMI_PASSWORD_PATH = '/api/users/me/password'
+
+// ─── Remote paths ─────────────────────────────────────────────────────────────
+
+const REMOTE_DIR = '/opt/umami'
+const REMOTE_ENV_PATH = `${REMOTE_DIR}/.env`
+const REMOTE_COMPOSE_PATH = `${REMOTE_DIR}/docker-compose.yaml`
+const REMOTE_CONFIG_DIR = `${REMOTE_DIR}/config`
+const REMOTE_CADDYFILE_PATH = `${REMOTE_CONFIG_DIR}/Caddyfile`
+const REMOTE_FINGERPRINT_PATH = `${REMOTE_DIR}/.db-password-fingerprint`
+const DEFAULT_REMOTE_USER = 'root'
+
+// ─── Fingerprint salt ─────────────────────────────────────────────────────────
+// A fixed salt so the fingerprint is deterministic across deploys but not a
+// raw hash of the password (adds a tiny bit of preimage resistance).
+const FINGERPRINT_SALT = 'umami-db-pw-v1'
+
+// ─── Shell metacharacter deny-list ────────────────────────────────────────────
+// These characters are dangerous when interpolated into remote shell context.
+const SHELL_METACHAR_RE = /[\n\r`$|;&'"\\]/
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Minimal subset of Bun.Subprocess used by this script. */
+export interface SpawnResult {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  stdin?: {write: (data: Uint8Array) => void; end: () => void}
+  exited: Promise<number>
+}
+
+export interface SpawnOpts {
+  env: DeployEnv
+  stdout: 'pipe'
+  stderr: 'pipe'
+  stdin?: 'pipe'
+}
+
+/** Injectable spawn function — defaults to Bun.spawn. */
+export type SpawnFn = (cmd: string[], opts: SpawnOpts) => SpawnResult
+
+export interface DeployEnv {
+  readonly [key: string]: string
+  PATH: string
+  HOME: string
+  UMAMI_DOMAIN: string
+}
+
+export interface DeployOpts {
+  env?: Record<string, string>
+  spawn?: SpawnFn
+  /** Injectable DNS resolver — throws if host doesn't resolve. */
+  resolve?: (host: string) => Promise<void>
+  fetch?: (url: string, init?: RequestInit) => Promise<Response>
+  sleep?: (ms: number) => Promise<void>
+  /** Number of public HTTPS probe attempts (default: 6). */
+  probeAttempts?: number
+  /** Interval between probe attempts in ms (default: 10_000). */
+  probeIntervalMs?: number
+}
+
+// ─── Exported helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Validates that a secret value contains no shell metacharacters that would be
+ * dangerous when interpolated into a remote shell context.
+ *
+ * @throws {Error} with the variable name and the offending character.
+ */
+export function validateSecretValue(value: string, name: string): void {
+  const match = SHELL_METACHAR_RE.exec(value)
+  if (match) {
+    const char = JSON.stringify(match[0])
+    throw new Error(
+      `${name} contains a shell metacharacter (${char}) that is not allowed in secret values. ` +
+        'Remove the character before deploying.',
+    )
+  }
+}
+
+/** Validated, typed environment required for deploy. */
+export interface ValidatedEnv {
+  PATH: string
+  HOME: string
+  UMAMI_DOMAIN: string
+  UMAMI_APP_SECRET: string
+  UMAMI_DB_PASSWORD: string
+  UMAMI_ADMIN_PASSWORD: string
+  SSH_AUTH_SOCK?: string
+  UMAMI_SSH_KEY?: string
+}
+
+/**
+ * Validates all required environment variables are present and well-formed.
+ * Calls validateUmamiHost on UMAMI_DOMAIN before any SSH argv is constructed.
+ *
+ * @throws {Error} with a specific message naming the missing/invalid variable.
+ * @returns A typed ValidatedEnv with all required fields guaranteed non-empty.
+ */
+export function validateEnv(env: Record<string, string>): ValidatedEnv {
+  const path = env.PATH
+  if (!path) {
+    throw new Error('PATH is required for deploy')
+  }
+
+  const home = env.HOME
+  if (!home) {
+    throw new Error('HOME is required for deploy')
+  }
+
+  // SSH context: local mode needs SSH_AUTH_SOCK; CI mode needs UMAMI_SSH_KEY
+  if (!env.SSH_AUTH_SOCK && !env.UMAMI_SSH_KEY) {
+    throw new Error('SSH context is required: set SSH_AUTH_SOCK (local mode) or UMAMI_SSH_KEY (CI mode)')
+  }
+
+  const domain = env.UMAMI_DOMAIN
+  if (!domain) {
+    throw new Error('UMAMI_DOMAIN is required for deploy')
+  }
+
+  const appSecret = env.UMAMI_APP_SECRET
+  if (!appSecret) {
+    throw new Error('UMAMI_APP_SECRET is required for deploy')
+  }
+
+  const dbPassword = env.UMAMI_DB_PASSWORD
+  if (!dbPassword) {
+    throw new Error('UMAMI_DB_PASSWORD is required for deploy')
+  }
+
+  const adminPassword = env.UMAMI_ADMIN_PASSWORD
+  if (!adminPassword) {
+    throw new Error('UMAMI_ADMIN_PASSWORD is required for deploy')
+  }
+
+  // Validate host before any SSH argv construction
+  validateUmamiHost(domain)
+
+  return {
+    PATH: path,
+    HOME: home,
+    UMAMI_DOMAIN: domain,
+    UMAMI_APP_SECRET: appSecret,
+    UMAMI_DB_PASSWORD: dbPassword,
+    UMAMI_ADMIN_PASSWORD: adminPassword,
+    ...(env.SSH_AUTH_SOCK ? {SSH_AUTH_SOCK: env.SSH_AUTH_SOCK} : {}),
+    ...(env.UMAMI_SSH_KEY ? {UMAMI_SSH_KEY: env.UMAMI_SSH_KEY} : {}),
+  }
+}
+
+/**
+ * Builds the contents of the remote .env file.
+ * Secrets travel via SSH stdin — this function only assembles the string.
+ */
+export function buildEnvFileContents(opts: {appSecret: string; dbPassword: string; domain: string}): string {
+  return (
+    `APP_SECRET=${opts.appSecret}\n` +
+    `POSTGRES_PASSWORD=${opts.dbPassword}\n` +
+    `DATABASE_URL=postgresql://umami:${opts.dbPassword}@db:5432/umami\n` +
+    `UMAMI_DOMAIN=${opts.domain}\n`
+  )
+}
+
+/**
+ * Computes a salted SHA-256 fingerprint of the DB password.
+ * The fingerprint is written to the remote sentinel file — never the password itself.
+ */
+export function computeDbPasswordFingerprint(password: string): string {
+  const hasher = new Bun.CryptoHasher('sha256')
+  hasher.update(`${FINGERPRINT_SALT}:${password}`)
+  return hasher.digest('hex')
+}
+
+// ─── SSH helpers ──────────────────────────────────────────────────────────────
+
+function sshIdentityOptions(keyPath: string | undefined): string[] {
+  if (keyPath) {
+    return ['-i', keyPath, '-o', 'IdentitiesOnly=yes']
+  }
+  return []
+}
+
+function sshCommand(host: string, command: string, keyPath?: string, controlPath?: string): string[] {
+  return [
+    'ssh',
+    ...sshIdentityOptions(keyPath),
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'ConnectTimeout=10',
+    '-o',
+    'StrictHostKeyChecking=yes',
+    ...(controlPath
+      ? ['-o', 'ControlMaster=auto', '-o', `ControlPath=${controlPath}`, '-o', 'ControlPersist=60s']
+      : []),
+    `${DEFAULT_REMOTE_USER}@${host}`,
+    command,
+  ]
+}
+
+function scpCommand(
+  localPath: string,
+  host: string,
+  remotePath: string,
+  keyPath?: string,
+  controlPath?: string,
+): string[] {
+  return [
+    'scp',
+    ...sshIdentityOptions(keyPath),
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=yes',
+    ...(controlPath
+      ? ['-o', 'ControlMaster=auto', '-o', `ControlPath=${controlPath}`, '-o', 'ControlPersist=60s']
+      : []),
+    localPath,
+    `${DEFAULT_REMOTE_USER}@${host}:${remotePath}`,
+  ]
+}
+
+function buildDeployEnv(env: Record<string, string>): DeployEnv {
+  return {
+    PATH: env.PATH ?? '/usr/bin:/bin',
+    HOME: env.HOME ?? '/root',
+    UMAMI_DOMAIN: env.UMAMI_DOMAIN ?? '',
+    ...(env.SSH_AUTH_SOCK ? {SSH_AUTH_SOCK: env.SSH_AUTH_SOCK} : {}),
+  }
+}
+
+function defaultSpawn(cmd: string[], opts: SpawnOpts): SpawnResult {
+  return Bun.spawn(cmd, opts)
+}
+
+async function runCommand(
+  label: string,
+  command: string[],
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+): Promise<{stdout: string; stderr: string}> {
+  console.warn(`\u001B[1;34m==>\u001B[0m ${label}`)
+
+  const proc = spawnFn(command, {env: deployEnv, stdout: 'pipe', stderr: 'pipe'})
+
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+
+  if (stdout.trim()) {
+    console.warn(stdout.trim())
+  }
+
+  if (exitCode !== 0) {
+    console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
+    if (stderr.trim()) {
+      console.error(stderr.trim())
+    }
+    throw new Error(`Command failed with exit code ${exitCode}: ${command.join(' ')}`)
+  }
+
+  return {stdout, stderr}
+}
+
+/**
+ * Writes content to a remote path via SSH stdin pipe.
+ * Content is NEVER placed in the shell command argv — it flows through stdin only.
+ */
+async function writeRemoteFile(
+  label: string,
+  host: string,
+  remotePath: string,
+  content: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+  controlPath?: string,
+): Promise<void> {
+  console.warn(`\u001B[1;34m==>\u001B[0m ${label}`)
+
+  const proc = spawnFn(sshCommand(host, `umask 077; cat > '${remotePath}'`, keyPath, controlPath), {
+    env: deployEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    stdin: 'pipe',
+  })
+
+  if (!proc.stdin) {
+    throw new Error(`Spawn did not provide stdin pipe for: ${label}`)
+  }
+
+  proc.stdin.write(new TextEncoder().encode(content))
+  proc.stdin.end()
+
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
+    if (stderr.trim()) {
+      console.error(stderr.trim())
+    }
+    throw new Error(`Command failed with exit code ${exitCode}: ${label}`)
+  }
+
+  if (stdout.trim()) {
+    console.warn(stdout.trim())
+  }
+}
+
+/**
+ * Reads the remote DB-password fingerprint sentinel.
+ * Returns empty string if the sentinel does not exist.
+ */
+async function readRemoteFingerprint(
+  host: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+  controlPath?: string,
+): Promise<string> {
+  const proc = spawnFn(
+    sshCommand(host, `cat '${REMOTE_FINGERPRINT_PATH}' 2>/dev/null || echo ''`, keyPath, controlPath),
+    {env: deployEnv, stdout: 'pipe', stderr: 'pipe'},
+  )
+  const stdout = await new Response(proc.stdout).text()
+  await proc.exited
+  return stdout.trim()
+}
+
+/**
+ * Attempts to rotate the Umami admin password from the default 'umami' to
+ * UMAMI_ADMIN_PASSWORD. Idempotent: if the default login fails, the password
+ * is assumed to already be rotated and the step is skipped.
+ *
+ * All secret bytes travel via SSH stdin (curl --data @-), never argv.
+ */
+async function rotateAdminPassword(
+  host: string,
+  adminPassword: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+  controlPath?: string,
+): Promise<void> {
+  console.warn('\u001B[1;34m==>\u001B[0m Attempting admin password rotation (idempotent)')
+
+  // Step 1: Try default login. Body travels via stdin.
+  const loginBody = JSON.stringify({username: 'admin', password: 'umami'})
+  const loginProc = spawnFn(
+    sshCommand(
+      host,
+      `curl -s -X POST -H 'Content-Type: application/json' --data @- http://localhost:3000${UMAMI_LOGIN_PATH}`,
+      keyPath,
+      controlPath,
+    ),
+    {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'},
+  )
+
+  if (!loginProc.stdin) {
+    throw new Error('Spawn did not provide stdin pipe for admin login')
+  }
+
+  loginProc.stdin.write(new TextEncoder().encode(loginBody))
+  loginProc.stdin.end()
+
+  const loginStdout = await new Response(loginProc.stdout).text()
+  await loginProc.exited
+
+  let token: string | null = null
+  try {
+    const parsed = JSON.parse(loginStdout) as {token?: string | null}
+    token = parsed.token ?? null
+  } catch {
+    // Non-JSON response — treat as failed login
+    token = null
+  }
+
+  if (!token) {
+    console.warn('\u001B[1;33m[info]\u001B[0m Default admin login failed — password already rotated, skipping.')
+    return
+  }
+
+  // Step 2: Update password. New password travels via stdin.
+  const updateBody = JSON.stringify({password: adminPassword})
+  const updateProc = spawnFn(
+    sshCommand(
+      host,
+      `curl -s -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ${token}' --data @- http://localhost:3000${UMAMI_PASSWORD_PATH}`,
+      keyPath,
+      controlPath,
+    ),
+    {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'},
+  )
+
+  if (!updateProc.stdin) {
+    throw new Error('Spawn did not provide stdin pipe for password update')
+  }
+
+  updateProc.stdin.write(new TextEncoder().encode(updateBody))
+  updateProc.stdin.end()
+
+  await new Response(updateProc.stdout).text()
+  const updateExit = await updateProc.exited
+
+  if (updateExit === 0) {
+    console.warn('\u001B[1;32m✓\u001B[0m Admin password rotated successfully.')
+  } else {
+    console.warn('\u001B[1;33m[warn]\u001B[0m Admin password update returned non-zero exit — verify manually.')
+  }
+}
+
+/**
+ * Default DNS resolver using Bun's built-in DNS.
+ */
+async function defaultResolve(host: string): Promise<void> {
+  const results = await Bun.dns.lookup(host)
+  if (!results || results.length === 0) {
+    throw new Error(`DNS resolution returned no results for ${host}`)
+  }
+}
+
+// ─── Main deploy orchestrator ─────────────────────────────────────────────────
+
+/**
+ * Deploys the Umami analytics stack to the remote droplet.
+ *
+ * Order of operations:
+ * 1. Validate env (throws before any SSH on failure)
+ * 2. DNS preflight
+ * 3. ControlMaster SSH multiplexing setup
+ * 4. Remote prep: mkdir -p /opt/umami/config
+ * 5. DB-password fingerprint guard
+ * 6. Materialize /opt/umami/.env via SSH stdin
+ * 7. scp docker-compose.yaml + Caddyfile
+ * 8. docker compose pull && up -d --wait
+ * 9. Write fingerprint sentinel (hash only, never password)
+ * 10. Public HTTPS probe (warning-only on failure)
+ * 11. Admin password rotation (idempotent)
+ */
+export async function deploy(opts: DeployOpts = {}): Promise<void> {
+  const env = opts.env ?? (process.env as Record<string, string>)
+  const spawnFn = opts.spawn ?? defaultSpawn
+  const resolveFn = opts.resolve ?? defaultResolve
+  const fetchFn = opts.fetch ?? globalThis.fetch
+  const sleepFn = opts.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)))
+  const probeAttempts = opts.probeAttempts ?? 6
+  const probeIntervalMs = opts.probeIntervalMs ?? 10_000
+
+  // Phase 1: Validate env — throws before any SSH on failure
+  const validated = validateEnv(env)
+
+  // After validateEnv passes, these are guaranteed non-empty strings
+  const host = validated.UMAMI_DOMAIN
+  const appSecret = validated.UMAMI_APP_SECRET
+  const dbPassword = validated.UMAMI_DB_PASSWORD
+  const adminPassword = validated.UMAMI_ADMIN_PASSWORD
+
+  // Boundary-validate all secret values before any SSH
+  validateSecretValue(appSecret, 'UMAMI_APP_SECRET')
+  validateSecretValue(dbPassword, 'UMAMI_DB_PASSWORD')
+  validateSecretValue(adminPassword, 'UMAMI_ADMIN_PASSWORD')
+
+  // Phase 2: DNS preflight
+  try {
+    await resolveFn(host)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    throw new Error(`DNS preflight failed for ${host}: ${msg}`)
+  }
+
+  const deployEnv = buildDeployEnv(env)
+
+  // CI mode: write UMAMI_SSH_KEY to a tmp file with mode 0o600.
+  // Local mode: keyPath stays undefined; SSH_AUTH_SOCK is forwarded via deployEnv.
+  let keyPath: string | undefined
+  let tmpDir: string | undefined
+
+  try {
+    // Always create a tmpdir — used for ControlPath socket in both CI and local mode.
+    tmpDir = mkdtempSync(join(tmpdir(), 'umami-deploy-'))
+
+    if (env.UMAMI_SSH_KEY) {
+      keyPath = join(tmpDir, 'id')
+      const keyContent = env.UMAMI_SSH_KEY.endsWith('\n') ? env.UMAMI_SSH_KEY : `${env.UMAMI_SSH_KEY}\n`
+      writeFileSync(keyPath, keyContent, {mode: 0o600})
+      // Defensive chmod in case umask narrowed the initial mode
+      chmodSync(keyPath, 0o600)
+    }
+
+    // ControlPath socket lives inside tmpDir
+    const controlPath = join(tmpDir, 'cm-%r@%h:%p')
+
+    // Phase 3: Remote prep
+    await runCommand(
+      'Creating remote directories',
+      sshCommand(host, `mkdir -p ${REMOTE_CONFIG_DIR}`, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    // Phase 4: DB-password fingerprint guard
+    const currentFingerprint = computeDbPasswordFingerprint(dbPassword)
+    const existingFingerprint = await readRemoteFingerprint(host, deployEnv, spawnFn, keyPath, controlPath)
+
+    if (existingFingerprint && existingFingerprint !== currentFingerprint) {
+      throw new Error(
+        'DB password fingerprint mismatch: the UMAMI_DB_PASSWORD does not match the fingerprint stored on the ' +
+          'droplet. Changing the Postgres password requires manual rotation — see the ALTER USER rotation runbook ' +
+          'in apps/umami/AGENTS.md. Deploy aborted.',
+      )
+    }
+
+    // Phase 5: Materialize /opt/umami/.env via SSH stdin
+    const envContents = buildEnvFileContents({appSecret, dbPassword, domain: host})
+    await writeRemoteFile(
+      'Writing /opt/umami/.env',
+      host,
+      REMOTE_ENV_PATH,
+      envContents,
+      deployEnv,
+      spawnFn,
+      keyPath,
+      controlPath,
+    )
+
+    // Phase 6: scp docker-compose.yaml and Caddyfile
+    const localCompose = join(import.meta.dir, '..', 'docker-compose.yaml')
+    const localCaddyfile = join(import.meta.dir, '..', 'config', 'Caddyfile')
+
+    await runCommand(
+      'Copying docker-compose.yaml',
+      scpCommand(localCompose, host, REMOTE_COMPOSE_PATH, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    await runCommand(
+      'Copying Caddyfile',
+      scpCommand(localCaddyfile, host, REMOTE_CADDYFILE_PATH, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    // Phase 7: docker compose pull && up -d --wait
+    await runCommand(
+      'Pulling Docker images',
+      sshCommand(host, `cd ${REMOTE_DIR} && docker compose pull`, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    await runCommand(
+      'Starting Docker Compose stack',
+      sshCommand(host, `cd ${REMOTE_DIR} && docker compose up -d --wait --wait-timeout 180`, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    // Phase 8: Write fingerprint sentinel AFTER healthy compose up
+    await writeRemoteFile(
+      'Writing DB password fingerprint sentinel',
+      host,
+      REMOTE_FINGERPRINT_PATH,
+      currentFingerprint,
+      deployEnv,
+      spawnFn,
+      keyPath,
+      controlPath,
+    )
+
+    // Phase 9: Public HTTPS probe (warning-only — Caddy ACME cert may still be issuing)
+    let probeOk = false
+    for (let attempt = 1; attempt <= probeAttempts; attempt++) {
+      try {
+        const response = await fetchFn(`https://${host}/api/heartbeat`, {
+          signal: AbortSignal.timeout(10_000),
+        })
+        if (response.ok) {
+          const body = (await response.json()) as {ok?: boolean}
+          if (body.ok === true) {
+            probeOk = true
+            break
+          }
+        }
+      } catch {
+        // Transient failure — retry
+      }
+
+      if (attempt < probeAttempts) {
+        await sleepFn(probeIntervalMs)
+      }
+    }
+
+    if (probeOk) {
+      console.warn(`\u001B[1;32m✓\u001B[0m Public HTTPS probe succeeded: https://${host}/api/heartbeat`)
+    } else {
+      console.warn(
+        `\u001B[1;33m[warn]\u001B[0m containers healthy; TLS cert still issuing — ` +
+          `verify at https://${host}/api/heartbeat`,
+      )
+    }
+
+    // Phase 10: Admin password rotation (idempotent)
+    await rotateAdminPassword(host, adminPassword, deployEnv, spawnFn, keyPath, controlPath)
+
+    console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
+  } finally {
+    // Clean up the tmp dir regardless of success or failure
+    if (tmpDir) {
+      rmSync(tmpDir, {recursive: true, force: true})
+    }
+  }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  deploy().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/apps/umami/src/deploy.ts
+++ b/apps/umami/src/deploy.ts
@@ -162,12 +162,17 @@ export function validateEnv(env: Record<string, string>): ValidatedEnv {
 /**
  * Builds the contents of the remote .env file.
  * Secrets travel via SSH stdin — this function only assembles the string.
+ *
+ * G4: The DB password is percent-encoded in DATABASE_URL (URL-reserved chars
+ * like @ : / # % would corrupt the connection string if left raw).
+ * POSTGRES_PASSWORD stays raw — Postgres reads it literally from env.
  */
 export function buildEnvFileContents(opts: {appSecret: string; dbPassword: string; domain: string}): string {
+  const encodedDbPassword = encodeURIComponent(opts.dbPassword)
   return (
     `APP_SECRET=${opts.appSecret}\n` +
     `POSTGRES_PASSWORD=${opts.dbPassword}\n` +
-    `DATABASE_URL=postgresql://umami:${opts.dbPassword}@db:5432/umami\n` +
+    `DATABASE_URL=postgresql://umami:${encodedDbPassword}@db:5432/umami\n` +
     `UMAMI_DOMAIN=${opts.domain}\n`
   )
 }
@@ -322,7 +327,13 @@ async function writeRemoteFile(
 
 /**
  * Reads the remote DB-password fingerprint sentinel.
- * Returns empty string if the sentinel does not exist.
+ *
+ * G3: Distinguishes three states:
+ *   - Sentinel absent (file-not-found, exit 1 with "No such file") → returns '' (first deploy)
+ *   - Sentinel present (exit 0) → returns its hash
+ *   - SSH/read failure (exit non-zero for a reason other than missing file) → throws
+ *
+ * Runs `cat <path>` WITHOUT `|| echo ''` so the exit code is meaningful.
  */
 async function readRemoteFingerprint(
   host: string,
@@ -331,21 +342,53 @@ async function readRemoteFingerprint(
   keyPath?: string,
   controlPath?: string,
 ): Promise<string> {
-  const proc = spawnFn(
-    sshCommand(host, `cat '${REMOTE_FINGERPRINT_PATH}' 2>/dev/null || echo ''`, keyPath, controlPath),
-    {env: deployEnv, stdout: 'pipe', stderr: 'pipe'},
-  )
+  const proc = spawnFn(sshCommand(host, `cat '${REMOTE_FINGERPRINT_PATH}'`, keyPath, controlPath), {
+    env: deployEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   const stdout = await new Response(proc.stdout).text()
-  await proc.exited
-  return stdout.trim()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+
+  if (exitCode === 0) {
+    return stdout.trim()
+  }
+
+  // Distinguish file-not-found (first deploy) from SSH/permission failures.
+  // "No such file" covers both Linux and macOS cat error messages.
+  const combinedOutput = (stdout + stderr).toLowerCase()
+  if (combinedOutput.includes('no such file')) {
+    // Sentinel absent — legitimate first deploy
+    return ''
+  }
+
+  // Any other non-zero exit is a transport or permission failure — fail closed.
+  throw new Error(
+    `Failed to read fingerprint sentinel from remote (exit ${exitCode}). ` +
+      'This may indicate an SSH transport failure or permission error. ' +
+      'Resolve the SSH connectivity issue before deploying.',
+  )
 }
 
 /**
  * Attempts to rotate the Umami admin password from the default 'umami' to
- * UMAMI_ADMIN_PASSWORD. Idempotent: if the default login fails, the password
- * is assumed to already be rotated and the step is skipped.
+ * UMAMI_ADMIN_PASSWORD. Idempotent: if the default login is cleanly rejected
+ * (HTTP 401/403 → curl exit 22), the password is already rotated — skip.
  *
- * All secret bytes travel via SSH stdin (curl --data @-), never argv.
+ * G1 — fails CLOSED:
+ *   - Connection/transport failure (curl exit 7, or docker exec failure) → THROW.
+ *     We cannot determine cred state; deploy must fail.
+ *   - HTTP auth rejection (curl exit 22 with auth body) → skip (already rotated).
+ *   - Login succeeds (exit 0 + token) → proceed to update + verify.
+ *
+ * G2 — called BEFORE Caddy starts (no public default-credential window).
+ *
+ * G5 — bearer token travels via stdin (curl config file), never argv.
+ *
+ * Exec reachability: curls run inside the umami container via
+ * `docker compose exec -T umami curl ...` so port 3000 is reachable on the
+ * internal compose network. The -T flag disables TTY so stdin piping works.
  */
 async function rotateAdminPassword(
   host: string,
@@ -357,17 +400,16 @@ async function rotateAdminPassword(
 ): Promise<void> {
   console.warn('\u001B[1;34m==>\u001B[0m Attempting admin password rotation (idempotent)')
 
-  // Step 1: Try default login. Body travels via stdin.
+  // Step 1: Try default login with --fail-with-body so HTTP >=400 → non-zero exit.
+  // Body travels via stdin; curl runs inside the umami container.
   const loginBody = JSON.stringify({username: 'admin', password: 'umami'})
-  const loginProc = spawnFn(
-    sshCommand(
-      host,
-      `curl -s -X POST -H 'Content-Type: application/json' --data @- http://localhost:3000${UMAMI_LOGIN_PATH}`,
-      keyPath,
-      controlPath,
-    ),
-    {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'},
+  const loginCmd = sshCommand(
+    host,
+    `cd ${REMOTE_DIR} && docker compose exec -T umami curl -s --fail-with-body -X POST -H 'Content-Type: application/json' --data @- http://localhost:3000${UMAMI_LOGIN_PATH}`,
+    keyPath,
+    controlPath,
   )
+  const loginProc = spawnFn(loginCmd, {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'})
 
   if (!loginProc.stdin) {
     throw new Error('Spawn did not provide stdin pipe for admin login')
@@ -377,33 +419,82 @@ async function rotateAdminPassword(
   loginProc.stdin.end()
 
   const loginStdout = await new Response(loginProc.stdout).text()
-  await loginProc.exited
+  const loginExit = await loginProc.exited
 
+  // Exit 22 = HTTP error (--fail-with-body) → clean auth rejection → already rotated.
+  // Exit 0 = HTTP 200 → check for token.
+  // Any other non-zero (7 = connection refused, 255 = ssh failure, etc.) → throw.
+  if (loginExit !== 0 && loginExit !== 22) {
+    throw new Error(
+      `Cannot reach umami to verify/rotate admin credentials (exit ${loginExit}). ` +
+        'Ensure the umami container is healthy before deploying.',
+    )
+  }
+
+  if (loginExit === 22) {
+    // Clean HTTP auth rejection — password already rotated.
+    console.warn('\u001B[1;33m[info]\u001B[0m Default admin login rejected — password already rotated, skipping.')
+    return
+  }
+
+  // Exit 0 — parse token from response.
   let token: string | null = null
   try {
     const parsed = JSON.parse(loginStdout) as {token?: string | null}
     token = parsed.token ?? null
   } catch {
-    // Non-JSON response — treat as failed login
     token = null
   }
 
   if (!token) {
-    console.warn('\u001B[1;33m[info]\u001B[0m Default admin login failed — password already rotated, skipping.')
+    // Exit 0 but no token — treat as already rotated (unexpected but safe to skip).
+    console.warn(
+      '\u001B[1;33m[info]\u001B[0m Default admin login returned no token — password already rotated, skipping.',
+    )
     return
   }
 
-  // Step 2: Update password. New password travels via stdin.
-  const updateBody = JSON.stringify({password: adminPassword})
-  const updateProc = spawnFn(
-    sshCommand(
-      host,
-      `curl -s -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ${token}' --data @- http://localhost:3000${UMAMI_PASSWORD_PATH}`,
-      keyPath,
-      controlPath,
-    ),
-    {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'},
+  // Step 2: Write a curl config file inside the container via stdin so the
+  // bearer token never appears in argv (G5). The config file is written to
+  // /tmp/uc inside the umami container, used for the update curl, then removed.
+  const curlConfigContent = `header = "Authorization: Bearer ${token}"\n`
+  const writeCurlConfigCmd = sshCommand(
+    host,
+    `cd ${REMOTE_DIR} && docker compose exec -T umami sh -c 'umask 077; cat > /tmp/uc'`,
+    keyPath,
+    controlPath,
   )
+  const writeCurlConfigProc = spawnFn(writeCurlConfigCmd, {
+    env: deployEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    stdin: 'pipe',
+  })
+
+  if (!writeCurlConfigProc.stdin) {
+    throw new Error('Spawn did not provide stdin pipe for curl config write')
+  }
+
+  writeCurlConfigProc.stdin.write(new TextEncoder().encode(curlConfigContent))
+  writeCurlConfigProc.stdin.end()
+
+  await new Response(writeCurlConfigProc.stdout).text()
+  const writeCurlConfigExit = await writeCurlConfigProc.exited
+
+  if (writeCurlConfigExit !== 0) {
+    throw new Error('Failed to write curl config file inside umami container for password update')
+  }
+
+  // Step 3: Update password. New password travels via stdin; token via curl config file.
+  // Cleanup of /tmp/uc happens in the same sh -c regardless of curl exit code.
+  const updateBody = JSON.stringify({password: adminPassword})
+  const updateCmd = sshCommand(
+    host,
+    `cd ${REMOTE_DIR} && docker compose exec -T umami sh -c 'curl -s --fail-with-body -X POST -H '"'"'Content-Type: application/json'"'"' -K /tmp/uc --data @- http://localhost:3000${UMAMI_PASSWORD_PATH}; rc=$?; rm -f /tmp/uc; exit $rc'`,
+    keyPath,
+    controlPath,
+  )
+  const updateProc = spawnFn(updateCmd, {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'})
 
   if (!updateProc.stdin) {
     throw new Error('Spawn did not provide stdin pipe for password update')
@@ -415,11 +506,80 @@ async function rotateAdminPassword(
   await new Response(updateProc.stdout).text()
   const updateExit = await updateProc.exited
 
-  if (updateExit === 0) {
-    console.warn('\u001B[1;32m✓\u001B[0m Admin password rotated successfully.')
-  } else {
-    console.warn('\u001B[1;33m[warn]\u001B[0m Admin password update returned non-zero exit — verify manually.')
+  if (updateExit !== 0) {
+    throw new Error(`Admin password update failed (exit ${updateExit}). Deploy aborted.`)
   }
+
+  // Step 4: Verify — re-login with the NEW password must succeed.
+  const verifyNewBody = JSON.stringify({username: 'admin', password: adminPassword})
+  const verifyNewCmd = sshCommand(
+    host,
+    `cd ${REMOTE_DIR} && docker compose exec -T umami curl -s --fail-with-body -X POST -H 'Content-Type: application/json' --data @- http://localhost:3000${UMAMI_LOGIN_PATH}`,
+    keyPath,
+    controlPath,
+  )
+  const verifyNewProc = spawnFn(verifyNewCmd, {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'})
+
+  if (!verifyNewProc.stdin) {
+    throw new Error('Spawn did not provide stdin pipe for rotation verification (new password)')
+  }
+
+  verifyNewProc.stdin.write(new TextEncoder().encode(verifyNewBody))
+  verifyNewProc.stdin.end()
+
+  const verifyNewStdout = await new Response(verifyNewProc.stdout).text()
+  const verifyNewExit = await verifyNewProc.exited
+
+  if (verifyNewExit !== 0) {
+    throw new Error(
+      'Admin password rotation verification failed: new password login was rejected. ' +
+        'The password may not have been updated correctly. Investigate manually.',
+    )
+  }
+
+  let verifyNewToken: string | null = null
+  try {
+    const parsed = JSON.parse(verifyNewStdout) as {token?: string | null}
+    verifyNewToken = parsed.token ?? null
+  } catch {
+    verifyNewToken = null
+  }
+
+  if (!verifyNewToken) {
+    throw new Error(
+      'Admin password rotation verification failed: new password login returned no token. ' + 'Investigate manually.',
+    )
+  }
+
+  // Step 5: Verify — re-login with the DEFAULT password must now FAIL (exit 22).
+  const verifyDefaultBody = JSON.stringify({username: 'admin', password: 'umami'})
+  const verifyDefaultCmd = sshCommand(
+    host,
+    `cd ${REMOTE_DIR} && docker compose exec -T umami curl -s --fail-with-body -X POST -H 'Content-Type: application/json' --data @- http://localhost:3000${UMAMI_LOGIN_PATH}`,
+    keyPath,
+    controlPath,
+  )
+  const verifyDefaultProc = spawnFn(verifyDefaultCmd, {env: deployEnv, stdout: 'pipe', stderr: 'pipe', stdin: 'pipe'})
+
+  if (!verifyDefaultProc.stdin) {
+    throw new Error('Spawn did not provide stdin pipe for rotation verification (default password)')
+  }
+
+  verifyDefaultProc.stdin.write(new TextEncoder().encode(verifyDefaultBody))
+  verifyDefaultProc.stdin.end()
+
+  await new Response(verifyDefaultProc.stdout).text()
+  const verifyDefaultExit = await verifyDefaultProc.exited
+
+  if (verifyDefaultExit === 0) {
+    // Default password still works — rotation did not stick.
+    throw new Error(
+      'Admin password rotation verification failed: default password still accepted after rotation. ' +
+        'The password update may not have persisted. Investigate manually.',
+    )
+  }
+
+  console.warn('\u001B[1;32m✓\u001B[0m Admin password rotated and verified successfully.')
 }
 
 /**
@@ -442,13 +602,15 @@ async function defaultResolve(host: string): Promise<void> {
  * 2. DNS preflight
  * 3. ControlMaster SSH multiplexing setup
  * 4. Remote prep: mkdir -p /opt/umami/config
- * 5. DB-password fingerprint guard
+ * 5. DB-password fingerprint guard (G3: fails on SSH error, not just mismatch)
  * 6. Materialize /opt/umami/.env via SSH stdin
  * 7. scp docker-compose.yaml + Caddyfile
- * 8. docker compose pull && up -d --wait
- * 9. Write fingerprint sentinel (hash only, never password)
- * 10. Public HTTPS probe (warning-only on failure)
- * 11. Admin password rotation (idempotent)
+ * 8. docker compose pull (all images)
+ * 9. docker compose up -d --wait db umami (internal only — Caddy NOT started yet)
+ * 10. Admin password rotation (G1: fail-closed; G2: before Caddy; G5: token via stdin)
+ * 11. docker compose up -d --wait caddy (now expose publicly)
+ * 12. Write DB-password fingerprint sentinel (hash only, never password)
+ * 13. Public HTTPS probe (warning-only on failure — Caddy ACME cert may still be issuing)
  */
 export async function deploy(opts: DeployOpts = {}): Promise<void> {
   const env = opts.env ?? (process.env as Record<string, string>)
@@ -511,7 +673,7 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       spawnFn,
     )
 
-    // Phase 4: DB-password fingerprint guard
+    // Phase 4: DB-password fingerprint guard (G3: SSH errors throw, not bypass)
     const currentFingerprint = computeDbPasswordFingerprint(dbPassword)
     const existingFingerprint = await readRemoteFingerprint(host, deployEnv, spawnFn, keyPath, controlPath)
 
@@ -554,7 +716,7 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       spawnFn,
     )
 
-    // Phase 7: docker compose pull && up -d --wait
+    // Phase 7: docker compose pull (all images)
     await runCommand(
       'Pulling Docker images',
       sshCommand(host, `cd ${REMOTE_DIR} && docker compose pull`, keyPath, controlPath),
@@ -562,14 +724,40 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       spawnFn,
     )
 
+    // Phase 8: Start db + umami only (Caddy NOT started — no public exposure yet).
+    // G2: Caddy is withheld until after admin rotation so there is no window
+    // where the default admin credentials are reachable from the public internet.
     await runCommand(
-      'Starting Docker Compose stack',
-      sshCommand(host, `cd ${REMOTE_DIR} && docker compose up -d --wait --wait-timeout 180`, keyPath, controlPath),
+      'Starting db and umami (internal only)',
+      sshCommand(
+        host,
+        `cd ${REMOTE_DIR} && docker compose up -d --wait --wait-timeout 180 db umami`,
+        keyPath,
+        controlPath,
+      ),
       deployEnv,
       spawnFn,
     )
 
-    // Phase 8: Write fingerprint sentinel AFTER healthy compose up
+    // Phase 9: Admin password rotation (G1: fail-closed; G2: before Caddy; G5: token via stdin)
+    // Rotation curls run inside the umami container via `docker compose exec -T umami`
+    // so port 3000 is reachable on the internal compose network.
+    await rotateAdminPassword(host, adminPassword, deployEnv, spawnFn, keyPath, controlPath)
+
+    // Phase 10: Start Caddy — now safe to expose publicly (rotation complete).
+    await runCommand(
+      'Starting Caddy (public exposure)',
+      sshCommand(
+        host,
+        `cd ${REMOTE_DIR} && docker compose up -d --wait --wait-timeout 180 caddy`,
+        keyPath,
+        controlPath,
+      ),
+      deployEnv,
+      spawnFn,
+    )
+
+    // Phase 11: Write fingerprint sentinel AFTER db+umami healthy
     await writeRemoteFile(
       'Writing DB password fingerprint sentinel',
       host,
@@ -581,7 +769,7 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       controlPath,
     )
 
-    // Phase 9: Public HTTPS probe (warning-only — Caddy ACME cert may still be issuing)
+    // Phase 12: Public HTTPS probe (warning-only — Caddy ACME cert may still be issuing)
     let probeOk = false
     for (let attempt = 1; attempt <= probeAttempts; attempt++) {
       try {
@@ -612,9 +800,6 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
           `verify at https://${host}/api/heartbeat`,
       )
     }
-
-    // Phase 10: Admin password rotation (idempotent)
-    await rotateAdminPassword(host, adminPassword, deployEnv, spawnFn, keyPath, controlPath)
 
     console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
   } finally {

--- a/apps/umami/src/host.test.ts
+++ b/apps/umami/src/host.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'bun:test'
+
+import {validateUmamiHost} from './host'
+
+describe('validateUmamiHost', () => {
+  it('accepts a standard FQDN', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot')).not.toThrow()
+    expect(validateUmamiHost('metrics.fro.bot')).toBe('metrics.fro.bot')
+  })
+
+  it('accepts localhost', () => {
+    expect(() => validateUmamiHost('localhost')).not.toThrow()
+  })
+
+  it('accepts an IPv4 address', () => {
+    expect(() => validateUmamiHost('147.182.133.210')).not.toThrow()
+  })
+
+  it('accepts a single-character hostname', () => {
+    expect(() => validateUmamiHost('a')).not.toThrow()
+  })
+
+  it('accepts a hostname with hyphens', () => {
+    expect(() => validateUmamiHost('my-metrics.prod.example.com')).not.toThrow()
+  })
+
+  it('rejects a leading-hyphen value (ProxyCommand injection vector)', () => {
+    expect(() => validateUmamiHost('-oProxyCommand=evil')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with shell metacharacters (semicolon)', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot;rm -rf')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with shell metacharacters (backtick)', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot`id`')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with spaces', () => {
+    expect(() => validateUmamiHost('metrics fro.bot')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with an at-sign', () => {
+    expect(() => validateUmamiHost('user@metrics.fro.bot')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects an empty string', () => {
+    expect(() => validateUmamiHost('')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('truncates the invalid value in the error message to ~30 chars', () => {
+    const longMalicious = `-oProxyCommand=${'A'.repeat(100)}`
+    let message = ''
+    try {
+      validateUmamiHost(longMalicious)
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toContain('Invalid UMAMI_DOMAIN')
+    expect(message.length).toBeLessThan(longMalicious.length + 50)
+  })
+})

--- a/apps/umami/src/host.ts
+++ b/apps/umami/src/host.ts
@@ -1,0 +1,31 @@
+// ─── Umami host validation ────────────────────────────────────────────────────
+//
+// Validates UMAMI_DOMAIN values before they are passed as ssh argv arguments.
+// A value starting with `-` would be interpreted by ssh as an option flag,
+// enabling ProxyCommand injection and local code execution.
+
+const VALID_HOST_RE = /^[a-z\d][a-z\d.\-]*$/i
+
+/**
+ * Validates a candidate UMAMI_DOMAIN value against a strict hostname allowlist.
+ *
+ * Accepts: hostnames, FQDNs, IPv4 addresses, `localhost`.
+ * Rejects: empty strings, values starting with `-`, and anything containing
+ * characters outside `[A-Za-z0-9.-]`.
+ *
+ * @throws {Error} with a sanitized excerpt of the invalid value.
+ * @returns The validated host string (unchanged).
+ */
+export function validateUmamiHost(host: string): string {
+  if (!host) {
+    throw new Error('Invalid UMAMI_DOMAIN: value is empty')
+  }
+
+  if (!VALID_HOST_RE.test(host)) {
+    // Truncate to 30 chars and strip non-printable bytes before echoing back
+    const excerpt = host.slice(0, 30).replaceAll(/[^\u0020-\u007E]/g, '?')
+    throw new Error(`Invalid UMAMI_DOMAIN: "${excerpt}" — must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`}`)
+  }
+
+  return host
+}

--- a/bun.lock
+++ b/bun.lock
@@ -40,9 +40,15 @@
     "apps/keeweb": {
       "name": "@marcusrbrown/infra-keeweb",
     },
+    "apps/umami": {
+      "name": "@marcusrbrown/infra-umami",
+      "dependencies": {
+        "@marcusrbrown/infra-shared": "workspace:*",
+      },
+    },
     "packages/cli": {
       "name": "@marcusrbrown/infra",
-      "version": "0.5.0",
+      "version": "0.8.1",
       "bin": {
         "infra": "src/cli.ts",
       },
@@ -173,6 +179,8 @@
     "@marcusrbrown/infra-keeweb": ["@marcusrbrown/infra-keeweb@workspace:apps/keeweb"],
 
     "@marcusrbrown/infra-shared": ["@marcusrbrown/infra-shared@workspace:packages/shared"],
+
+    "@marcusrbrown/infra-umami": ["@marcusrbrown/infra-umami@workspace:apps/umami"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/docs/plans/2026-05-27-002-feat-umami-analytics-deployment-plan.md
+++ b/docs/plans/2026-05-27-002-feat-umami-analytics-deployment-plan.md
@@ -1,0 +1,760 @@
+---
+title: 'feat: self-hosted Umami analytics deployment (apps/umami)'
+type: feat
+status: active
+date: 2026-05-27
+origin: 'GitHub issue #315 + Fro Bot triage (comment 4560738565)'
+deepened: 2026-05-27
+---
+
+# feat: self-hosted Umami analytics deployment (apps/umami)
+
+## Overview
+
+Add a self-hosted [Umami](https://umami.is) analytics deployment as a new `apps/umami/`
+package, deployed to a dedicated DigitalOcean droplet via Docker Compose (Umami v3.1.0 +
+PostgreSQL 15) behind Caddy for auto-TLS at `metrics.fro.bot`. This gives projects
+privacy-respecting, cookie-free web analytics with no third-party data processor. The first
+consumer is the Systematic docs site (`https://fro.bot/systematic`), which needs visitor
+measurement that preserves its "nothing phones home / no third-party tracking" posture.
+
+The app follows the repo's established droplet+compose model: it borrows `apps/cliproxy/`'s
+public-HTTPS-behind-Caddy shape and `apps/gateway/`'s SSH hygiene, secret-file
+materialization, host validation, provision scaffolding, and CLI command module. Its one
+genuinely new concern is **relational persistence** — a PostgreSQL data volume that must
+survive redeploys and whose credentials are baked into the volume on first init.
+
+## Problem Frame
+
+Origin: GitHub issue #315, with a detailed Fro Bot triage comment that validated the repo
+patterns and recommended the droplet+compose path. The deployment-target fork (Cloudflare
+Workers vs droplet) is **resolved: droplet + Docker Compose** (operator decision, 2026-05-27).
+
+The Systematic docs analytics work is blocked until this instance is live with a website ID.
+No work is blocked on the Systematic side until the instance exists; once live, that side
+needs only a cookie-free `<script>` tag plus two custom events.
+
+Why self-hosted Umami: strongest defensible privacy claim (no third-party processor, no
+cross-border transfer, no consent banner), cookie-free and DNT-respecting by default, and
+reusable across any number of sites via per-site tracking IDs against one instance.
+
+## Requirements Trace
+
+- R1. Umami instance reachable over HTTPS at a stable subdomain (`metrics.fro.bot`), TLS via
+  Caddy auto-cert.
+- R2. Privacy baseline enforced: cookie-free, DNT-respected, no PII; `DISABLE_TELEMETRY=1`
+  (no Umami phone-home) and `PRIVATE_MODE=1` (no external calls) set on the instance.
+- R3. Deploy is idempotent and follows repo deploy-flow conventions: secrets via SSH
+  stdin/files never argv, host validated before SSH argv, container-health + app-level HTTP
+  health-gated completion.
+- R4. PostgreSQL data persists across redeploys in a named volume; the deploy never wipes it.
+- R5. CLI commands `umami status`, `umami deploy` (remote default + `--local`), and
+  `umami logs` wired and registered, with `umami status` in the unified `status` rollup.
+- R6. A tracking website/ID provisioned in Umami for the Systematic docs site, captured for
+  the downstream docs instrumentation (the script-tag attributes documented for that
+  consumer). Ownership: this is satisfied by an operator-prerequisite step (Umami website
+  creation is a manual admin-UI action after first deploy — see Documentation / Operational
+  Notes step 7) plus Unit 8 documenting the exact tag; it is intentionally not a code unit.
+- R7. Operator docs (`apps/umami/AGENTS.md`) cover deploy flow, first-login admin-password
+  rotation, the privacy-config baseline, Postgres backup/restore, retention policy, secret
+  rotation (including the DB-password constraint), and upgrade flow.
+- R8. Deploy automated via `.github/workflows/deploy-umami.yaml` in an `umami` GitHub
+  environment, SHA-pinned actions, path-filtered with `predicate-quantifier: every`, pinned
+  host keys, explicit secrets.
+
+## Scope Boundaries
+
+- No Cloudflare Workers / D1 path — droplet + compose only (operator decision).
+- No shared-droplet placement for v1 — a dedicated `s-1vcpu-1gb` droplet (resize triggers
+  documented). A shared-droplet decision can be made deliberately later.
+- No automated/scheduled backups for v1 — the manual `pg_dump` runbook in AGENTS.md is the v1
+  backup story.
+- No MySQL variant — PostgreSQL only.
+- No adblock-evasion proxy rewrites (`TRACKER_SCRIPT_NAME` / `COLLECT_API_ENDPOINT`) for v1 —
+  documented as an available option, not configured.
+- The plan provisions the deployment; it does NOT modify the Systematic repo. The downstream
+  `docs/astro.config.mjs` script-tag wiring is a separate task in that repo (R6 only captures
+  the website ID and documents the exact tag).
+
+### Deferred to Separate Tasks
+
+- `umami backup` / `umami restore` CLI commands (gateway CA backup/restore pattern adapted to
+  `pg_dump` tarballs): separate follow-up once the manual runbook proves the shape. Tracked as
+  a future enhancement.
+- Systematic docs `<script>` tag + `view_quick_start` / `click_install_cta` custom events:
+  downstream task in the Systematic repo, unblocked once R6 yields a website ID.
+- Scheduled off-droplet backup to S3/R2: future iteration if retention/DR requirements grow.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Public-HTTPS + Caddy shape** — `apps/cliproxy/docker-compose.yaml` (Caddy service with
+  `80:80`/`443:443`, `caddy_data`/`caddy_config` named volumes, mounts `./config/Caddyfile`;
+  app service with a `wget --spider` healthcheck) and `apps/cliproxy/config/Caddyfile`
+  (`{$DOMAIN} { reverse_proxy <service>:<port> }`). Mirror this for `umami:3000`.
+- **deploy.ts contract** — `apps/cliproxy/src/deploy.ts` (env validation, `docker compose pull
+  && up -d --wait --wait-timeout 90`, post-deploy HTTPS health check) and
+  `apps/gateway/src/deploy.ts` (secret-file materialization via SSH stdin never argv,
+  `validateGatewayHost` before SSH argv, ControlMaster/ControlPersist SSH multiplexing from
+  PR #277, CI temp-key-file from `*_SSH_KEY` with trailing-newline handling, env validation
+  before any SSH).
+- **provision-droplet.ts** — `apps/gateway/server/provision-droplet.ts`: `doctl`,
+  `docker-20-04` image slug (the corrected slug from PR #271 — NOT `docker-24-04`),
+  `s-1vcpu-1gb` size, key-by-name selection via `GATEWAY_SSH_KEY_NAME` (PR #268), `pinHostKeys`
+  into `.github/known_hosts`, shared helpers from `@marcusrbrown/infra-shared`, and the
+  `if (import.meta.main)` guard so test imports don't trigger live `doctl`.
+- **Shared helpers** — `packages/shared/server/droplet-helpers.ts` exports `ssh`, `scp`,
+  `run`, `runCapture`, `sleep`, `validateDoctl`, `dropletExists`, `getSshFingerprint`,
+  `getDropletIpWithWait`, `waitForSsh`, `pinHostKeys`. Umami's provision reuses all except
+  possibly `runCapture`.
+- **Host validation** — `apps/gateway/src/host.ts` `validateGatewayHost` and
+  `packages/cli/src/commands/gateway/host.ts`: reject `-`-prefixed values and characters
+  outside `[A-Za-z0-9.-]` before any SSH argv construction. Clone as `validateUmamiHost`.
+- **CLI command module** — `packages/cli/src/commands/gateway/` (`index.ts` barrel →
+  `registerGatewayCommands`, `status.ts` with SSH `docker compose ps --format json` + NDJSON
+  parsing from PR #278 + `ActionCtx` threading, `deploy.ts` remote `gh workflow run` default +
+  `--local`, `logs.ts` with CI-refusal/`--allow-ci` + sensitive-data warning, `host.ts`).
+- **Unified status** — `packages/cli/src/commands/status.ts`: `StatusSummary['app']` union,
+  per-app `getXStatusSummary` aggregator, `StatusDependencies`, `Promise.allSettled` array,
+  `appNames` array, `toJsonPayload`.
+- **Deploy workflow** — `.github/workflows/deploy-cliproxy.yaml` and `deploy-gateway.yaml`:
+  SHA-pinned actions, `dorny/paths-filter` with `predicate-quantifier: every` (the bug fixed
+  in PR #191 — required), `environment: <app>`, committed `.github/known_hosts`,
+  `bun install --frozen-lockfile --ignore-scripts`, explicit secrets (never `inherit`),
+  change-detection filter excluding `**/*.md` / `**/*.test.ts`.
+- **MCP fidelity** — `packages/cli/src/commands/mcp.ts` `MCP_ALLOWLIST` and
+  `packages/cli/src/lib/action-ctx.ts` `ActionCtx`: `gateway status` is MCP-capturable (SSH +
+  docker compose ps → structured); `umami status` follows the same Tier-1/Tier-2 test bar.
+- **Renovate image pinning** — `.github/renovate.json5` packageRules for
+  `eceasy/cli-proxy-api` and `caddy` (sourceUrl + changelogUrl + standalone PRs). Add an
+  equivalent entry for the Umami image.
+- **cli.ts registration** — `packages/cli/src/cli.ts` registers app barrels in order; add
+  `registerUmamiCommands(cli)`.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md` — first deploy
+  is an end-to-end **deploy-contract** validation, not a feature smoke test. Failure waves to
+  pre-empt: SSH key newline/`libcrypto` (GH Actions strips trailing whitespace — append `\n`
+  when writing the key file), corrupted secret re-seeding, UFW SSH rate-limiting (use
+  ControlMaster multiplexing, don't weaken the firewall), `docker compose ps` NDJSON parsing,
+  docker image slug. Verify stored secret values structurally, don't "just retry."
+- `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md` — stale
+  lockfile after adding a workspace member, wrong/aliased env var, hashed-only host keys
+  (CI connects by domain, so pin unhashed domain entries), an app that needs its storage path
+  explicitly configured (here: Postgres `DATABASE_URL` + the data volume mount).
+- Project memory: `docker compose up -d --wait --wait-timeout` still needs an app-level HTTP
+  readiness check after (PR #82 race); deploy workflows use `predicate-quantifier: every`
+  (PR #81/#165/#191); cross-org reusable workflows pass secrets explicitly; CI lint/tsc jobs
+  pin Node 24 (deploy workflows do not need it — no lint/tsc step).
+
+### External References
+
+- Umami v3.1.0 — https://github.com/umami-software/umami/releases/tag/v3.1.0
+- Official install + first-login rotation — https://docs.umami.is/docs/install
+- Environment variables (`DISABLE_TELEMETRY`, `PRIVATE_MODE`, `DATABASE_URL`, `APP_SECRET`) —
+  https://docs.umami.is/docs/environment-variables
+- Official `docker-compose.yml` (service shape, healthchecks, volume) —
+  https://raw.githubusercontent.com/umami-software/umami/master/docker-compose.yml
+- Health endpoint `/api/heartbeat` → `{"ok":true}` —
+  https://raw.githubusercontent.com/umami-software/umami/master/src/app/api/heartbeat/route.ts
+- Tracker configuration (`data-website-id`, `data-do-not-track`, `data-exclude-search`,
+  `data-exclude-hash`, `/script.js`) — https://docs.umami.is/docs/tracker-configuration
+- FAQ (cookie-free, indefinite retention) — https://docs.umami.is/docs/faq
+
+## Key Technical Decisions
+
+- **Image: pin `docker.umami.is/umami-software/umami:postgresql-v3.1.0`** (the PostgreSQL
+  prebuilt variant at the current release), not `:postgresql-latest`. Rationale: versioned,
+  reviewable, Renovate-trackable updates — matches the repo's `eceasy/cli-proxy-api:vX.Y.Z`
+  and `caddy:2.11.x` pinning practice. Postgres image: `postgres:15-alpine` (official compose
+  uses 15-alpine). Verify the exact `postgresql-v3.1.0` tag exists at implementation time. If
+  the versioned tag is absent, resolve and pin the specific **digest of the v3.1.0 release
+  image** — never `latest@digest`, which is a moving target and not equivalent to v3.1.0.
+  Document the exact digest used.
+- **DB secret naming:** the GitHub environment secret is `UMAMI_DB_PASSWORD`; deploy.ts writes
+  it into the droplet `.env` as `POSTGRES_PASSWORD` (consumed by the postgres container) and
+  composes it into `DATABASE_URL`. One secret, two on-disk names — stated once here, used
+  consistently everywhere.
+- **No `upstream.json`.** Unlike gateway (which clones+builds the `fro-bot/agent` repo on the
+  droplet), Umami ships as a prebuilt image. The version pin lives in `docker-compose.yaml`
+  and is Renovate-managed. This makes Umami structurally a **cliproxy clone, not a gateway
+  clone**, for the image-versioning dimension.
+- **Secret materialization: write `.env` on the droplet every deploy via SSH stdin** (gateway
+  pattern), containing `APP_SECRET`, `POSTGRES_PASSWORD`, and the constructed
+  `DATABASE_URL=postgresql://umami:<POSTGRES_PASSWORD>@db:5432/umami`. Compose reads the
+  `.env`. Secrets never appear in argv. `APP_SECRET` rotation only invalidates active login
+  sessions (re-login), so it's lower-risk but still discouraged casually.
+- **DB-password fingerprint guard (root-cause prevention, not just docs).** `POSTGRES_PASSWORD`
+  is baked into the Postgres data volume on first init; regenerating `.env` with a different
+  password on a later deploy would break DB auth and take the public site down. deploy.ts
+  prevents this structurally: on the first successful deploy it writes a **fingerprint** (a
+  salted SHA-256 hash of `POSTGRES_PASSWORD`, never the password itself) to a droplet sentinel
+  file (e.g. `/opt/umami/.db-password-fingerprint`). Every subsequent deploy compares the
+  current secret's fingerprint against the sentinel; on mismatch it **refuses to deploy** with
+  a clear message pointing at the `ALTER USER` rotation runbook (Unit 8). This makes a silent
+  brick impossible — a rotation must go through the documented in-DB migration, which updates
+  both the live role password and the sentinel. The fingerprint is a hash so the sentinel file
+  holds no secret material.
+- **Persistence over preservation.** cliproxy preserves a mutable `config.yaml` (skip-upload
+  unless `--force-config`). Umami has no such mutable file on disk — all runtime state lives
+  in the Postgres volume `umami-db-data`. So the deploy does NOT need a config-preservation
+  branch; it needs the **volume to persist** (named volume, never `docker compose down -v`).
+  The `.env` is regenerated every deploy from the stable secrets.
+- **Health-gate: container-health is the success signal; public HTTPS is a bounded-retry
+  warning.** `docker compose up -d --wait --wait-timeout 180` blocks on the compose
+  healthchecks (postgres `pg_isready`, umami `curl http://localhost:3000/api/heartbeat`,
+  `depends_on: condition: service_healthy`) — this is the authoritative deploy-success signal
+  (container is healthy on its localhost interface). deploy.ts then probes the **public**
+  `GET https://${UMAMI_HOST}/api/heartbeat` as a **bounded retry** (e.g. ~6 attempts over
+  ~60s). On the first deploy Caddy must still complete a Let's Encrypt ACME challenge (depends
+  on DNS + LE timing), so if the public probe doesn't return `{"ok":true}` within the retry
+  window deploy.ts emits a WARNING — `containers healthy; TLS cert still issuing — verify at
+  https://${UMAMI_HOST}/api/heartbeat` — and **succeeds**, rather than false-failing a healthy
+  deploy. `compose up` is idempotent, so a re-run is always safe. Timeout raised from 120s to
+  180s for first-boot DB migrations. (Refines the PR #82 readiness lesson: container-health is
+  the contract; public TLS lag on first deploy is a warning, not a failure.)
+- **Automated admin-password rotation (close the default-creds window).** Umami boots with
+  `admin`/`umami`; the public endpoint must not sit reachable with known defaults waiting on a
+  manual rotation. After containers are healthy, deploy.ts logs into Umami over the droplet's
+  **localhost interface via SSH** (never the public endpoint) using the default creds and sets
+  the admin password from a new `UMAMI_ADMIN_PASSWORD` GitHub secret (Umami's auth API:
+  `POST /api/auth/login` → token → `POST /api/users/<id>/password` or equivalent for the
+  running version — confirm the exact endpoints at implementation). This is idempotent: once
+  rotated, the default-cred login fails, so deploy.ts treats a failed default-login as
+  "already rotated" and continues. Closes the takeover window entirely. Cost: one extra secret
+  (`UMAMI_ADMIN_PASSWORD`) and a coupling to Umami's auth API shape (pin to the v3.1.0 API;
+  re-verify on image bumps).
+- **Privacy baseline baked into compose env:** `DISABLE_TELEMETRY=1` (no Umami phone-home) and
+  `PRIVATE_MODE=1` (blocks all external calls incl. DuckDuckGo favicon lookups). Cookie-free
+  and DNT are Umami defaults; the downstream tracker tag adds `data-do-not-track="true"`.
+- **Droplet `s-1vcpu-1gb` dedicated.** Umami + a small Postgres is light. Resize trigger
+  documented: bump to `s-1vcpu-2gb` if Postgres memory pressure or sustained query latency
+  appears as traffic grows.
+- **ControlMaster SSH multiplexing** in deploy.ts from the outset (gateway PR #277) — the
+  deploy makes several SSH/scp calls (mkdir, write `.env`, scp compose + Caddyfile, compose
+  up, health check), enough to trip UFW's default 6-new-connections/30s `limit ssh` rule.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Deployment target (Workers vs droplet)? **Droplet + Docker Compose** (operator decision).
+- Hostname? **`metrics.fro.bot`** (Fro Bot recommendation; product-neutral, privacy-aligned).
+- Pin the image or track `latest`? **Pin the versioned PostgreSQL tag**, Renovate-managed.
+- `upstream.json`? **No** — prebuilt image, version pinned in compose.
+- Config preservation like cliproxy? **No** — state is in the Postgres volume; regenerate
+  `.env` each deploy from stable secrets, never remove the volume.
+- Backup in v1 scope? **Manual `pg_dump` runbook in AGENTS.md**; backup/restore CLI deferred.
+- CLI surface? **`status` / `deploy` / `logs`** (issue's stated surface).
+- DB-password rotation safety? **Deploy-time fingerprint guard** — deploy.ts refuses when the
+  secret changed against the volume's initialized password; rotation must go through the
+  `ALTER USER` runbook (root-cause prevention, not docs-only).
+- First-deploy Caddy ACME race on the health check? **Container-health is the success signal;
+  the public-HTTPS probe is a bounded retry that warns (not fails) on cert-issuance lag.**
+  Timeout raised to 180s for first-boot migrations.
+- Default-creds (`admin`/`umami`) exposure window? **Automated post-deploy rotation over the
+  droplet localhost interface** using a new `UMAMI_ADMIN_PASSWORD` secret; idempotent (skips
+  if already rotated). Closes the window without manual action.
+
+### Deferred to Implementation
+
+- Exact `postgresql-v3.1.0` tag existence — confirm against the registry when writing
+  `docker-compose.yaml`; if absent, pin the v3.1.0 release digest (never `latest@digest`).
+- Exact Umami v3.1.0 auth API endpoints for the automated admin rotation (`POST /api/auth/login`
+  → token; the password-update route/shape) — confirm against the running image at
+  implementation; the rotation step is localhost-only and idempotent.
+- Whether `DATABASE_TYPE` must be set explicitly (official compose omits it; env docs mention
+  it as Docker-only) — set it to `postgresql` defensively if the image needs it, decide when
+  testing the first boot.
+- Exact Caddyfile health/timeout tuning and whether Umami needs any proxy-header passthrough
+  beyond Caddy's defaults — confirm on first deploy.
+- Final public-probe retry count/window and `wait-timeout` (start at 180s) — tune from observed
+  first-boot migration duration.
+
+## Output Structure
+
+    apps/umami/
+    ├── package.json                      # @marcusrbrown/infra-umami
+    ├── AGENTS.md                         # operator docs (Unit 8)
+    ├── docker-compose.yaml               # umami + postgres + caddy, pinned, healthchecks
+    ├── config/
+    │   └── Caddyfile                     # metrics.fro.bot reverse_proxy umami:3000
+    ├── src/
+    │   ├── deploy.ts                     # env validation, .env materialization, compose, health-gate
+    │   ├── deploy.test.ts
+    │   ├── host.ts                       # validateUmamiHost
+    │   └── host.test.ts
+    └── server/
+        ├── provision-droplet.ts          # doctl, key-by-name, pinHostKeys, import.meta.main guard
+        └── provision-droplet.test.ts
+
+    packages/cli/src/commands/umami/
+    ├── index.ts                          # registerUmamiCommands + getUmamiStatusSummary
+    ├── status.ts                         # SSH docker compose ps (NDJSON), ActionCtx, MCP-capturable
+    ├── status.test.ts
+    ├── deploy.ts                         # gh workflow run default + --local
+    ├── deploy.test.ts
+    ├── logs.ts                           # stream container logs, CI-refusal + sensitive warning
+    ├── logs.test.ts
+    ├── host.ts                           # validateUmamiHost (CLI copy mirroring gateway)
+    └── host.test.ts
+
+    .github/workflows/deploy-umami.yaml   # SHA-pinned, paths-filter quantifier, environment: umami
+
+## Implementation Units
+
+- [ ] **Unit 1: App scaffolding — package, compose stack, Caddy, Renovate pin**
+
+**Goal:** Create the `apps/umami/` package with the Docker Compose stack (Umami + Postgres +
+Caddy), Caddy reverse-proxy config, and the Renovate image-pin entry. `docker compose config`
+validates; `bun install` refreshes the lockfile for the new workspace member.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `apps/umami/package.json` (`@marcusrbrown/infra-umami`, private; scripts
+  `deploy`/`provision`/`test`; dep `@marcusrbrown/infra-shared`)
+- Create: `apps/umami/docker-compose.yaml`
+- Create: `apps/umami/config/Caddyfile`
+- Create: `apps/umami/AGENTS.md` (placeholder; fleshed out in Unit 8)
+- Modify: `.github/renovate.json5` (packageRules entry for the Umami image: sourceUrl
+  `https://github.com/umami-software/umami`, changelogUrl, standalone PR group)
+- Modify: `bun.lock` (commit after `bun install`)
+
+**Approach:**
+- Compose: three services. `umami` (image
+  `docker.umami.is/umami-software/umami:postgresql-v3.1.0`, `init: true`, `restart:
+  unless-stopped`, env from `.env` — `DATABASE_URL`, `APP_SECRET`, `DISABLE_TELEMETRY=1`,
+  `PRIVATE_MODE=1`, optionally `DATABASE_TYPE=postgresql`; healthcheck `curl -f
+  http://localhost:3000/api/heartbeat`; `depends_on: db: condition: service_healthy`).
+  `db` (`postgres:15-alpine`, `restart: unless-stopped`, env `POSTGRES_DB=umami`/
+  `POSTGRES_USER=umami`/`POSTGRES_PASSWORD` from `.env`; healthcheck `pg_isready -U umami -d
+  umami`; named volume `umami-db-data:/var/lib/postgresql/data`). The `db` service publishes
+  NO host port — no `ports:` mapping, never expose `5432` — reachable only on the internal
+  compose network. `caddy` (`caddy:2.11-alpine`
+  digest-pinned, `80:80`/`443:443`, `caddy_data`+`caddy_config` named volumes, mounts
+  `./config/Caddyfile`, `reverse_proxy umami:3000`).
+- Caddyfile: `{$UMAMI_HOST} { reverse_proxy umami:3000 }` (Caddy auto-TLS).
+- Privacy env set at the compose layer so it's tracked and reviewable, not just on the droplet.
+- Do NOT put real secret values in any tracked file — `APP_SECRET`/`POSTGRES_PASSWORD` come
+  from the droplet `.env` written by deploy.ts (Unit 3). Tracked compose references them via
+  `${VAR}` interpolation from the `.env`.
+
+**Patterns to follow:** `apps/cliproxy/docker-compose.yaml`, `apps/cliproxy/config/Caddyfile`,
+the `caddy`/`eceasy` packageRules in `.github/renovate.json5`.
+
+**Test scenarios:**
+- Test expectation: none for the YAML/config files themselves (no behavioral code) — validate
+  via `docker compose config` exit 0 in the Unit's verification, and the executable conventions
+  test (`packages/cli/src/conventions.test.ts`) already enforces `.yaml` extension / no
+  bundledDependencies repo-wide.
+
+**Verification:**
+- `docker compose -f apps/umami/docker-compose.yaml config` exits 0.
+- `bun install` produces a clean `bun.lock` diff (new workspace member only).
+- No secret values in any tracked file (grep clean).
+
+- [ ] **Unit 2: Host validation**
+
+**Goal:** `validateUmamiHost` rejects `-`-prefixed hostnames and characters outside
+`[A-Za-z0-9.-]` before any value reaches SSH argv.
+
+**Requirements:** R3
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `apps/umami/src/host.ts`
+- Create: `apps/umami/src/host.test.ts`
+
+**Approach:** Clone `apps/gateway/src/host.ts` exactly (same regex, same throw message shape,
+renamed `validateUmamiHost`). This is a security-critical guard — SSH treats `-`-prefixed
+hostnames as flags (e.g. `-oProxyCommand=`).
+
+**Execution note:** Test-first — write the rejection cases before the implementation; this is
+a security boundary with a known contract.
+
+**Patterns to follow:** `apps/gateway/src/host.ts`, `apps/gateway/src/host.test.ts`.
+
+**Test scenarios:**
+- Happy path: `metrics.fro.bot`, `1.2.3.4` → accepted.
+- Error path: `-oProxyCommand=evil` → throws.
+- Error path: hostnames with spaces, `;`, `|`, `$`, backticks, quotes → throws.
+- Edge case: empty string → throws.
+
+**Verification:** All rejection cases throw; valid hosts pass; tests green.
+
+- [ ] **Unit 3: deploy.ts — env validation, `.env` materialization, compose, health-gate**
+
+**Goal:** `apps/umami/src/deploy.ts` validates env, materializes the droplet `.env` via SSH
+stdin (never argv), uploads compose + Caddyfile, runs `docker compose pull && up -d --wait`,
+guards against a DB-password change that would brick the volume, gates on container health
+with a bounded public-HTTPS retry, and rotates the default admin password over localhost.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1 (compose stack), Unit 2 (host validation).
+
+**Files:**
+- Create: `apps/umami/src/deploy.ts`
+- Create: `apps/umami/src/deploy.test.ts`
+
+**Approach:**
+- Validate env before any SSH: `PATH`, `HOME`, SSH context (`SSH_AUTH_SOCK` for local, or
+  `UMAMI_SSH_KEY` temp-key-file for CI with trailing-`\n` append), `UMAMI_HOST`,
+  `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, `UMAMI_ADMIN_PASSWORD`. Call
+  `validateUmamiHost(UMAMI_HOST)` before constructing any SSH argv.
+- ControlMaster/ControlPersist SSH multiplexing (gateway PR #277) with a temp socket dir,
+  reused across all SSH/scp calls; clean up the socket on exit.
+- Remote: `mkdir -p /opt/umami/config`. Write `/opt/umami/.env` via
+  `Bun.spawn(ssh(...), {stdin: 'pipe'})` then `proc.stdin.write(contents); proc.stdin.end()` —
+  contents = `APP_SECRET=...\nPOSTGRES_PASSWORD=...\nDATABASE_URL=postgresql://umami:<pw>@db:5432/umami\nUMAMI_HOST=...\n`.
+  Apply defensive validation at the boundary (reject `\n`, `\r`, backtick, `$`, `|`, `;`, `&`,
+  quotes, backslash in the secret values used in remote shell context). No deploy error path
+  ever echoes secret contents; tests assert the `.env` is written only via stdin and never
+  logged.
+- Preflight: resolve `UMAMI_HOST` DNS before attempting SSH/deploy and fail fast with a clear
+  message if it does not resolve — prevents a late, opaque Caddy ACME failure when DNS isn't
+  configured yet.
+- `scp` `docker-compose.yaml` → `/opt/umami/docker-compose.yaml` and `config/Caddyfile` →
+  `/opt/umami/config/Caddyfile`.
+- **DB-password fingerprint guard (before compose up):** compute a salted SHA-256 of
+  `POSTGRES_PASSWORD`. Read the droplet sentinel `/opt/umami/.db-password-fingerprint` (if it
+  exists). If present and it does NOT match the current fingerprint, **refuse to deploy** with
+  a message naming the `ALTER USER` runbook (Unit 8) — the volume was initialized with a
+  different password and proceeding would break DB auth. If absent (first deploy), proceed and
+  write the sentinel after a successful `up`. The sentinel holds only the hash, never the
+  password.
+- `cd /opt/umami && docker compose pull && docker compose up -d --wait --wait-timeout 180`.
+  Container health (`pg_isready` + umami localhost `/api/heartbeat`) via `--wait` is the
+  authoritative success signal. After success, write the DB-password fingerprint sentinel.
+- **Bounded public-HTTPS probe (warning, not gate):** retry `GET https://${UMAMI_HOST}/api/heartbeat`
+  (~6 attempts over ~60s) expecting `{"ok":true}`. On success, done. On lingering failure
+  (first-deploy Caddy ACME lag), emit a WARNING (`containers healthy; TLS cert still issuing —
+  verify at https://${UMAMI_HOST}/api/heartbeat`) and **succeed** — do not throw. `compose up`
+  is idempotent so a re-run is always safe.
+- **Automated admin-password rotation (over localhost, after health):** via SSH on the
+  droplet, hit Umami's auth API on `http://localhost:3000` (never the public host): log in with
+  default `admin`/`umami`, and if that succeeds set the admin password to
+  `UMAMI_ADMIN_PASSWORD`. If the default login FAILS, treat it as already-rotated and continue
+  (idempotent). Confirm the exact v3.1.0 auth endpoints at implementation (`POST /api/auth/login`
+  → token; password-update route). The admin password value travels via SSH stdin / request
+  body, never argv.
+- Never `docker compose down -v` (would destroy the Postgres volume). The deploy only does
+  `up -d`.
+
+**Execution note:** Test-first for the env-validation, host-validation, and command-construction
+paths (mock `Bun.spawn` at the boundary; assert no secret bytes in argv).
+
+**Patterns to follow:** `apps/gateway/src/deploy.ts` (secret-file stdin, ControlMaster, CI
+key-file + trailing newline, env validation), `apps/cliproxy/src/deploy.ts` (compose
+pull/up/--wait + post-deploy HTTPS health check).
+
+**Test scenarios:**
+- Happy path: all env present → builds the expected SSH/scp/compose command sequence; the
+  `.env` contents are piped via stdin, not argv.
+- Error path: missing `UMAMI_HOST` / `UMAMI_APP_SECRET` / `UMAMI_DB_PASSWORD` /
+  `UMAMI_ADMIN_PASSWORD` / SSH context → throws a specific message, no SSH attempted.
+- Error path (security): `UMAMI_HOST='-oProxyCommand=x'` → `validateUmamiHost` throws before
+  any argv construction.
+- Error path (security): a secret value containing `\n`/`\r` or shell metacharacters → rejected
+  at the boundary, never written.
+- Error path (DB-password guard): sentinel exists with a non-matching fingerprint → deploy
+  refuses before `compose up`, message names the rotation runbook, no compose invoked.
+- Happy path (first deploy): no sentinel → proceeds, writes the sentinel after a healthy `up`;
+  fingerprint is a hash, the password never appears in the sentinel contents.
+- Edge case (fingerprint match): sentinel matches current secret → deploy proceeds normally.
+- Edge case (Caddy ACME lag): public-HTTPS probe never returns `{"ok":true}` within the retry
+  window but containers are healthy → deploy SUCCEEDS with a warning (does NOT throw).
+- Integration (public health success): public probe returns `{"ok":true}` → no warning.
+- Edge case (admin rotation idempotency): default `admin`/`umami` login fails (already rotated)
+  → rotation step is skipped, deploy continues; login succeeds → password is set to
+  `UMAMI_ADMIN_PASSWORD` and the admin password value never appears in argv.
+- Edge case: CI mode (`UMAMI_SSH_KEY` set, no `SSH_AUTH_SOCK`) → writes a temp key file with a
+  trailing newline, `chmod 600`, cleans it up.
+- Edge case: no secret bytes (DB password, app secret, admin password) appear in any
+  constructed argv array (assert across the whole command sequence).
+
+**Verification:** Tests green; manual first deploy reaches `{"ok":true}` over HTTPS (or warns
+on cert lag and a follow-up `umami status` confirms); the default admin login no longer works
+post-deploy; the Postgres volume persists across a second deploy (data not wiped); a deploy
+with a changed `UMAMI_DB_PASSWORD` is refused by the fingerprint guard.
+
+- [ ] **Unit 4: provision-droplet.ts**
+
+**Goal:** One-time droplet provisioning for `metrics.fro.bot`: create the droplet, select the
+SSH key by name, wait for SSH, pin host keys into `.github/known_hosts`.
+
+**Requirements:** R1, R8
+
+**Dependencies:** Unit 2 (host validation reused for any host arg).
+
+**Files:**
+- Create: `apps/umami/server/provision-droplet.ts`
+- Create: `apps/umami/server/provision-droplet.test.ts`
+
+**Approach:**
+- Import shared helpers from `@marcusrbrown/infra-shared`: `validateDoctl({checkAuth: true})`,
+  `dropletExists` (abort if exists unless `--force`), `getSshFingerprint`,
+  `getDropletIpWithWait`, `waitForSsh`, `pinHostKeys`, `run`.
+- Create `s-1vcpu-1gb` droplet, image slug `docker-20-04` (the corrected slug — NOT
+  `docker-24-04`), region matching the other droplets.
+- Key selection by name: `UMAMI_SSH_KEY_NAME` env override, default `fro-bot-umami`
+  (`getSshFingerprint` matches by name, never by position — the PR #268 lesson).
+- After SSH connectivity, `pinHostKeys` appends both the `metrics.fro.bot` domain (unhashed)
+  and the droplet IP entries to `.github/known_hosts`; print a reminder to commit it.
+- Gate all top-level execution behind `if (import.meta.main)` so test imports don't trigger
+  live `doctl`/`ssh`/network calls.
+
+**Execution note:** Test-first for the guard behavior and key-selection logic (mock the shared
+helpers / `Bun.spawn`).
+
+**Patterns to follow:** `apps/gateway/server/provision-droplet.ts`,
+`apps/cliproxy/server/provision-droplet.ts`, `packages/shared/server/droplet-helpers.ts`.
+
+**Test scenarios:**
+- Happy path: provisions, selects key `fro-bot-umami` by name, pins both host-key forms.
+- Edge case: `UMAMI_SSH_KEY_NAME` override → that key name is used.
+- Error path: droplet already exists, no `--force` → aborts with a clear message, no creation.
+- Error path: `doctl` not authenticated → aborts.
+- Integration: importing the module in a test does NOT trigger `doctl`/network (the
+  `import.meta.main` guard holds).
+
+**Verification:** Tests green; live run creates the droplet and appends host keys; re-run
+without `--force` refuses.
+
+- [ ] **Unit 5: CLI command module (`umami status` / `deploy` / `logs` / host)**
+
+**Goal:** `packages/cli/src/commands/umami/` with `status`, `deploy`, `logs`, a CLI-side
+`host.ts`, and the `index.ts` barrel; registered in `cli.ts`.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 3 (deploy.ts target for `--local`), Unit 4.
+
+**Files:**
+- Create: `packages/cli/src/commands/umami/index.ts` (`registerUmamiCommands` +
+  `getUmamiStatusSummary` export)
+- Create: `packages/cli/src/commands/umami/status.ts` + `status.test.ts`
+- Create: `packages/cli/src/commands/umami/deploy.ts` + `deploy.test.ts`
+- Create: `packages/cli/src/commands/umami/logs.ts` + `logs.test.ts`
+- Create: `packages/cli/src/commands/umami/host.ts` + `host.test.ts`
+- Modify: `packages/cli/src/cli.ts` (register the barrel)
+- Modify: `packages/cli/src/commands/mcp.ts` (add `umami status` to `MCP_ALLOWLIST`)
+- Modify: `packages/cli/src/__snapshots__/cli.test.ts.snap` (help output)
+
+**Approach:**
+- `status.ts`: SSH `docker compose --project-directory /opt/umami ps --format json`, parse
+  both JSON-array and NDJSON (PR #278), render service/state/health rows; thread `ActionCtx`
+  for MCP capture; export `getUmamiStatusSummary(host)` for the unified rollup; an HTTP
+  `/api/heartbeat` check may augment the summary. Action body is a named export delegating
+  from `.action()`; try/catch routes failures to `ctx.console.error` with `ctx.process.exit(1)`
+  outside the try (the MCP double-catch lesson).
+- `deploy.ts`: default `gh workflow run "Deploy Umami" --repo marcusrbrown/infra` (requires
+  `gh`); `--local` runs `bun run --cwd apps/umami deploy`; `--dry-run` prints the plan.
+- `logs.ts`: SSH tail `docker compose logs`; refuse streaming under CI unless `--allow-ci`;
+  always emit a sensitive-data stderr warning (mirror gateway `logs.ts`).
+- `host.ts`: `validateUmamiHost` (CLI copy mirroring `packages/cli/src/commands/gateway/host.ts`),
+  called in `status`/`logs` before SSH argv.
+- Snapshot test normalizes the version string (`stdout.replace(/infra\/\d+\.\d+\.\d+/,
+  'infra/x.x.x')`) and uses `NO_COLOR=1`.
+
+**Execution note:** Test-first per command; mock `Bun.spawn`/`fetch` at the boundary.
+
+**Patterns to follow:** `packages/cli/src/commands/gateway/` (all four files + barrel),
+`packages/cli/src/commands/mcp.ts`, `packages/cli/src/lib/action-ctx.ts`.
+
+**Test scenarios:**
+- `status`: NDJSON output parsed → service rows; JSON-array output parsed; SSH failure →
+  `ctx.console.error` + exit 1 (no throw); host validation rejects bad host before SSH;
+  output flows through `ctx` (Tier-2 MCP capture).
+- `deploy`: remote mode constructs `gh workflow run "Deploy Umami"`; `--local` constructs
+  `bun run --cwd apps/umami deploy`; `--dry-run` prints without side effects; missing `gh` →
+  clear error.
+- `logs`: CI without `--allow-ci` → refuses; `--allow-ci` → proceeds; sensitive-data warning
+  always emitted; host validated before SSH.
+- `host`: same rejection/acceptance matrix as Unit 2.
+- Help snapshot: includes `umami status`/`deploy`/`logs`; version normalized.
+
+**Verification:** All command help responds; tests green; `umami status` appears as an MCP
+tool when the allowlist is asserted.
+
+- [ ] **Unit 6: Unified status rollup wiring**
+
+**Goal:** `umami` appears in `bunx @marcusrbrown/infra status` (table + `--json`).
+
+**Requirements:** R5
+
+**Dependencies:** Unit 5 (`getUmamiStatusSummary`).
+
+**Files:**
+- Modify: `packages/cli/src/commands/status.ts`
+- Modify: `packages/cli/src/commands/status.test.ts`
+- Modify: `packages/cli/src/__snapshots__/` if the table snapshot changes
+
+**Approach:** Extend `StatusSummary['app']` union with `'umami'`; add the
+`getUmamiStatusSummary` import + `StatusDependencies` entry; add to the `Promise.allSettled`
+array and the `appNames` array (order matters — append after gateway); extend `toJsonPayload`
+with the `umami` key. Use `UMAMI_HOST` from env (mirroring `GATEWAY_HOST`).
+
+**Patterns to follow:** the `gateway` wiring already present in `status.ts`.
+
+**Test scenarios:**
+- Happy path: all four apps resolve → table has a `umami` row; `--json` payload has a `umami`
+  key.
+- Error path: `umami` aggregator rejects → `errorSummary('umami', ...)` cell, other apps
+  unaffected (graceful degradation).
+- Edge case: `UMAMI_HOST` unset → umami row shows the not-configured error, not a crash.
+
+**Verification:** `status` table + `--json` include `umami`; tests green.
+
+- [ ] **Unit 7: Deploy workflow**
+
+**Goal:** `.github/workflows/deploy-umami.yaml` deploys on push (path-filtered) or
+`workflow_dispatch`, in the `umami` environment, with pinned host keys and explicit secrets.
+
+**Requirements:** R8
+
+**Dependencies:** Unit 3 (deploy target).
+
+**Files:**
+- Create: `.github/workflows/deploy-umami.yaml`
+- Modify: `.github/known_hosts` (host-key block added at provision time, Unit 4 — committed
+  before first CI deploy)
+
+**Approach:** Mirror `.github/workflows/deploy-cliproxy.yaml`: SHA-pinned actions with
+`# vX.Y.Z` comments; `dorny/paths-filter` with `predicate-quantifier: every` and a filter
+matching `apps/umami/**` while excluding `apps/umami/**/*.md`, `**/*.test.ts`, `__fixtures__`,
+`__snapshots__`; `environment: umami`; `cp .github/known_hosts ~/.ssh/known_hosts` (never
+`ssh-keyscan`); `bun install --frozen-lockfile --ignore-scripts`; explicit secrets
+(`UMAMI_SSH_KEY`, `UMAMI_HOST`, `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, `UMAMI_ADMIN_PASSWORD`,
+`DIGITALOCEAN_ACCESS_TOKEN` if needed); deploy condition `workflow_dispatch || umami-changed`.
+No Node-24 pin (no lint/tsc step in a deploy workflow).
+
+**Test scenarios:**
+- Test expectation: none (workflow YAML) — validated by YAML parse + the executable
+  conventions test (`.yaml` extension, SHA-pin, no `secrets: inherit`, no `ssh-keyscan` in CI,
+  paths-filter quantifier guard all already enforced in `packages/cli/src/conventions.test.ts`).
+
+**Verification:** `conventions.test.ts` passes (it scans all workflows); YAML parses; the
+paths-filter quantifier guard is satisfied; a workflow-only change does not trigger the deploy
+(quantifier correct).
+
+- [ ] **Unit 8: Operator docs (`apps/umami/AGENTS.md`) + root AGENTS.md cross-reference**
+
+**Goal:** Complete operator documentation for deploy, day-2 ops, privacy baseline, persistence,
+and lifecycle.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** Units 1–7 (documents their behavior).
+
+**Files:**
+- Modify: `apps/umami/AGENTS.md` (flesh out the Unit 1 placeholder)
+- Modify: `AGENTS.md` (root — add umami to structure/where-to-look/commands/secrets)
+- Modify: `packages/cli/AGENTS.md` if umami CLI conventions need a note
+
+**Approach:** Cover: deploy flow (remote default + `--local`, the container-health gate +
+bounded public-HTTPS warning), the automated admin-password rotation (deploy.ts rotates
+`admin`/`umami` → `UMAMI_ADMIN_PASSWORD` over localhost; document that operators no longer log
+in with defaults, and how to recover/re-rotate if needed), the privacy baseline
+(`DISABLE_TELEMETRY=1`, `PRIVATE_MODE=1`, cookie-free + DNT defaults, the downstream tracker
+tag with `data-do-not-track`/`data-exclude-search`/`data-exclude-hash`), Postgres
+backup/restore runbook (`pg_dump` over SSH; named volume `umami-db-data`), **retention
+policy** — state a concrete policy: either a defined retention window with a deletion
+procedure, or an explicit, justified decision to retain indefinitely (not merely "indefinite
+by default"), **secret rotation** — the **`ALTER USER` DB-password rotation runbook** (the
+fingerprint guard refuses a naive rotation; the runbook is: deploy still on old secret → SSH
+`ALTER USER umami WITH PASSWORD '<new>'` against the live DB → update the `UMAMI_DB_PASSWORD`
+secret AND the droplet sentinel → redeploy), plus `APP_SECRET` rotation (invalidates
+sessions) and `UMAMI_ADMIN_PASSWORD` rotation (re-run deploy or rotate in-app), and the
+upgrade flow (bump the pinned image tag via Renovate → deploy; re-verify the auth-rotation API
+shape on major bumps). Anti-patterns: never `docker compose down -v` (destroys the DB volume);
+never rotate `UMAMI_DB_PASSWORD` outside the `ALTER USER` runbook; never put secrets in argv.
+R6: document the exact Systematic docs `<script>` tag with the captured `data-website-id`
+placeholder so the downstream task can drop it in.
+
+**Test scenarios:**
+- Test expectation: none (documentation) — but the plan-taxonomy grep gate and the
+  no-secret-values rule apply: no `R[0-9]`/`Unit N` in shipped AGENTS.md prose, no real secret
+  values.
+
+**Verification:** Docs cover all R7 topics; `metrics.fro.bot` privacy defaults documented;
+the script tag for the downstream consumer is present; grep-clean of secrets and plan
+taxonomy.
+
+## System-Wide Impact
+
+- **Interaction graph:** New deploy workflow + new CLI command group + a new row in the unified
+  `status` rollup. No change to keeweb/cliproxy/gateway behavior. `cli.ts` gains one more
+  `register*Commands` call.
+- **Error propagation:** deploy.ts must throw (fail the deploy) on health-gate failure, never
+  report success on a booting/unreachable instance. CLI actions route operational failures
+  through `ctx.console.error` + `ctx.process.exit(1)` (outside try) for MCP-visible content.
+- **State lifecycle risks:** The Postgres volume `umami-db-data` is user data — the deploy must
+  never `down -v`. The `UMAMI_DB_PASSWORD`↔volume coupling is the highest-risk footgun;
+  documented as an anti-pattern with a migration runbook. First boot runs DB migrations
+  (longer than cliproxy's boot — hence the 180s wait-timeout). The `UMAMI_DB_PASSWORD`↔volume
+  coupling is guarded structurally by deploy.ts's fingerprint check (refuses a bricking
+  rotation), not just documented.
+- **API surface parity:** `umami status` joins `gateway status` as an MCP-capturable,
+  ActionCtx-threaded, NDJSON-parsing command — same Tier-1/Tier-2 test bar.
+- **Integration coverage:** First deploy is the real contract test (per both cascade docs) —
+  expect multiple attempts; the health-gate + the conventions test + the boundary tests are the
+  safety net.
+- **Unchanged invariants:** No change to the published CLI runtime contracts of existing apps;
+  the new commands are additive. `packages/shared/` helpers are reused, not modified. The
+  unified `status` JSON gains a `umami` key (additive — existing consumers ignoring unknown
+  keys are unaffected).
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| First-deploy cascade (lockfile, host keys, SSH key newline, readiness race) | High | Med | Bake every documented prevention into the units; treat first deploy as contract validation, expect 2-3 attempts (both cascade docs). |
+| `UMAMI_DB_PASSWORD` rotated → Postgres volume auth break | Med | High | **Deploy-time fingerprint guard** in deploy.ts refuses the deploy when the secret no longer matches the volume's initialized password (hash sentinel on the droplet); rotation must go through the `ALTER USER` runbook (Unit 8) which updates both the role and the sentinel. Root-cause prevention, not docs-only. |
+| `postgresql-v3.1.0` tag may not exist (docs show `postgresql-latest`) | Med | Low | Confirm at implementation; if absent, pin the specific digest of the v3.1.0 release image (never `latest@digest` — not equivalent to v3.1.0); document the exact digest. |
+| UFW SSH rate-limit on multi-call deploy | Med | Med | ControlMaster multiplexing in deploy.ts from the start (gateway PR #277). |
+| First-deploy public-HTTPS health check false-fails on Caddy ACME cert lag | Med | Med | Container-health (`compose --wait`) is the authoritative success signal; the public-HTTPS probe is a bounded retry that emits a WARNING (not a failure) on cert-issuance lag. `compose up` is idempotent. |
+| First-boot DB migration exceeds wait-timeout | Med | Low | 180s timeout; container-health is the gate, not a fixed time; re-run is idempotent. |
+| Public analytics endpoint exposed with default `admin`/`umami` creds | Med | High | **Automated post-deploy rotation** over the droplet localhost interface using `UMAMI_ADMIN_PASSWORD`; idempotent (skips if already rotated). Closes the takeover window without manual action. |
+| Indefinite data retention drifts into a privacy liability | Low | Med | AGENTS.md states the retention policy explicitly; `PRIVATE_MODE`+`DISABLE_TELEMETRY` minimize collection; cookie-free + DNT by default. |
+
+## Documentation / Operational Notes
+
+- **No changeset** for most units — `apps/umami/`, workflows, and AGENTS.md don't affect the
+  published `@marcusrbrown/infra` runtime. **Unit 5 (CLI commands) DOES ship in
+  `packages/cli/src/` and is user-facing → it warrants a `minor` changeset** (new `umami`
+  command surface). Unit 6 (status rollup) ships in the same changeset.
+- **Operator prerequisites (Marcus owns, before first CI deploy):**
+  1. Register an SSH key named `fro-bot-umami` with DigitalOcean.
+  2. Run `apps/umami/server/provision-droplet.ts` (loads `.env` from CWD — run from repo root)
+     → creates the droplet, pins host keys → commit `.github/known_hosts`.
+  3. Configure DNS: `metrics.fro.bot` A record → droplet IP.
+  4. Create the `umami` GitHub environment (reviewer `marcusrbrown`, `main` branch only).
+  5. Set environment secrets: `UMAMI_SSH_KEY` (private key, trailing newline handled by
+     deploy.ts), `UMAMI_HOST=metrics.fro.bot`, `UMAMI_APP_SECRET` (random hex),
+     `UMAMI_DB_PASSWORD` (random — rotate only via the `ALTER USER` runbook), and
+     `UMAMI_ADMIN_PASSWORD` (random — deploy.ts sets the Umami admin password to this over
+     localhost). Add to `.env` locally too.
+  6. First deploy → deploy.ts auto-rotates the default admin password to `UMAMI_ADMIN_PASSWORD`
+     (no manual rotation needed). Log in with `admin` / `UMAMI_ADMIN_PASSWORD` to verify.
+  7. Create the Systematic docs website in Umami → capture the `data-website-id` (R6).
+- The `umami` environment secrets and the prerequisite list should land in root `AGENTS.md`
+  notes alongside the existing keeweb/cliproxy/gateway secret documentation.
+
+## Sources & References
+
+- **Origin:** GitHub issue #315 + Fro Bot triage comment (4560738565).
+- Repo patterns: `apps/cliproxy/` (Caddy+public-HTTP), `apps/gateway/` (provision/secret-file/
+  CLI/ControlMaster), `packages/shared/server/droplet-helpers.ts`,
+  `packages/cli/src/commands/gateway/`, `packages/cli/src/commands/status.ts`,
+  `.github/workflows/deploy-cliproxy.yaml`.
+- Learnings: `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md`,
+  `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md`.
+- Umami: v3.1.0 release, docs.umami.is (install, environment-variables, tracker-configuration,
+  faq), official docker-compose.yml, `/api/heartbeat` route.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -31,7 +31,7 @@ export default defineConfig(
   },
   {
     name: 'cli-and-scripts',
-    files: ['**/cli.ts', '**/build.ts', '**/setup-*.ts'],
+    files: ['**/cli.ts', '**/build.ts', '**/setup-*.ts', '**/provision-droplet.ts'],
     rules: {
       'no-console': 'off',
     },

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -125,6 +125,23 @@ Commands:
     --include-ca                       Restore the mitmproxy CA certificate and private key. Currently the only supported restore target. (default: true)
 
 
+  umami status                         Show operational health of the Umami analytics deployment via docker compose ps.
+
+    --key [key]                        Environment variable name holding the SSH host. Falls back to UMAMI_DOMAIN when omitted.
+
+
+  umami deploy                         Deploy Umami analytics. Default mode triggers the GitHub Deploy Umami workflow, while --local runs apps/umami deploy directly with Bun.
+
+    --local                            Run local deployment with Bun using apps/umami instead of triggering GitHub Actions. (default: false)
+    --dry-run                          Validate deploy prerequisites and print planned actions without executing local deploy or dispatching workflow. (default: false)
+
+
+  umami logs [service]                 Stream logs from an Umami service via SSH and docker compose.
+
+    --tail [n]                         Number of log lines to tail from each service. (default: 100)
+    --allow-ci                         Allow log streaming in CI environments. Logs may contain sensitive credentials. (default: false)
+
+
   status                               Show status of all deployments
 
     --json                             Output machine-readable JSON with keeweb, cliproxy, and gateway summary objects.

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -140,11 +140,12 @@ Commands:
 
     --tail [n]                         Number of log lines to tail from each service. (default: 100)
     --allow-ci                         Allow log streaming in CI environments. Logs may contain sensitive credentials. (default: false)
+    --key [key]                        Environment variable name holding the SSH host. Falls back to UMAMI_DOMAIN when omitted.
 
 
   status                               Show status of all deployments
 
-    --json                             Output machine-readable JSON with keeweb, cliproxy, and gateway summary objects.
+    --json                             Output machine-readable JSON with keeweb, cliproxy, gateway, and umami summary objects.
     --verbose                          Include verbose per-app health check details when building the summary rows.
 
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import {registerGatewayCommands} from './commands/gateway'
 import {registerKeewebCommands} from './commands/keeweb'
 import {registerMcp} from './commands/mcp'
 import {registerStatus} from './commands/status'
+import {registerUmamiCommands} from './commands/umami'
 
 declare const process: {
   argv: string[]
@@ -20,6 +21,7 @@ cli.option('--verbose', 'Enable verbose output for all commands')
 registerKeewebCommands(cli)
 registerCliproxyCommands(cli)
 registerGatewayCommands(cli)
+registerUmamiCommands(cli)
 registerStatus(cli)
 registerMcp(cli)
 

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -37,6 +37,7 @@ import {registerGatewayCommands} from './gateway'
 import {registerKeewebCommands} from './keeweb'
 import {MCP_ALLOWLIST, registerMcp} from './mcp'
 import {registerStatus} from './status'
+import {registerUmamiCommands} from './umami'
 
 // ─── Tool name constants ──────────────────────────────────────────────────────
 
@@ -64,6 +65,7 @@ function buildTestCli(): ReturnType<typeof goke> {
   registerKeewebCommands(cli)
   registerCliproxyCommands(cli)
   registerGatewayCommands(cli)
+  registerUmamiCommands(cli)
   registerStatus(cli)
   registerMcp(cli)
   return cli
@@ -105,7 +107,7 @@ describe('mcp integration (Tier-1, in-process)', () => {
 
   // ── tools/list assertions ──────────────────────────────────────────────────
 
-  test('tools/list returns exactly the 10 allowlist tool names', async () => {
+  test('tools/list returns exactly the allowlist tool names', async () => {
     const result = await client.listTools()
     const names = result.tools.map((t: {name: string}) => t.name).sort()
     expect(names).toEqual(EXPECTED_TOOLS)

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -55,6 +55,8 @@ const CLI_ONLY_TOOLS = [
   'gateway_restore',
   'keeweb_deploy',
   'keeweb_open',
+  'umami_deploy',
+  'umami_logs',
 ].sort()
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -24,6 +24,7 @@ export const MCP_ALLOWLIST: ReadonlySet<string> = new Set([
   'cliproxy config get',
   'cliproxy config set',
   'keeweb status',
+  'umami status',
   'status',
 ])
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -13,6 +13,8 @@ import {createMcpAction} from '@goke/mcp'
  * - `cliproxy setup`   — interactive (@clack/prompts wizard, requires TTY)
  * - `gateway restore`  — destructive policy (replaces mitmproxy CA on live gateway, deferred to MCP v2 #292)
  * - `keeweb open`      — host-machine side effect (spawns local browser, requires user intent)
+ * - `umami deploy`     — intentionally CLI-only: mutates live deployment and requires environment approval
+ * - `umami logs`       — intentionally CLI-only: streams logs that may emit sensitive data (DB passwords, app secrets)
  */
 export const MCP_ALLOWLIST: ReadonlySet<string> = new Set([
   'gateway status',

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -31,11 +31,21 @@ const healthyGateway: StatusSummary = {
   usageStats: '—',
 }
 
+const healthyUmami: StatusSummary = {
+  app: 'umami',
+  http: 'OK: umami:running/healthy',
+  lastDeploy: '—',
+  version: '—',
+  contentHash: '—',
+  usageStats: '—',
+}
+
 function makeDeps(overrides?: Partial<Parameters<typeof registerStatus>[1]>): Parameters<typeof registerStatus>[1] {
   return {
     getKeewebStatusSummary: async () => healthyKeeweb,
     getCliproxyStatusSummary: async () => healthyCliproxy,
     getGatewayStatusSummary: async () => healthyGateway,
+    getUmamiStatusSummary: async () => healthyUmami,
     ...overrides,
   }
 }
@@ -52,6 +62,30 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
     expect(expectCapturedToInclude(captured, '| keeweb | OK | 2026-04-12 10:00 | — | match | — |')).toBe(true)
     expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
     expect(expectCapturedToInclude(captured, '| gateway | OK: gateway:running/healthy | — | — | — | — |')).toBe(true)
+    expect(expectCapturedToInclude(captured, '| umami | OK: umami:running/healthy | — | — | — | — |')).toBe(true)
+  })
+
+  it('shows an error row when umami is unreachable and keeps the other results', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await unifiedStatusAction(
+      {},
+      ctx,
+      makeDeps({
+        getUmamiStatusSummary: async () => {
+          throw new Error('UMAMI_DOMAIN not set')
+        },
+      }),
+    )
+
+    expect(
+      expectCapturedToInclude(
+        captured,
+        '| umami | ❌ UMAMI_DOMAIN not set | ❌ UMAMI_DOMAIN not set | ❌ UMAMI_DOMAIN not set | ❌ UMAMI_DOMAIN not set | ❌ UMAMI_DOMAIN not set |',
+      ),
+    ).toBe(true)
+    expect(expectCapturedToInclude(captured, '| gateway | OK: gateway:running/healthy | — | — | — | — |')).toBe(true)
+    expect(captured.stderr.join('')).toContain('umami status check failed: UMAMI_DOMAIN not set')
   })
 
   it('shows an error row when one app fails and keeps the other results', async () => {
@@ -92,11 +126,13 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
       keeweb: {http: string}
       cliproxy: {version: string}
       gateway: {http: string}
+      umami: {http: string}
     }
 
     expect(parsed.keeweb.http).toBe('OK')
     expect(parsed.cliproxy.version).toBe('v1.2.3')
     expect(parsed.gateway.http).toBe('OK: gateway:running/healthy')
+    expect(parsed.umami.http).toBe('OK: umami:running/healthy')
   })
 
   it('does not write to global console (output is captured via ctx)', async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -133,7 +133,7 @@ export function registerStatus(
     .command('status', 'Show status of all deployments')
     .option(
       '--json',
-      z.boolean().describe('Output machine-readable JSON with keeweb, cliproxy, and gateway summary objects.'),
+      z.boolean().describe('Output machine-readable JSON with keeweb, cliproxy, gateway, and umami summary objects.'),
     )
     .option(
       '--verbose',

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -7,13 +7,14 @@ import {z} from 'zod'
 import {getCliproxyStatusSummary} from './cliproxy/status'
 import {getGatewayStatusSummary} from './gateway'
 import {getKeewebStatusSummary} from './keeweb/status'
+import {getUmamiStatusSummary} from './umami'
 
 declare const process: {
   env: Record<string, string | undefined>
 }
 
 export interface StatusSummary {
-  app: 'keeweb' | 'cliproxy' | 'gateway'
+  app: 'keeweb' | 'cliproxy' | 'gateway' | 'umami'
   http: string
   lastDeploy: string
   version: string
@@ -27,6 +28,7 @@ interface StatusDependencies {
   getKeewebStatusSummary: (verbose: boolean) => Promise<StatusSummary>
   getCliproxyStatusSummary: (baseUrl: string, key: string, verbose: boolean) => Promise<StatusSummary>
   getGatewayStatusSummary: (host: string) => Promise<StatusSummary>
+  getUmamiStatusSummary: (host: string) => Promise<StatusSummary>
 }
 
 const DEFAULT_CLIPROXY_URL = 'https://cliproxy.fro.bot'
@@ -63,6 +65,7 @@ function toJsonPayload(rows: StatusSummary[]): Record<AppName, StatusSummary> {
     keeweb: rows.find(row => row.app === 'keeweb') ?? errorSummary('keeweb', 'missing result'),
     cliproxy: rows.find(row => row.app === 'cliproxy') ?? errorSummary('cliproxy', 'missing result'),
     gateway: rows.find(row => row.app === 'gateway') ?? errorSummary('gateway', 'missing result'),
+    umami: rows.find(row => row.app === 'umami') ?? errorSummary('umami', 'missing result'),
   }
 }
 
@@ -78,20 +81,23 @@ export async function unifiedStatusAction(
     getKeewebStatusSummary,
     getCliproxyStatusSummary,
     getGatewayStatusSummary,
+    getUmamiStatusSummary,
   },
 ): Promise<void> {
   const verbose = options.verbose === true
   const cliproxyBaseUrl = stripTrailingSlash(process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
   const cliproxyKey = process.env.CLIPROXY_MANAGEMENT_KEY ?? ''
   const gatewayHost = process.env.GATEWAY_HOST ?? ''
+  const umamiHost = process.env.UMAMI_DOMAIN ?? ''
 
   const results = await Promise.allSettled([
     dependencies.getKeewebStatusSummary(verbose),
     dependencies.getCliproxyStatusSummary(cliproxyBaseUrl, cliproxyKey, verbose),
     dependencies.getGatewayStatusSummary(gatewayHost),
+    dependencies.getUmamiStatusSummary(umamiHost),
   ])
 
-  const appNames: AppName[] = ['keeweb', 'cliproxy', 'gateway']
+  const appNames: AppName[] = ['keeweb', 'cliproxy', 'gateway', 'umami']
   const rows: StatusSummary[] = results.map((result, index) => {
     const app = appNames[index] ?? 'keeweb'
     if (result.status === 'fulfilled') {
@@ -120,6 +126,7 @@ export function registerStatus(
     getKeewebStatusSummary,
     getCliproxyStatusSummary,
     getGatewayStatusSummary,
+    getUmamiStatusSummary,
   },
 ): void {
   cli

--- a/packages/cli/src/commands/umami/deploy.test.ts
+++ b/packages/cli/src/commands/umami/deploy.test.ts
@@ -84,10 +84,43 @@ describe('getUmamiDeployEnv', () => {
     expect(() => getUmamiDeployEnv()).toThrow('HOME is required')
   })
 
-  it('throws when SSH_AUTH_SOCK is missing', () => {
-    setManagedEnv({PATH: '/usr/bin:/bin', HOME: '/home/user', SSH_AUTH_SOCK: undefined})
+  it('throws when SSH_AUTH_SOCK is missing and no UMAMI_SSH_KEY either', () => {
+    setManagedEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/user',
+      SSH_AUTH_SOCK: undefined,
+      UMAMI_SSH_KEY: undefined,
+    })
 
-    expect(() => getUmamiDeployEnv()).toThrow('SSH_AUTH_SOCK is required')
+    expect(() => getUmamiDeployEnv()).toThrow('Local deploy needs an SSH context')
+  })
+
+  it('succeeds with only SSH_AUTH_SOCK set (no UMAMI_SSH_KEY)', () => {
+    setManagedEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/user',
+      SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+      UMAMI_SSH_KEY: undefined,
+    })
+
+    const env = getUmamiDeployEnv()
+
+    expect(env.SSH_AUTH_SOCK).toBe('/tmp/ssh-agent.sock')
+    expect('UMAMI_SSH_KEY' in env).toBe(false)
+  })
+
+  it('succeeds with only UMAMI_SSH_KEY set (no SSH_AUTH_SOCK) and includes the key in env', () => {
+    setManagedEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/user',
+      SSH_AUTH_SOCK: undefined,
+      UMAMI_SSH_KEY: 'ssh-ed25519 AAAA...',
+    })
+
+    const env = getUmamiDeployEnv()
+
+    expect(env.UMAMI_SSH_KEY).toBe('ssh-ed25519 AAAA...')
+    expect('SSH_AUTH_SOCK' in env).toBe(false)
   })
 
   it('includes optional umami env vars when set', () => {

--- a/packages/cli/src/commands/umami/deploy.test.ts
+++ b/packages/cli/src/commands/umami/deploy.test.ts
@@ -1,0 +1,169 @@
+import {resolve} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+
+import {getUmamiDeployEnv, validateUmamiRemotePreconditions} from './deploy'
+
+const repoRoot = resolve(import.meta.dir, '../../../../..')
+
+const envKeys = [
+  'HOME',
+  'PATH',
+  'SSH_AUTH_SOCK',
+  'UMAMI_DOMAIN',
+  'UMAMI_APP_SECRET',
+  'UMAMI_DB_PASSWORD',
+  'UMAMI_ADMIN_PASSWORD',
+  'UMAMI_SSH_KEY',
+] as const
+
+type ManagedEnvKey = (typeof envKeys)[number]
+
+let originalEnv: Partial<Record<ManagedEnvKey, string | undefined>>
+
+function restoreManagedEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function setManagedEnv(overrides: Partial<Record<ManagedEnvKey, string | undefined>>): void {
+  restoreManagedEnv()
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key as ManagedEnvKey]
+    } else {
+      process.env[key as ManagedEnvKey] = value
+    }
+  }
+}
+
+beforeEach(() => {
+  originalEnv = {}
+  for (const key of envKeys) {
+    originalEnv[key] = process.env[key]
+  }
+})
+
+afterEach(() => {
+  restoreManagedEnv()
+})
+
+// ─── getUmamiDeployEnv ────────────────────────────────────────────────────────
+
+describe('getUmamiDeployEnv', () => {
+  it('returns env object with required keys when all are set', () => {
+    setManagedEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/user',
+      SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+      UMAMI_DOMAIN: 'metrics.fro.bot',
+    })
+
+    const env = getUmamiDeployEnv()
+
+    expect(env.PATH).toBe('/usr/bin:/bin')
+    expect(env.HOME).toBe('/home/user')
+    expect(env.SSH_AUTH_SOCK).toBe('/tmp/ssh-agent.sock')
+    expect(env.UMAMI_DOMAIN).toBe('metrics.fro.bot')
+  })
+
+  it('throws when PATH is missing', () => {
+    setManagedEnv({PATH: undefined, HOME: '/home/user', SSH_AUTH_SOCK: '/tmp/ssh-agent.sock'})
+
+    expect(() => getUmamiDeployEnv()).toThrow('PATH is required')
+  })
+
+  it('throws when HOME is missing', () => {
+    setManagedEnv({PATH: '/usr/bin:/bin', HOME: undefined, SSH_AUTH_SOCK: '/tmp/ssh-agent.sock'})
+
+    expect(() => getUmamiDeployEnv()).toThrow('HOME is required')
+  })
+
+  it('throws when SSH_AUTH_SOCK is missing', () => {
+    setManagedEnv({PATH: '/usr/bin:/bin', HOME: '/home/user', SSH_AUTH_SOCK: undefined})
+
+    expect(() => getUmamiDeployEnv()).toThrow('SSH_AUTH_SOCK is required')
+  })
+
+  it('includes optional umami env vars when set', () => {
+    setManagedEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/user',
+      SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+      UMAMI_APP_SECRET: 'secret123',
+      UMAMI_DB_PASSWORD: 'dbpass',
+      UMAMI_ADMIN_PASSWORD: 'adminpass',
+    })
+
+    const env = getUmamiDeployEnv()
+
+    expect(env.UMAMI_APP_SECRET).toBe('secret123')
+    expect(env.UMAMI_DB_PASSWORD).toBe('dbpass')
+    expect(env.UMAMI_ADMIN_PASSWORD).toBe('adminpass')
+  })
+})
+
+// ─── validateUmamiRemotePreconditions ─────────────────────────────────────────
+
+describe('validateUmamiRemotePreconditions', () => {
+  it('throws a clear error when gh is not available', () => {
+    // We cannot reliably mock Bun.which, so we test the function contract:
+    // if gh is not installed, it should throw with a helpful message.
+    // This test verifies the error message shape by calling with a known-missing binary.
+    // In CI where gh IS installed, we skip this test.
+    if (Bun.which('gh')) {
+      // gh is available — just verify the function does not throw
+      expect(() => validateUmamiRemotePreconditions()).not.toThrow()
+      return
+    }
+
+    expect(() => validateUmamiRemotePreconditions()).toThrow('gh CLI is required')
+  })
+})
+
+// ─── deploy command (subprocess integration via CLI) ─────────────────────────
+
+describe('deploy command', () => {
+  it('dry-run remote mode prints planned gh workflow run command without executing', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'packages/cli/src/cli.ts', 'umami', 'deploy', '--dry-run'], {
+      cwd: repoRoot,
+      env: {...process.env, NO_COLOR: '1'},
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Dry run')
+    expect(stdout).toContain('Deploy Umami')
+  })
+
+  it('dry-run local mode prints planned bun command without executing', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'packages/cli/src/cli.ts', 'umami', 'deploy', '--local', '--dry-run'], {
+      cwd: repoRoot,
+      env: {...process.env, NO_COLOR: '1'},
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Dry run')
+    expect(stdout).toContain('apps/umami')
+  })
+})

--- a/packages/cli/src/commands/umami/deploy.ts
+++ b/packages/cli/src/commands/umami/deploy.ts
@@ -19,6 +19,7 @@ export function getUmamiDeployEnv(): Record<string, string> {
   const path = process.env.PATH
   const home = process.env.HOME
   const sshAuthSock = process.env.SSH_AUTH_SOCK
+  const sshKey = process.env.UMAMI_SSH_KEY
 
   if (!path) {
     throw new Error('PATH is required for local deploy')
@@ -28,19 +29,19 @@ export function getUmamiDeployEnv(): Record<string, string> {
     throw new Error('HOME is required for local deploy')
   }
 
-  if (!sshAuthSock) {
-    throw new Error('SSH_AUTH_SOCK is required for local deploy. Start ssh-agent and load your deploy key first.')
+  if (!sshAuthSock && !sshKey) {
+    throw new Error('Local deploy needs an SSH context: set SSH_AUTH_SOCK (ssh-agent) or UMAMI_SSH_KEY (key from env).')
   }
 
   return {
     PATH: path,
     HOME: home,
-    SSH_AUTH_SOCK: sshAuthSock,
+    ...(sshAuthSock ? {SSH_AUTH_SOCK: sshAuthSock} : {}),
     UMAMI_DOMAIN: process.env.UMAMI_DOMAIN ?? '',
     UMAMI_APP_SECRET: process.env.UMAMI_APP_SECRET ?? '',
     UMAMI_DB_PASSWORD: process.env.UMAMI_DB_PASSWORD ?? '',
     UMAMI_ADMIN_PASSWORD: process.env.UMAMI_ADMIN_PASSWORD ?? '',
-    UMAMI_SSH_KEY: process.env.UMAMI_SSH_KEY ?? '',
+    ...(sshKey ? {UMAMI_SSH_KEY: sshKey} : {}),
   }
 }
 

--- a/packages/cli/src/commands/umami/deploy.ts
+++ b/packages/cli/src/commands/umami/deploy.ts
@@ -1,0 +1,131 @@
+import type {goke} from 'goke'
+
+import {z} from 'zod'
+
+declare const process: {
+  env: Record<string, string | undefined>
+  exitCode?: number
+}
+
+const REPO = 'marcusrbrown/infra'
+const WORKFLOW_NAME = 'Deploy Umami'
+const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy-umami.yaml'
+
+type CliInstance = ReturnType<typeof goke>
+
+// ─── Env helpers ─────────────────────────────────────────────────────────────
+
+export function getUmamiDeployEnv(): Record<string, string> {
+  const path = process.env.PATH
+  const home = process.env.HOME
+  const sshAuthSock = process.env.SSH_AUTH_SOCK
+
+  if (!path) {
+    throw new Error('PATH is required for local deploy')
+  }
+
+  if (!home) {
+    throw new Error('HOME is required for local deploy')
+  }
+
+  if (!sshAuthSock) {
+    throw new Error('SSH_AUTH_SOCK is required for local deploy. Start ssh-agent and load your deploy key first.')
+  }
+
+  return {
+    PATH: path,
+    HOME: home,
+    SSH_AUTH_SOCK: sshAuthSock,
+    UMAMI_DOMAIN: process.env.UMAMI_DOMAIN ?? '',
+    UMAMI_APP_SECRET: process.env.UMAMI_APP_SECRET ?? '',
+    UMAMI_DB_PASSWORD: process.env.UMAMI_DB_PASSWORD ?? '',
+    UMAMI_ADMIN_PASSWORD: process.env.UMAMI_ADMIN_PASSWORD ?? '',
+    UMAMI_SSH_KEY: process.env.UMAMI_SSH_KEY ?? '',
+  }
+}
+
+export function validateUmamiRemotePreconditions(): void {
+  if (!Bun.which('gh')) {
+    throw new Error('gh CLI is required for remote deploy. Install gh and run `gh auth login`.')
+  }
+}
+
+// ─── Command registration ─────────────────────────────────────────────────────
+
+export function registerUmamiDeploy(cli: CliInstance): void {
+  cli
+    .command(
+      'umami deploy',
+      'Deploy Umami analytics. Default mode triggers the GitHub Deploy Umami workflow, while --local runs apps/umami deploy directly with Bun.',
+    )
+    .option(
+      '--local',
+      z
+        .boolean()
+        .default(false)
+        .describe('Run local deployment with Bun using apps/umami instead of triggering GitHub Actions.'),
+    )
+    .option(
+      '--dry-run',
+      z
+        .boolean()
+        .default(false)
+        .describe(
+          'Validate deploy prerequisites and print planned actions without executing local deploy or dispatching workflow.',
+        ),
+    )
+    .example('# Trigger remote GitHub Actions deploy (default mode)')
+    .example('infra umami deploy')
+    .example('# Validate local deploy preconditions and planned command')
+    .example('infra umami deploy --local --dry-run')
+    .example('# Run local deploy with explicit SSH agent context')
+    .example('infra umami deploy --local')
+    .action(async options => {
+      if (options.local) {
+        const command = ['bun', 'run', '--cwd', 'apps/umami', 'deploy']
+
+        if (options.dryRun) {
+          console.log('Dry run: local umami deploy')
+          console.log(`- command: ${command.join(' ')}`)
+          return
+        }
+
+        const env = getUmamiDeployEnv()
+
+        const child = Bun.spawn(command, {
+          env,
+          stdout: 'inherit',
+          stderr: 'inherit',
+        })
+
+        const exitCode = await child.exited
+        if (exitCode !== 0) {
+          throw new Error(`Local deploy failed with exit code ${exitCode}`)
+        }
+
+        return
+      }
+
+      validateUmamiRemotePreconditions()
+
+      if (options.dryRun) {
+        console.log('Dry run: remote umami deploy')
+        console.log(`- command: gh workflow run "${WORKFLOW_NAME}" --repo ${REPO}`)
+        console.log(`- workflow URL: ${WORKFLOW_URL}`)
+        return
+      }
+
+      const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+      })
+
+      const exitCode = await child.exited
+      if (exitCode !== 0) {
+        throw new Error(`Failed to trigger "${WORKFLOW_NAME}" workflow (exit code ${exitCode})`)
+      }
+
+      console.log(`Workflow triggered: ${WORKFLOW_URL}`)
+      console.log('Approve the umami environment deployment in GitHub Actions to continue.')
+    })
+}

--- a/packages/cli/src/commands/umami/host.test.ts
+++ b/packages/cli/src/commands/umami/host.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'bun:test'
+
+import {validateUmamiHost} from './host'
+
+describe('validateUmamiHost', () => {
+  it('accepts a standard FQDN', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot')).not.toThrow()
+    expect(validateUmamiHost('metrics.fro.bot')).toBe('metrics.fro.bot')
+  })
+
+  it('accepts localhost', () => {
+    expect(() => validateUmamiHost('localhost')).not.toThrow()
+  })
+
+  it('accepts an IPv4 address', () => {
+    expect(() => validateUmamiHost('147.182.133.210')).not.toThrow()
+  })
+
+  it('accepts a single-character hostname', () => {
+    expect(() => validateUmamiHost('a')).not.toThrow()
+  })
+
+  it('accepts a hostname with hyphens', () => {
+    expect(() => validateUmamiHost('my-metrics.prod.example.com')).not.toThrow()
+  })
+
+  it('rejects a leading-hyphen value (ProxyCommand injection vector)', () => {
+    expect(() => validateUmamiHost('-oProxyCommand=evil')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with shell metacharacters (semicolon)', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot;rm -rf')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with shell metacharacters (backtick)', () => {
+    expect(() => validateUmamiHost('metrics.fro.bot`id`')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with spaces', () => {
+    expect(() => validateUmamiHost('metrics fro.bot')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects a value with an at-sign', () => {
+    expect(() => validateUmamiHost('user@metrics.fro.bot')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('rejects an empty string', () => {
+    expect(() => validateUmamiHost('')).toThrow('Invalid UMAMI_DOMAIN')
+  })
+
+  it('truncates the invalid value in the error message to ~30 chars', () => {
+    const longMalicious = `-oProxyCommand=${'A'.repeat(100)}`
+    let message = ''
+    try {
+      validateUmamiHost(longMalicious)
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toContain('Invalid UMAMI_DOMAIN')
+    expect(message.length).toBeLessThan(longMalicious.length + 50)
+  })
+})

--- a/packages/cli/src/commands/umami/host.ts
+++ b/packages/cli/src/commands/umami/host.ts
@@ -1,0 +1,31 @@
+// ─── Umami host validation ────────────────────────────────────────────────────
+//
+// Validates UMAMI_DOMAIN values before they are passed as ssh argv arguments.
+// A value starting with `-` would be interpreted by ssh as an option flag,
+// enabling ProxyCommand injection and local code execution.
+
+const VALID_HOST_RE = /^[a-z\d][a-z\d.\-]*$/i
+
+/**
+ * Validates a candidate UMAMI_DOMAIN value against a strict hostname allowlist.
+ *
+ * Accepts: hostnames, FQDNs, IPv4 addresses, `localhost`.
+ * Rejects: empty strings, values starting with `-`, and anything containing
+ * characters outside `[A-Za-z0-9.-]`.
+ *
+ * @throws {Error} with a sanitized excerpt of the invalid value.
+ * @returns The validated host string (unchanged).
+ */
+export function validateUmamiHost(host: string): string {
+  if (!host) {
+    throw new Error('Invalid UMAMI_DOMAIN: value is empty')
+  }
+
+  if (!VALID_HOST_RE.test(host)) {
+    // Truncate to 30 chars and strip non-printable bytes before echoing back
+    const excerpt = host.slice(0, 30).replaceAll(/[^\u0020-\u007E]/g, '?')
+    throw new Error(`Invalid UMAMI_DOMAIN: "${excerpt}" — must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`}`)
+  }
+
+  return host
+}

--- a/packages/cli/src/commands/umami/index.ts
+++ b/packages/cli/src/commands/umami/index.ts
@@ -1,0 +1,13 @@
+import type {goke} from 'goke'
+
+import {registerUmamiDeploy} from './deploy'
+import {registerUmamiLogs} from './logs'
+import {registerUmamiStatus} from './status'
+
+export {getUmamiStatusSummary} from './status'
+
+export function registerUmamiCommands(cli: ReturnType<typeof goke>): void {
+  registerUmamiStatus(cli)
+  registerUmamiDeploy(cli)
+  registerUmamiLogs(cli)
+}

--- a/packages/cli/src/commands/umami/logs.test.ts
+++ b/packages/cli/src/commands/umami/logs.test.ts
@@ -116,4 +116,39 @@ describe('logs command', () => {
     expect(result.refused).toBe(false)
     expect(result.exitCode).toBe(42)
   })
+
+  it('accepts caddy as a valid service', async () => {
+    delete process.env.CI
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'caddy',
+      tail: 100,
+      allowCi: false,
+    }
+
+    const result = await streamUmamiLogs(opts, makeLogsSpawn(0))
+    expect(result.refused).toBe(false)
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('rejects an unknown service when called directly (bypassing the CLI action)', async () => {
+    delete process.env.CI
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'notaservice',
+      tail: 100,
+      allowCi: false,
+    }
+
+    let spawnCalled = false
+    const spy: LogsSpawnFn = (_cmd, _opts) => {
+      spawnCalled = true
+      return {exited: Promise.resolve(0)}
+    }
+
+    await expect(streamUmamiLogs(opts, spy)).rejects.toThrow(/Invalid service/)
+    expect(spawnCalled).toBe(false)
+  })
 })

--- a/packages/cli/src/commands/umami/logs.test.ts
+++ b/packages/cli/src/commands/umami/logs.test.ts
@@ -1,0 +1,119 @@
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+
+import {streamUmamiLogs, type LogsSpawnFn, type StreamLogsOpts} from './logs'
+
+// ─── streamUmamiLogs ─────────────────────────────────────────────────────────
+
+function makeLogsSpawn(exitCode = 0): LogsSpawnFn {
+  return (_cmd, _opts) => ({exited: Promise.resolve(exitCode)})
+}
+
+describe('logs command', () => {
+  let originalCI: string | undefined
+  let originalUmamiDomain: string | undefined
+
+  beforeEach(() => {
+    originalCI = process.env.CI
+    originalUmamiDomain = process.env.UMAMI_DOMAIN
+  })
+
+  afterEach(() => {
+    if (originalCI === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalCI
+    }
+
+    if (originalUmamiDomain === undefined) {
+      delete process.env.UMAMI_DOMAIN
+    } else {
+      process.env.UMAMI_DOMAIN = originalUmamiDomain
+    }
+  })
+
+  it('refuses to stream logs in CI without --allow-ci', async () => {
+    process.env.CI = 'true'
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'umami',
+      tail: 100,
+      allowCi: false,
+    }
+
+    const messages: string[] = []
+    const result = await streamUmamiLogs(opts, makeLogsSpawn(), msg => messages.push(msg))
+
+    expect(result.refused).toBe(true)
+    expect(messages.join('')).toContain('Refusing to stream logs in CI')
+  })
+
+  it('proceeds in CI when --allow-ci is set', async () => {
+    process.env.CI = 'true'
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'umami',
+      tail: 100,
+      allowCi: true,
+    }
+
+    const warnings: string[] = []
+    const result = await streamUmamiLogs(opts, makeLogsSpawn(), undefined, msg => warnings.push(msg))
+
+    expect(result.refused).toBe(false)
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('always emits a sensitive-data warning to stderr', async () => {
+    delete process.env.CI
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'umami',
+      tail: 100,
+      allowCi: false,
+    }
+
+    const warnings: string[] = []
+    await streamUmamiLogs(opts, makeLogsSpawn(), undefined, msg => warnings.push(msg))
+
+    expect(warnings.join('')).toContain('sensitive')
+  })
+
+  it('rejects invalid host before spawning SSH', async () => {
+    delete process.env.CI
+
+    const opts: StreamLogsOpts = {
+      host: '-oProxyCommand=evil',
+      service: 'umami',
+      tail: 100,
+      allowCi: false,
+    }
+
+    let spawnCalled = false
+    const spy: LogsSpawnFn = (_cmd, _opts) => {
+      spawnCalled = true
+      return {exited: Promise.resolve(0)}
+    }
+
+    await expect(streamUmamiLogs(opts, spy)).rejects.toThrow('Invalid UMAMI_DOMAIN')
+    expect(spawnCalled).toBe(false)
+  })
+
+  it('returns exitCode from the SSH subprocess', async () => {
+    delete process.env.CI
+
+    const opts: StreamLogsOpts = {
+      host: 'metrics.fro.bot',
+      service: 'umami',
+      tail: 50,
+      allowCi: false,
+    }
+
+    const result = await streamUmamiLogs(opts, makeLogsSpawn(42))
+
+    expect(result.refused).toBe(false)
+    expect(result.exitCode).toBe(42)
+  })
+})

--- a/packages/cli/src/commands/umami/logs.ts
+++ b/packages/cli/src/commands/umami/logs.ts
@@ -14,7 +14,7 @@ const COMPOSE_PROJECT_DIR = '/opt/umami'
 const SENSITIVE_WARNING =
   'Warning: Logs may contain database passwords, app secrets, or user data. Treat output as sensitive; do not capture in shared logs or chat.'
 
-export const VALID_SERVICES = ['umami', 'db'] as const
+export const VALID_SERVICES = ['umami', 'db', 'caddy'] as const
 
 export type ValidService = (typeof VALID_SERVICES)[number]
 
@@ -60,6 +60,9 @@ export async function streamUmamiLogs(
   printOut?: (msg: string) => void,
   printErr?: (msg: string) => void,
 ): Promise<StreamLogsResult> {
+  // Validate service at the top so direct callers cannot bypass the guard.
+  validateService(opts.service)
+
   const isCI = process.env.CI === 'true'
 
   if (isCI && !opts.allowCi) {

--- a/packages/cli/src/commands/umami/logs.ts
+++ b/packages/cli/src/commands/umami/logs.ts
@@ -117,6 +117,10 @@ export function registerUmamiLogs(cli: ReturnType<typeof goke>): void {
         .default(false)
         .describe('Allow log streaming in CI environments. Logs may contain sensitive credentials.'),
     )
+    .option(
+      '--key [key]',
+      z.string().describe('Environment variable name holding the SSH host. Falls back to UMAMI_DOMAIN when omitted.'),
+    )
     .action(async (service, options) => {
       const targetService = (service as string | undefined) ?? 'umami'
 
@@ -128,10 +132,11 @@ export function registerUmamiLogs(cli: ReturnType<typeof goke>): void {
         return
       }
 
-      const host = process.env.UMAMI_DOMAIN
+      const hostEnvKey = options.key ?? 'UMAMI_DOMAIN'
+      const host = process.env[hostEnvKey]
 
       if (!host) {
-        console.error('Umami host not set. Export UMAMI_DOMAIN to the hostname of your Umami deployment.')
+        console.error('Umami host not set. Export UMAMI_DOMAIN or pass --key <env-name> pointing to a set variable.')
         process.exitCode = 1
         return
       }

--- a/packages/cli/src/commands/umami/logs.ts
+++ b/packages/cli/src/commands/umami/logs.ts
@@ -1,0 +1,153 @@
+import type {goke} from 'goke'
+
+import {z} from 'zod'
+
+import {validateUmamiHost} from './host'
+
+declare const process: {
+  env: Record<string, string | undefined>
+  exitCode?: number
+  stderr: {write: (msg: string) => void}
+}
+
+const COMPOSE_PROJECT_DIR = '/opt/umami'
+const SENSITIVE_WARNING =
+  'Warning: Logs may contain database passwords, app secrets, or user data. Treat output as sensitive; do not capture in shared logs or chat.'
+
+export const VALID_SERVICES = ['umami', 'db'] as const
+
+export type ValidService = (typeof VALID_SERVICES)[number]
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function validateService(service: string): asserts service is ValidService {
+  if (!VALID_SERVICES.includes(service as ValidService)) {
+    throw new Error(`Invalid service "${service}". Valid services: ${VALID_SERVICES.join(', ')}`)
+  }
+}
+
+// ─── Injectable spawn type ────────────────────────────────────────────────────
+
+export type LogsSpawnFn = (
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'inherit'; stderr: 'inherit'},
+) => {
+  exited: Promise<number>
+}
+
+export interface StreamLogsOpts {
+  host: string
+  service: string
+  tail: number
+  allowCi: boolean
+}
+
+export interface StreamLogsResult {
+  refused: boolean
+  exitCode?: number
+}
+
+function defaultLogsSpawn(
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'inherit'; stderr: 'inherit'},
+): {exited: Promise<number>} {
+  return Bun.spawn(cmd, opts)
+}
+
+export async function streamUmamiLogs(
+  opts: StreamLogsOpts,
+  spawn: LogsSpawnFn = defaultLogsSpawn,
+  printOut?: (msg: string) => void,
+  printErr?: (msg: string) => void,
+): Promise<StreamLogsResult> {
+  const isCI = process.env.CI === 'true'
+
+  if (isCI && !opts.allowCi) {
+    const msg = 'Refusing to stream logs in CI without --allow-ci. Logs may contain sensitive credentials or user data.'
+    if (printOut) {
+      printOut(msg)
+    } else {
+      console.log(msg)
+    }
+
+    return {refused: true}
+  }
+
+  // Warn on every run — logs are sensitive regardless of context
+  if (printErr) {
+    printErr(SENSITIVE_WARNING)
+  } else {
+    console.error(SENSITIVE_WARNING)
+  }
+
+  validateUmamiHost(opts.host)
+
+  const sshCmd = [
+    'ssh',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=yes',
+    `root@${opts.host}`,
+    `docker compose --project-directory ${COMPOSE_PROJECT_DIR} logs --no-color --tail=${opts.tail} ${opts.service}`,
+  ]
+
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: process.env.HOME ?? '/tmp',
+    ...(process.env.SSH_AUTH_SOCK ? {SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK} : {}),
+  }
+
+  const child = spawn(sshCmd, {env, stdout: 'inherit', stderr: 'inherit'})
+  const exitCode = await child.exited
+
+  return {refused: false, exitCode}
+}
+
+// ─── Command registration ─────────────────────────────────────────────────────
+
+export function registerUmamiLogs(cli: ReturnType<typeof goke>): void {
+  cli
+    .command('umami logs [service]', 'Stream logs from an Umami service via SSH and docker compose.')
+    .option('--tail [n]', z.number().default(100).describe('Number of log lines to tail from each service.'))
+    .option(
+      '--allow-ci',
+      z
+        .boolean()
+        .default(false)
+        .describe('Allow log streaming in CI environments. Logs may contain sensitive credentials.'),
+    )
+    .action(async (service, options) => {
+      const targetService = (service as string | undefined) ?? 'umami'
+
+      try {
+        validateService(targetService)
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exitCode = 1
+        return
+      }
+
+      const host = process.env.UMAMI_DOMAIN
+
+      if (!host) {
+        console.error('Umami host not set. Export UMAMI_DOMAIN to the hostname of your Umami deployment.')
+        process.exitCode = 1
+        return
+      }
+
+      const tail = typeof options.tail === 'number' ? options.tail : 100
+      const allowCi = options.allowCi === true
+
+      const result = await streamUmamiLogs({host, service: targetService, tail, allowCi})
+
+      if (result.refused) {
+        process.exitCode = 1
+        return
+      }
+
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode ?? 1
+      }
+    })
+}

--- a/packages/cli/src/commands/umami/status.test.ts
+++ b/packages/cli/src/commands/umami/status.test.ts
@@ -1,0 +1,265 @@
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+
+import {createCapturedCtx, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
+import {
+  getUmamiComposeStatus,
+  parseComposePs,
+  parseComposePsOutput,
+  umamiStatusAction,
+  type ComposePsEntry,
+  type ServiceRow,
+} from './status'
+
+// ─── parseComposePsOutput ─────────────────────────────────────────────────────
+
+describe('parseComposePsOutput', () => {
+  it('parses NDJSON output (one JSON object per line)', () => {
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: ''}),
+    ].join('\n')
+
+    const entries = parseComposePsOutput(ndjson)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual({Name: 'umami', State: 'running', Health: 'healthy'})
+    expect(entries[1]).toEqual({Name: 'db', State: 'running', Health: ''})
+  })
+
+  it('parses JSON-array output (legacy compose format)', () => {
+    const jsonArray = JSON.stringify([
+      {Name: 'umami', State: 'running', Health: 'healthy'},
+      {Name: 'db', State: 'running', Health: ''},
+    ])
+
+    const entries = parseComposePsOutput(jsonArray)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual({Name: 'umami', State: 'running', Health: 'healthy'})
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseComposePsOutput('')).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(parseComposePsOutput('   \n  ')).toEqual([])
+  })
+})
+
+// ─── parseComposePs ──────────────────────────────────────────────────────────
+
+describe('parseComposePs', () => {
+  it('maps running services with healthy status', () => {
+    const raw: ComposePsEntry[] = [
+      {Name: 'umami', State: 'running', Health: 'healthy'},
+      {Name: 'db', State: 'running', Health: ''},
+    ]
+
+    const rows = parseComposePs(raw)
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toEqual({service: 'umami', state: 'running', health: 'healthy'} satisfies ServiceRow)
+    expect(rows[1]).toEqual({service: 'db', state: 'running', health: 'n-a'} satisfies ServiceRow)
+  })
+
+  it('maps exited state', () => {
+    const raw: ComposePsEntry[] = [{Name: 'umami', State: 'exited', Health: ''}]
+
+    const rows = parseComposePs(raw)
+
+    expect(rows[0]).toEqual({service: 'umami', state: 'exited', health: 'n-a'} satisfies ServiceRow)
+  })
+
+  it('maps unhealthy health status', () => {
+    const raw: ComposePsEntry[] = [{Name: 'umami', State: 'running', Health: 'unhealthy'}]
+
+    const rows = parseComposePs(raw)
+
+    expect(rows[0]?.health).toBe('unhealthy')
+  })
+
+  it('maps starting health status', () => {
+    const raw: ComposePsEntry[] = [{Name: 'umami', State: 'running', Health: 'starting'}]
+
+    const rows = parseComposePs(raw)
+
+    expect(rows[0]?.health).toBe('starting')
+  })
+
+  it('maps unknown health values to n-a', () => {
+    const raw: ComposePsEntry[] = [{Name: 'umami', State: 'running', Health: 'something-weird'}]
+
+    const rows = parseComposePs(raw)
+
+    expect(rows[0]?.health).toBe('n-a')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseComposePs([])).toEqual([])
+  })
+})
+
+// ─── getUmamiComposeStatus (SSH mocked via SpawnFn) ──────────────────────────
+
+type SpawnFn = (
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+) => {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+function makeSpawn(stdout: string, stderr = '', exitCode = 0): SpawnFn {
+  return (_cmd, _opts) => {
+    const enc = new TextEncoder()
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(enc.encode(stdout))
+          controller.close()
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.enqueue(enc.encode(stderr))
+          controller.close()
+        },
+      }),
+      exited: Promise.resolve(exitCode),
+    }
+  }
+}
+
+describe('getUmamiComposeStatus', () => {
+  it('returns service rows from NDJSON output', async () => {
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: ''}),
+    ].join('\n')
+
+    const result = await getUmamiComposeStatus('metrics.fro.bot', makeSpawn(ndjson))
+
+    expect(result.ok).toBe(true)
+    expect(result.services).toHaveLength(2)
+    expect(result.services[0]?.service).toBe('umami')
+  })
+
+  it('returns service rows from JSON-array output', async () => {
+    const jsonArray = JSON.stringify([
+      {Name: 'umami', State: 'running', Health: 'healthy'},
+      {Name: 'db', State: 'running', Health: ''},
+    ])
+
+    const result = await getUmamiComposeStatus('metrics.fro.bot', makeSpawn(jsonArray))
+
+    expect(result.ok).toBe(true)
+    expect(result.services).toHaveLength(2)
+  })
+
+  it('returns ok=false when SSH exits non-zero', async () => {
+    const result = await getUmamiComposeStatus('metrics.fro.bot', makeSpawn('', 'connection refused', 1))
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('SSH command failed')
+  })
+
+  it('rejects invalid host before spawning SSH', async () => {
+    let spawnCalled = false
+    const spy: SpawnFn = (cmd, opts) => {
+      spawnCalled = true
+      return makeSpawn('')(cmd, opts)
+    }
+
+    await expect(getUmamiComposeStatus('-oProxyCommand=evil', spy)).rejects.toThrow('Invalid UMAMI_DOMAIN')
+    expect(spawnCalled).toBe(false)
+  })
+})
+
+// ─── umamiStatusAction ───────────────────────────────────────────────────────
+
+describe('status command', () => {
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalEnv = {UMAMI_DOMAIN: process.env.UMAMI_DOMAIN}
+  })
+
+  afterEach(() => {
+    if (originalEnv.UMAMI_DOMAIN === undefined) {
+      delete process.env.UMAMI_DOMAIN
+    } else {
+      process.env.UMAMI_DOMAIN = originalEnv.UMAMI_DOMAIN
+    }
+  })
+
+  it('outputs service rows through ctx when services are running', async () => {
+    process.env.UMAMI_DOMAIN = 'metrics.fro.bot'
+
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: ''}),
+    ].join('\n')
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await umamiStatusAction({}, ctx, makeSpawn(ndjson))
+
+    const output = captured.stdout.join('\n')
+    expect(output).toContain('umami')
+    expect(output).toContain('running')
+    expect(captured.exit).toBeNull()
+  })
+
+  it('calls ctx.console.error and ctx.process.exit(1) on SSH failure without throwing', async () => {
+    process.env.UMAMI_DOMAIN = 'metrics.fro.bot'
+
+    const {ctx, captured} = createCapturedCtx()
+
+    let threw = false
+    try {
+      await umamiStatusAction({}, ctx, makeSpawn('', 'connection refused', 1))
+    } catch (error) {
+      if (error instanceof MockProcessExit) {
+        // expected — MockProcessExit is thrown by ctx.process.exit
+      } else {
+        threw = true
+      }
+    }
+
+    expect(threw).toBe(false)
+    expect(captured.stderr.join('')).toContain('Error')
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('calls ctx.console.error and exits when UMAMI_DOMAIN is not set', async () => {
+    delete process.env.UMAMI_DOMAIN
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await umamiStatusAction({}, ctx)
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    expect(captured.stderr.join('')).toContain('UMAMI_DOMAIN')
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('rejects bad host via ctx.console.error without throwing unhandled', async () => {
+    process.env.UMAMI_DOMAIN = '-oProxyCommand=evil'
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await umamiStatusAction({}, ctx, makeSpawn(''))
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    expect(captured.stderr.join('')).toContain('Invalid UMAMI_DOMAIN')
+    expect(captured.exit?.code).toBe(1)
+  })
+})

--- a/packages/cli/src/commands/umami/status.test.ts
+++ b/packages/cli/src/commands/umami/status.test.ts
@@ -305,4 +305,43 @@ describe('status command', () => {
     expect(captured.stderr.join('')).toMatch(/no services|empty/i)
     expect(captured.exit?.code).toBe(1)
   })
+
+  it('reports degraded when a service is running but health is unhealthy', async () => {
+    process.env.UMAMI_DOMAIN = 'metrics.fro.bot'
+
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'unhealthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: 'healthy'}),
+    ].join('\n')
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await umamiStatusAction({}, ctx, makeSpawn(ndjson))
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    const output = captured.stdout.join('\n')
+    expect(output).toContain('DEGRADED')
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('reports OK when a service is running with health n-a (e.g. caddy has no healthcheck)', async () => {
+    process.env.UMAMI_DOMAIN = 'metrics.fro.bot'
+
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'caddy', State: 'running', Health: ''}),
+    ].join('\n')
+
+    const {ctx, captured} = createCapturedCtx()
+
+    await umamiStatusAction({}, ctx, makeSpawn(ndjson))
+
+    const output = captured.stdout.join('\n')
+    expect(output).toContain('Status: OK')
+    expect(captured.exit).toBeNull()
+  })
 })

--- a/packages/cli/src/commands/umami/status.test.ts
+++ b/packages/cli/src/commands/umami/status.test.ts
@@ -183,7 +183,7 @@ describe('status command', () => {
   let originalEnv: Record<string, string | undefined>
 
   beforeEach(() => {
-    originalEnv = {UMAMI_DOMAIN: process.env.UMAMI_DOMAIN}
+    originalEnv = {UMAMI_DOMAIN: process.env.UMAMI_DOMAIN, MY_UMAMI_HOST: process.env.MY_UMAMI_HOST}
   })
 
   afterEach(() => {
@@ -191,6 +191,12 @@ describe('status command', () => {
       delete process.env.UMAMI_DOMAIN
     } else {
       process.env.UMAMI_DOMAIN = originalEnv.UMAMI_DOMAIN
+    }
+
+    if (originalEnv.MY_UMAMI_HOST === undefined) {
+      delete process.env.MY_UMAMI_HOST
+    } else {
+      process.env.MY_UMAMI_HOST = originalEnv.MY_UMAMI_HOST
     }
   })
 
@@ -260,6 +266,43 @@ describe('status command', () => {
     }
 
     expect(captured.stderr.join('')).toContain('Invalid UMAMI_DOMAIN')
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('reads host from the env var named by --key instead of UMAMI_DOMAIN', async () => {
+    delete process.env.UMAMI_DOMAIN
+    process.env.MY_UMAMI_HOST = 'metrics.fro.bot'
+
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: ''}),
+    ].join('\n')
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await umamiStatusAction({key: 'MY_UMAMI_HOST'}, ctx, makeSpawn(ndjson))
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    const output = captured.stdout.join('\n')
+    expect(output).toContain('umami')
+    expect(captured.exit).toBeNull()
+  })
+
+  it('exits 1 with a clear message when docker compose ps returns empty output', async () => {
+    process.env.UMAMI_DOMAIN = 'metrics.fro.bot'
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await umamiStatusAction({}, ctx, makeSpawn(''))
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    expect(captured.stderr.join('')).toMatch(/no services|empty/i)
     expect(captured.exit?.code).toBe(1)
   })
 })

--- a/packages/cli/src/commands/umami/status.test.ts
+++ b/packages/cli/src/commands/umami/status.test.ts
@@ -3,6 +3,7 @@ import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 import {createCapturedCtx, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
 import {
   getUmamiComposeStatus,
+  getUmamiStatusSummary,
   parseComposePs,
   parseComposePsOutput,
   umamiStatusAction,
@@ -174,6 +175,45 @@ describe('getUmamiComposeStatus', () => {
 
     await expect(getUmamiComposeStatus('-oProxyCommand=evil', spy)).rejects.toThrow('Invalid UMAMI_DOMAIN')
     expect(spawnCalled).toBe(false)
+  })
+})
+
+// ─── getUmamiStatusSummary ────────────────────────────────────────────────────
+
+describe('getUmamiStatusSummary', () => {
+  it('shows service rows with DEGRADED marker when services present but unhealthy', async () => {
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'unhealthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: 'healthy'}),
+    ].join('\n')
+
+    const summary = await getUmamiStatusSummary('metrics.fro.bot', makeSpawn(ndjson))
+
+    expect(summary.http).toContain('DEGRADED')
+    expect(summary.http).toContain('umami')
+    expect(summary.http).not.toContain('No services reported')
+  })
+
+  it('shows ERROR with no-services message when compose ps returns empty output', async () => {
+    const summary = await getUmamiStatusSummary('metrics.fro.bot', makeSpawn(''))
+
+    expect(summary.http).toContain('ERROR')
+    expect(summary.http).toContain('No services')
+    expect(summary.http).not.toContain('DEGRADED')
+  })
+
+  it('shows OK with service rows when all services are healthy', async () => {
+    const ndjson = [
+      JSON.stringify({Name: 'umami', State: 'running', Health: 'healthy'}),
+      JSON.stringify({Name: 'db', State: 'running', Health: 'healthy'}),
+    ].join('\n')
+
+    const summary = await getUmamiStatusSummary('metrics.fro.bot', makeSpawn(ndjson))
+
+    expect(summary.http).toContain('OK')
+    expect(summary.http).toContain('umami')
+    expect(summary.http).not.toContain('DEGRADED')
+    expect(summary.http).not.toContain('ERROR')
   })
 })
 

--- a/packages/cli/src/commands/umami/status.ts
+++ b/packages/cli/src/commands/umami/status.ts
@@ -1,0 +1,254 @@
+import type {goke} from 'goke'
+import type {ActionCtx} from '../../lib/action-ctx'
+import type {StatusSummary} from '../status'
+
+import {z} from 'zod'
+
+import {validateUmamiHost} from './host'
+
+declare const process: {
+  env: Record<string, string | undefined>
+  exitCode?: number
+}
+
+const COMPOSE_PROJECT_DIR = '/opt/umami'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ComposePsEntry {
+  Name: string
+  State: string
+  Health: string
+}
+
+export type HealthStatus = 'healthy' | 'unhealthy' | 'starting' | 'n-a'
+
+export interface ServiceRow {
+  service: string
+  state: string
+  health: HealthStatus
+}
+
+export interface UmamiStatusResult {
+  ok: boolean
+  services: ServiceRow[]
+  error?: string
+}
+
+export type SpawnFn = (
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+) => {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function parseComposePsOutput(stdoutText: string): ComposePsEntry[] {
+  const trimmed = stdoutText.trim()
+  if (trimmed.length === 0) return []
+
+  // Legacy compose may emit a single JSON array; current versions emit NDJSON.
+  if (trimmed.startsWith('[')) {
+    const parsed: unknown = JSON.parse(trimmed)
+    return Array.isArray(parsed) ? (parsed as ComposePsEntry[]) : []
+  }
+
+  // NDJSON: one JSON object per non-empty line.
+  return trimmed
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => JSON.parse(line) as ComposePsEntry)
+}
+
+function normalizeHealth(raw: string): HealthStatus {
+  if (raw === 'healthy' || raw === 'unhealthy' || raw === 'starting') {
+    return raw
+  }
+
+  return 'n-a'
+}
+
+export function parseComposePs(entries: ComposePsEntry[]): ServiceRow[] {
+  return entries.map(entry => ({
+    service: entry.Name,
+    state: entry.State,
+    health: normalizeHealth(entry.Health),
+  }))
+}
+
+export function isAllRunning(rows: ServiceRow[]): boolean {
+  return rows.every(row => row.state === 'running')
+}
+
+// ─── SSH-backed status fetch ──────────────────────────────────────────────────
+
+function defaultSpawn(
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+): ReturnType<SpawnFn> {
+  return Bun.spawn(cmd, opts) as ReturnType<SpawnFn>
+}
+
+export async function getUmamiComposeStatus(host: string, spawn: SpawnFn = defaultSpawn): Promise<UmamiStatusResult> {
+  validateUmamiHost(host)
+
+  const sshCmd = [
+    'ssh',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=yes',
+    `root@${host}`,
+    `docker compose --project-directory ${COMPOSE_PROJECT_DIR} ps --format json`,
+  ]
+
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: process.env.HOME ?? '/tmp',
+    ...(process.env.SSH_AUTH_SOCK ? {SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK} : {}),
+  }
+
+  const child = spawn(sshCmd, {env, stdout: 'pipe', stderr: 'pipe'})
+
+  const [stdoutText, stderrText, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
+
+  if (exitCode !== 0) {
+    return {
+      ok: false,
+      services: [],
+      error: `SSH command failed (exit ${exitCode}): ${stderrText.trim() || 'unknown error'}`,
+    }
+  }
+
+  let entries: ComposePsEntry[]
+
+  try {
+    entries = parseComposePsOutput(stdoutText)
+  } catch {
+    return {ok: false, services: [], error: `Failed to parse docker compose ps output: ${stdoutText.slice(0, 200)}`}
+  }
+
+  const services = parseComposePs(entries)
+  const ok = isAllRunning(services)
+
+  return {ok, services}
+}
+
+// ─── Unified status aggregator export ────────────────────────────────────────
+
+export async function getUmamiStatusSummary(host: string): Promise<StatusSummary> {
+  let result: UmamiStatusResult
+
+  try {
+    result = await getUmamiComposeStatus(host)
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    return {
+      app: 'umami',
+      http: `ERROR: ${errorMsg}`,
+      lastDeploy: '—',
+      version: '—',
+      contentHash: '—',
+      usageStats: '—',
+    }
+  }
+
+  if (!result.ok || result.services.length === 0) {
+    const errorMsg = result.error ?? 'No services reported'
+    return {
+      app: 'umami',
+      http: `ERROR: ${errorMsg}`,
+      lastDeploy: '—',
+      version: '—',
+      contentHash: '—',
+      usageStats: '—',
+    }
+  }
+
+  const rows = result.services.map(s => `${s.service}:${s.state}/${s.health}`).join(', ')
+
+  return {
+    app: 'umami',
+    http: `OK: ${rows}`,
+    lastDeploy: '—',
+    version: '—',
+    contentHash: '—',
+    usageStats: '—',
+  }
+}
+
+// ─── Action (exported for direct testing) ────────────────────────────────────
+
+export async function umamiStatusAction(
+  _options: Record<string, unknown>,
+  ctx: ActionCtx,
+  spawn?: SpawnFn,
+): Promise<void> {
+  const host = process.env.UMAMI_DOMAIN
+
+  if (!host) {
+    ctx.console.error('Umami host not set. Export UMAMI_DOMAIN to the hostname of your Umami deployment.')
+    ctx.process.exit(1)
+    return
+  }
+
+  ctx.console.log('Umami status')
+  ctx.console.log('')
+
+  let result: UmamiStatusResult
+
+  try {
+    result = await getUmamiComposeStatus(host, spawn)
+  } catch (error) {
+    ctx.console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    ctx.process.exit(1)
+    return
+  }
+
+  if (!result.ok && result.services.length === 0) {
+    ctx.console.error(`Error: ${result.error ?? 'Unknown error'}`)
+    ctx.process.exit(1)
+    return
+  }
+
+  ctx.console.log('Service          State      Health')
+  ctx.console.log('─────────────────────────────────────')
+
+  for (const row of result.services) {
+    const svc = row.service.padEnd(16)
+    const state = row.state.padEnd(10)
+    ctx.console.log(`${svc} ${state} ${row.health}`)
+  }
+
+  ctx.console.log('')
+
+  if (result.ok) {
+    ctx.console.log('Status: OK')
+  } else {
+    ctx.console.log('Status: DEGRADED (one or more services not running)')
+    ctx.process.exit(1)
+  }
+}
+
+// ─── Command registration ─────────────────────────────────────────────────────
+
+export function registerUmamiStatus(cli: ReturnType<typeof goke>): void {
+  cli
+    .command('umami status', 'Show operational health of the Umami analytics deployment via docker compose ps.')
+    .option(
+      '--key [key]',
+      z
+        .string()
+        .optional()
+        .describe('Environment variable name holding the SSH host. Falls back to UMAMI_DOMAIN when omitted.'),
+    )
+    .action((options, ctx) => umamiStatusAction(options, ctx))
+}

--- a/packages/cli/src/commands/umami/status.ts
+++ b/packages/cli/src/commands/umami/status.ts
@@ -144,11 +144,11 @@ export async function getUmamiComposeStatus(host: string, spawn: SpawnFn = defau
 
 // ─── Unified status aggregator export ────────────────────────────────────────
 
-export async function getUmamiStatusSummary(host: string): Promise<StatusSummary> {
+export async function getUmamiStatusSummary(host: string, spawn?: SpawnFn): Promise<StatusSummary> {
   let result: UmamiStatusResult
 
   try {
-    result = await getUmamiComposeStatus(host)
+    result = await getUmamiComposeStatus(host, spawn)
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)
     return {
@@ -161,7 +161,8 @@ export async function getUmamiStatusSummary(host: string): Promise<StatusSummary
     }
   }
 
-  if (!result.ok || result.services.length === 0) {
+  // Three-way split: no services → ERROR, services present but degraded → DEGRADED, all healthy → OK
+  if (result.services.length === 0) {
     const errorMsg = result.error ?? 'No services reported'
     return {
       app: 'umami',
@@ -174,6 +175,17 @@ export async function getUmamiStatusSummary(host: string): Promise<StatusSummary
   }
 
   const rows = result.services.map(s => `${s.service}:${s.state}/${s.health}`).join(', ')
+
+  if (!result.ok) {
+    return {
+      app: 'umami',
+      http: `DEGRADED: ${rows}`,
+      lastDeploy: '—',
+      version: '—',
+      contentHash: '—',
+      usageStats: '—',
+    }
+  }
 
   return {
     app: 'umami',

--- a/packages/cli/src/commands/umami/status.ts
+++ b/packages/cli/src/commands/umami/status.ts
@@ -81,7 +81,7 @@ export function parseComposePs(entries: ComposePsEntry[]): ServiceRow[] {
 }
 
 export function isAllRunning(rows: ServiceRow[]): boolean {
-  return rows.every(row => row.state === 'running')
+  return rows.every(row => row.state === 'running' && (row.health === 'healthy' || row.health === 'n-a'))
 }
 
 // ─── SSH-backed status fetch ──────────────────────────────────────────────────

--- a/packages/cli/src/commands/umami/status.ts
+++ b/packages/cli/src/commands/umami/status.ts
@@ -188,14 +188,15 @@ export async function getUmamiStatusSummary(host: string): Promise<StatusSummary
 // ─── Action (exported for direct testing) ────────────────────────────────────
 
 export async function umamiStatusAction(
-  _options: Record<string, unknown>,
+  options: {key?: string | undefined},
   ctx: ActionCtx,
   spawn?: SpawnFn,
 ): Promise<void> {
-  const host = process.env.UMAMI_DOMAIN
+  const hostEnvKey = options.key ?? 'UMAMI_DOMAIN'
+  const host = process.env[hostEnvKey]
 
   if (!host) {
-    ctx.console.error('Umami host not set. Export UMAMI_DOMAIN to the hostname of your Umami deployment.')
+    ctx.console.error('Umami host not set. Export UMAMI_DOMAIN or pass --key <env-name> pointing to a set variable.')
     ctx.process.exit(1)
     return
   }
@@ -213,8 +214,8 @@ export async function umamiStatusAction(
     return
   }
 
-  if (!result.ok && result.services.length === 0) {
-    ctx.console.error(`Error: ${result.error ?? 'Unknown error'}`)
+  if (result.services.length === 0) {
+    ctx.console.error(`Error: No services reported by docker compose ps`)
     ctx.process.exit(1)
     return
   }


### PR DESCRIPTION
## Summary

Adds a self-hosted [Umami](https://umami.is) analytics deployment at `metrics.fro.bot` — a privacy-respecting, cookie-free alternative to third-party analytics. This unblocks first-party metrics for other projects without shipping visitor data to anyone else.

Umami runs as a three-service Docker Compose stack (Umami + Postgres + Caddy) on a dedicated DigitalOcean droplet, fronted by Caddy for automatic HTTPS. It follows the same operational shape as the existing cliproxy and gateway apps.

## What's included

- **`apps/umami/`** — Compose stack (images digest-pinned to numbered tags: `umamisoftware/umami:3.1.0`, `postgres:15-alpine`, `caddy:2.11.3-alpine`, all Renovate-tracked), Caddyfile, the deploy orchestrator, and a droplet provisioning script.
- **`infra umami` CLI** — `status` (compose health over SSH, also exposed as an MCP tool), `deploy` (remote workflow or `--local`), and `logs`. The unified `infra status` now includes a `umami` row.
- **Deploy Umami workflow** — path-filtered, runs in a dedicated `umami` environment, pins host keys from the committed `known_hosts`.
- **Operator runbook** (`apps/umami/AGENTS.md`) — deploy flow, the DB-password rotation procedure, privacy baseline, backup/restore, and retention policy.

## Privacy posture

This deployment exists to keep analytics private, so the stack sets `DISABLE_TELEMETRY=1` (no phone-home) and `PRIVATE_MODE=1` (no outbound external calls), on top of Umami being cookie-free and DNT-respecting by default. Postgres is never published to the host — only Caddy's 80/443 are exposed.

## Deploy safety

The deploy orchestrator handles the failure modes the earlier app rollouts taught us to expect:

- **Persistent data is protected.** The Postgres volume survives every deploy. A salted-hash fingerprint sentinel refuses any DB-password change that would break the existing volume, pointing the operator at the in-place `ALTER USER` rotation runbook instead. An unreadable sentinel aborts rather than silently looking like a first deploy.
- **No default-credential exposure.** Umami first-boots with `admin`/`umami`. The deploy brings up the database and app internally, rotates the admin password to `UMAMI_ADMIN_PASSWORD` over the container network, and only then starts Caddy — so the default credentials are never reachable on the public endpoint. Rotation fails the deploy if it can't confirm the new password works and the default no longer does.
- **First-boot readiness.** `docker compose up --wait` gates on container health (180s covers DB migrations); the public HTTPS check warns rather than fails while Caddy's certificate is still issuing.
- **Secrets never touch argv.** The `.env`, the SSH key, and the admin bearer token are all materialized over stdin; host and secret values are validated before any SSH command is built.

## Verification

- 925 tests pass, type-check and lint clean.
- `docker compose config` renders; the deploy workflow passes the repo's workflow-convention checks.

## Follow-up (after merge)

Operator prerequisites before the first deploy: create the `umami` environment and its secrets (`UMAMI_SSH_KEY`, `UMAMI_DOMAIN`, `UMAMI_APP_SECRET`, `UMAMI_DB_PASSWORD`, `UMAMI_ADMIN_PASSWORD`), point `metrics.fro.bot` DNS at the droplet, run the provisioning script, and commit the pinned host keys. After the first deploy, log in and capture the website ID for the tracker script.
