### PR TITLE
chore: remove stale taxonomy comments from mcp integration test

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -150,12 +150,6 @@ describe('mcp integration (Tier-1, in-process)', () => {
   // Mode C: when a command returns structured data AND prints to stdout,
   // the CallToolResult must contain BOTH a stdout text block AND a
   // stringified return-value text block.
-  //
-  // Re-enable after Unit 4 lands (cliproxy keys list refactor to return
-  // structured data alongside ctx-printed text).
-
-  // Re-enable after Unit 4 lands (cliproxy keys list refactor to return
-  // structured data alongside ctx-printed text).
   test('cliproxy_keys_list returns BOTH stdout block AND structured return block (Mode C contract)', async () => {
     const originalFetch = globalThis.fetch
     const originalKey = process.env.CLIPROXY_MANAGEMENT_KEY


### PR DESCRIPTION
## Summary

The `cliproxy_keys_list` Mode C contract test in `packages/cli/src/commands/mcp.test.ts` carried two duplicated `// Re-enable after Unit 4 lands …` comments directly above it. The test is already enabled and passing — that refactor shipped long ago — so the comments were both factually stale and leaked internal plan taxonomy into shipped source.

## Change

Remove the 6 stale comment lines. The legitimate Mode C contract explanation (what the test asserts) stays; the test itself is untouched.

## Verification

- `bun test packages/cli/src/commands/mcp.test.ts` → 4 pass
- Taxonomy grep across `packages/cli/src` + `apps/*/src` + `apps/*/server` → zero matches
- `eslint --max-warnings=0` → clean
