### PR TITLE
chore: add root deploy/provision wrappers that load repo-root .env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 - **Git hooks**: `simple-git-hooks` + `lint-staged` → `eslint --fix` on commit.
 - **CI install**: `bun install --frozen-lockfile --ignore-scripts` (skip simple-git-hooks postinstall).
 - **Cross-org reusable workflows**: Pass secrets explicitly (never `secrets: inherit` with `bfra-me/.github`). (enforced)
-- **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root.
+- **Workspace commands**: Run app scripts with `bun run --cwd apps/<name> <script>`, not from root. Exception: `provision`/`deploy` need the repo-root `.env` (Bun loads `.env` from CWD only), so run them via the root wrappers `bun run provision:<app>` / `bun run deploy:<app>` (cliproxy, gateway, umami) instead of `--cwd`.
 - **Changesets**: `@changesets/cli` for versioning. Renovate PRs get auto-generated changeset files.
 - **Tests**: Colocated `*.test.ts` alongside source. Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Use `NO_COLOR=1` in subprocess env for deterministic snapshots. Mock at boundaries (fetch, Bun.spawn), not internals. CI runs `bun test --recursive` as a parallel job alongside lint/type-check.
 - **CI Node pin**: All workflows running `bun run lint` or `bunx tsc` must pin Node 24 via `actions/setup-node` — ESLint binary shebang uses system Node, which on ubuntu-latest is Node 20 (lacks ES2024 APIs like `Object.groupBy`).
@@ -120,6 +120,8 @@ bunx @marcusrbrown/infra status                   # Unified status (all deployme
 bunx @marcusrbrown/infra status --json            # Machine-readable status
 bunx @marcusrbrown/infra mcp                      # Start MCP server
 bun run apps/keeweb/server/setup-deploy-user.ts # Provision deploy user on server
+bun run provision:umami                         # Provision umami droplet (loads root .env; also :cliproxy, :gateway)
+bun run deploy:umami                            # Local umami deploy (loads root .env; also :cliproxy, :gateway)
 ```
 
 ## NOTES

--- a/package.json
+++ b/package.json
@@ -8,9 +8,15 @@
   ],
   "scripts": {
     "changeset": "changeset",
+    "deploy:cliproxy": "bun run apps/cliproxy/src/deploy.ts",
+    "deploy:gateway": "bun run apps/gateway/src/deploy.ts",
+    "deploy:umami": "bun run apps/umami/src/deploy.ts",
     "fix": "eslint --fix",
     "lint": "eslint",
     "prepare": "simple-git-hooks",
+    "provision:cliproxy": "bun run apps/cliproxy/server/provision-droplet.ts",
+    "provision:gateway": "bun run apps/gateway/server/provision-droplet.ts",
+    "provision:umami": "bun run apps/umami/server/provision-droplet.ts",
     "test": "bun test --recursive",
     "version-changesets": "changeset version"
   },


### PR DESCRIPTION
## Summary

`bun` only loads `.env` from the current working directory, so `bun run --cwd apps/<app> provision` (and `deploy`) silently runs without the repo-root `.env` — where `DIGITALOCEAN_ACCESS_TOKEN` and the per-app secrets live. Provisioning the umami droplet hit this directly: the script came up with no token and no `UMAMI_DOMAIN` until invoked from the repo root.

Provisioning has no CLI equivalent (there's no `infra <app> provision`), so the only path is a `bun run` script — which makes this the natural place to fix it.

## Change

Add root-level wrapper scripts that run the app entrypoints from the repo root, so Bun loads the root `.env` natively:

- `provision:cliproxy` / `provision:gateway` / `provision:umami`
- `deploy:cliproxy` / `deploy:gateway` / `deploy:umami`

Invoke as `bun run provision:umami` / `bun run deploy:umami` instead of `bun run --cwd apps/umami …`. Flags pass through (`bun run deploy:cliproxy --force-config`).

`build`/`test` keep using `--cwd` — they don't need the root `.env`.

## Notes

- CI deploy workflows are unaffected: they pass secrets via the environment, and the workflow step keeps using `--cwd`. (`--env-file` was the alternative but it touches app `package.json`, which sits in the deploy `paths-filter` and would queue gated deploys on every merge — the root wrappers avoid that entirely.)
- Docs updated in `AGENTS.md` (workspace-commands convention + commands block).
