### PR TITLE
fix: SSH identity-file support for droplet provisioning

### DIFF
--- a/apps/cliproxy/AGENTS.md
+++ b/apps/cliproxy/AGENTS.md
@@ -85,5 +85,7 @@ Anthropic-only repos use the single-provider subset of these shapes (unchanged f
 - **Secrets**: `CLIPROXY_SSH_KEY`, `CLIPROXY_MANAGEMENT_KEY`, `CLIPROXY_DOMAIN` scoped to GitHub environment `cliproxy`. `DIGITALOCEAN_ACCESS_TOKEN` is repo-level.
 - **Local `.env`**: `CLIPROXY_MANAGEMENT_KEY` must match the droplet's `MANAGEMENT_PASSWORD` (set during provisioning, printed once).
 - **Provisioning SSH key**: `provision-droplet.ts` looks up the DigitalOcean SSH key by name. Default is `fro-bot-cliproxy`; override with `CLIPROXY_SSH_KEY_NAME` env var. Shared helper lives in `packages/shared/server/droplet-helpers.ts`.
+- **Provisioning SSH auth**: when `CLIPROXY_SSH_KEY` is set, `provision-droplet.ts` materializes it to a `0600` temp key file and pins it with `-i` + `IdentitiesOnly=yes` (no ssh-agent needed; cleaned up after); when unset, it falls back to ssh-agent.
+- **Run provisioning via the root wrapper**: `bun run provision:cliproxy` (loads the repo-root `.env`; `bun run --cwd apps/cliproxy provision` would miss it).
 - **OAuth refresh**: Claude OAuth tokens auto-refresh in `cliproxy_auth` volume. Manual refresh: `bunx @marcusrbrown/infra cliproxy login claude`.
 - **API key recovery**: There is no recovery tooling. If keys are wiped, regenerate via `cliproxy keys add` and redistribute. `cliproxy config get --output backup.json` (with `0600` perms) is the safest backup mechanism.

--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -1,53 +1,257 @@
-import {describe, expect, it} from 'bun:test'
+import {existsSync} from 'node:fs'
 
-import {validateCliproxyDomain} from './provision-droplet'
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+
+import {performProvisioning, resolveProvisionIdentity, validateCliproxyDomain} from './provision-droplet'
 
 // ---------------------------------------------------------------------------
-// validateCliproxyDomain
+// Env helpers
 // ---------------------------------------------------------------------------
 
-describe('validateCliproxyDomain', () => {
-  it('accepts a valid domain', () => {
-    expect(validateCliproxyDomain('cliproxy.fro.bot')).toBe('cliproxy.fro.bot')
+const managedEnvKeys = ['CLIPROXY_DOMAIN', 'CLIPROXY_SSH_KEY'] as const
+type ManagedEnvKey = (typeof managedEnvKeys)[number]
+
+let savedEnv: Partial<Record<ManagedEnvKey, string | undefined>>
+
+function saveEnv(): void {
+  savedEnv = Object.fromEntries(managedEnvKeys.map(k => [k, process.env[k]]))
+}
+
+function restoreEnv(): void {
+  for (const key of managedEnvKeys) {
+    const value = savedEnv[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+// A fake private key for testing — not a real key, just realistic shape
+const FAKE_PRIVATE_KEY = '-----BEGIN OPENSSH PRIVATE KEY-----\nfakebase64content\n-----END OPENSSH PRIVATE KEY-----'
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('provision-droplet', () => {
+  beforeEach(() => {
+    saveEnv()
   })
 
-  it('accepts a plain hostname', () => {
-    expect(validateCliproxyDomain('example.com')).toBe('example.com')
+  afterEach(() => {
+    restoreEnv()
   })
 
-  it('throws on a value containing a newline (heredoc termination)', () => {
-    expect(() => validateCliproxyDomain('cliproxy.fro.bot\nENVFILE\nevil')).toThrow(/disallowed characters/)
+  // ---------------------------------------------------------------------------
+  // validateCliproxyDomain
+  // ---------------------------------------------------------------------------
+
+  describe('validateCliproxyDomain', () => {
+    it('accepts a valid domain', () => {
+      expect(validateCliproxyDomain('cliproxy.fro.bot')).toBe('cliproxy.fro.bot')
+    })
+
+    it('accepts a plain hostname', () => {
+      expect(validateCliproxyDomain('example.com')).toBe('example.com')
+    })
+
+    it('throws on a value containing a newline (heredoc termination)', () => {
+      expect(() => validateCliproxyDomain('cliproxy.fro.bot\nENVFILE\nevil')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a dollar sign (variable expansion)', () => {
+      expect(() => validateCliproxyDomain('host$PATH')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a backtick (command substitution)', () => {
+      expect(() => validateCliproxyDomain('host`id`')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a pipe (command chaining)', () => {
+      expect(() => validateCliproxyDomain('host|cat /etc/passwd')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a semicolon (command separator)', () => {
+      expect(() => validateCliproxyDomain('host;rm -rf /')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing an ampersand (background execution)', () => {
+      expect(() => validateCliproxyDomain('host&evil')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a single quote', () => {
+      expect(() => validateCliproxyDomain("host'evil")).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a double quote', () => {
+      expect(() => validateCliproxyDomain('host"evil')).toThrow(/disallowed characters/)
+    })
+
+    it('throws on a value containing a backslash', () => {
+      expect(() => validateCliproxyDomain(String.raw`host\evil`)).toThrow(/disallowed characters/)
+    })
   })
 
-  it('throws on a value containing a dollar sign (variable expansion)', () => {
-    expect(() => validateCliproxyDomain('host$PATH')).toThrow(/disallowed characters/)
+  // ---------------------------------------------------------------------------
+  // resolveProvisionIdentity — identity materialization helper
+  // ---------------------------------------------------------------------------
+
+  describe('resolveProvisionIdentity', () => {
+    it('returns a temp file path when key material is provided', () => {
+      const {identityFile, cleanup} = resolveProvisionIdentity(FAKE_PRIVATE_KEY)
+      try {
+        expect(identityFile).toBeTruthy()
+        expect(identityFile).not.toBe('')
+        expect(existsSync(identityFile ?? '')).toBe(true)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('cleanup removes the temp file', () => {
+      const {identityFile, cleanup} = resolveProvisionIdentity(FAKE_PRIVATE_KEY)
+      expect(existsSync(identityFile ?? '')).toBe(true)
+      cleanup()
+      expect(existsSync(identityFile ?? '')).toBe(false)
+    })
+
+    it('cleanup is idempotent — calling twice does not throw', () => {
+      const {cleanup} = resolveProvisionIdentity(FAKE_PRIVATE_KEY)
+      cleanup()
+      expect(() => cleanup()).not.toThrow()
+    })
+
+    it('returns no identityFile and a no-op cleanup when key material is absent', () => {
+      const {identityFile, cleanup} = resolveProvisionIdentity(undefined)
+      expect(identityFile).toBeUndefined()
+      expect(() => cleanup()).not.toThrow()
+    })
   })
 
-  it('throws on a value containing a backtick (command substitution)', () => {
-    expect(() => validateCliproxyDomain('host`id`')).toThrow(/disallowed characters/)
-  })
+  // ---------------------------------------------------------------------------
+  // performProvisioning — full SSH orchestration seam
+  // ---------------------------------------------------------------------------
 
-  it('throws on a value containing a pipe (command chaining)', () => {
-    expect(() => validateCliproxyDomain('host|cat /etc/passwd')).toThrow(/disallowed characters/)
-  })
+  describe('SSH provisioning orchestration', () => {
+    it('threads identity file through waitForSsh and all helper calls when key is set', async () => {
+      const capturedWaitForSsh: {host: string; user: string; identityFile?: string}[] = []
+      const capturedCopyComposeFiles: {host: string; identityFile?: string}[] = []
+      const capturedWriteRemoteEnvFile: {host: string; identityFile?: string}[] = []
+      const capturedDeployCompose: {host: string; identityFile?: string}[] = []
 
-  it('throws on a value containing a semicolon (command separator)', () => {
-    expect(() => validateCliproxyDomain('host;rm -rf /')).toThrow(/disallowed characters/)
-  })
+      const fakeWaitForSsh = async (host: string, user: string, opts?: {identityFile?: string}) => {
+        capturedWaitForSsh.push({host, user, identityFile: opts?.identityFile})
+      }
+      const fakeCopyComposeFiles = async (host: string, identityFile?: string) => {
+        capturedCopyComposeFiles.push({host, identityFile})
+      }
+      const fakeWriteRemoteEnvFile = async (host: string, identityFile?: string): Promise<string> => {
+        capturedWriteRemoteEnvFile.push({host, identityFile})
+        return 'fake-mgmt-password'
+      }
+      const fakeDeployCompose = async (host: string, identityFile?: string) => {
+        capturedDeployCompose.push({host, identityFile})
+      }
 
-  it('throws on a value containing an ampersand (background execution)', () => {
-    expect(() => validateCliproxyDomain('host&evil')).toThrow(/disallowed characters/)
-  })
+      await performProvisioning('1.2.3.4', FAKE_PRIVATE_KEY, {
+        waitForSsh: fakeWaitForSsh,
+        copyComposeFiles: fakeCopyComposeFiles,
+        writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        deployCompose: fakeDeployCompose,
+      })
 
-  it('throws on a value containing a single quote', () => {
-    expect(() => validateCliproxyDomain("host'evil")).toThrow(/disallowed characters/)
-  })
+      // waitForSsh must have received a non-empty identity file path
+      expect(capturedWaitForSsh).toHaveLength(1)
+      const {identityFile: wsfPath} = capturedWaitForSsh[0] ?? {}
+      expect(wsfPath).toBeTruthy()
 
-  it('throws on a value containing a double quote', () => {
-    expect(() => validateCliproxyDomain('host"evil')).toThrow(/disallowed characters/)
-  })
+      // All helpers must receive the same identity file path
+      expect(capturedCopyComposeFiles[0]?.identityFile).toBe(wsfPath)
+      expect(capturedWriteRemoteEnvFile[0]?.identityFile).toBe(wsfPath)
+      expect(capturedDeployCompose[0]?.identityFile).toBe(wsfPath)
+    })
 
-  it('throws on a value containing a backslash', () => {
-    expect(() => validateCliproxyDomain(String.raw`host\evil`)).toThrow(/disallowed characters/)
+    it('does not pass identity file to any helper when no key material is given', async () => {
+      const capturedIdentities: (string | undefined)[] = []
+
+      const recordIdentity = (identityFile?: string) => {
+        capturedIdentities.push(identityFile)
+      }
+
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        recordIdentity(opts?.identityFile)
+      }
+      const fakeCopyComposeFiles = async (_host: string, identityFile?: string) => {
+        recordIdentity(identityFile)
+      }
+      const fakeWriteRemoteEnvFile = async (_host: string, identityFile?: string): Promise<string> => {
+        recordIdentity(identityFile)
+        return 'fake-mgmt-password'
+      }
+      const fakeDeployCompose = async (_host: string, identityFile?: string) => {
+        recordIdentity(identityFile)
+      }
+
+      await performProvisioning('1.2.3.4', undefined, {
+        waitForSsh: fakeWaitForSsh,
+        copyComposeFiles: fakeCopyComposeFiles,
+        writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        deployCompose: fakeDeployCompose,
+      })
+
+      // No helper should have received an identity file
+      for (const id of capturedIdentities) {
+        expect(id).toBeUndefined()
+      }
+    })
+
+    it('cleans up the temp key file even when a provisioning step throws', async () => {
+      let capturedPath: string | undefined
+
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+        throw new Error('provisioning step failed')
+      }
+      const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
+      const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
+        'fake-mgmt-password'
+      const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
+
+      await expect(
+        performProvisioning('1.2.3.4', FAKE_PRIVATE_KEY, {
+          waitForSsh: fakeWaitForSsh,
+          copyComposeFiles: fakeCopyComposeFiles,
+          writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+          deployCompose: fakeDeployCompose,
+        }),
+      ).rejects.toThrow('provisioning step failed')
+
+      // The temp file must have been cleaned up in the finally block
+      expect(capturedPath).toBeTruthy()
+      expect(existsSync(capturedPath ?? '')).toBe(false)
+    })
+
+    it('does not create a temp file when no key material is provided', async () => {
+      let capturedPath: string | undefined
+
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+      }
+      const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
+      const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
+        'fake-mgmt-password'
+      const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
+
+      await performProvisioning('1.2.3.4', undefined, {
+        waitForSsh: fakeWaitForSsh,
+        copyComposeFiles: fakeCopyComposeFiles,
+        writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        deployCompose: fakeDeployCompose,
+      })
+
+      expect(capturedPath).toBeUndefined()
+    })
   })
 })

--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -1,8 +1,13 @@
 import {existsSync} from 'node:fs'
 
-import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
+import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
-import {performProvisioning, resolveProvisionIdentity, validateCliproxyDomain} from './provision-droplet'
+import {
+  performProvisioning,
+  resolveProvisionIdentity,
+  validateCliproxyDomain,
+  writeRemoteEnvFile,
+} from './provision-droplet'
 
 // ---------------------------------------------------------------------------
 // Env helpers
@@ -128,6 +133,12 @@ describe('provision-droplet', () => {
       expect(identityFile).toBeUndefined()
       expect(() => cleanup()).not.toThrow()
     })
+
+    it('treats a whitespace-only key as absent — no temp file, no-op cleanup', () => {
+      const {identityFile, cleanup} = resolveProvisionIdentity('   \n  ')
+      expect(identityFile).toBeUndefined()
+      expect(() => cleanup()).not.toThrow()
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -157,6 +168,7 @@ describe('provision-droplet', () => {
 
       await performProvisioning('1.2.3.4', FAKE_PRIVATE_KEY, {
         waitForSsh: fakeWaitForSsh,
+        pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
         deployCompose: fakeDeployCompose,
@@ -196,6 +208,7 @@ describe('provision-droplet', () => {
 
       await performProvisioning('1.2.3.4', undefined, {
         waitForSsh: fakeWaitForSsh,
+        pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
         deployCompose: fakeDeployCompose,
@@ -222,6 +235,7 @@ describe('provision-droplet', () => {
       await expect(
         performProvisioning('1.2.3.4', FAKE_PRIVATE_KEY, {
           waitForSsh: fakeWaitForSsh,
+          pinHostKeys: async () => {},
           copyComposeFiles: fakeCopyComposeFiles,
           writeRemoteEnvFile: fakeWriteRemoteEnvFile,
           deployCompose: fakeDeployCompose,
@@ -246,12 +260,55 @@ describe('provision-droplet', () => {
 
       await performProvisioning('1.2.3.4', undefined, {
         waitForSsh: fakeWaitForSsh,
+        pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
         deployCompose: fakeDeployCompose,
       })
 
       expect(capturedPath).toBeUndefined()
+    })
+
+    it('calls waitForSsh before pinHostKeys when pinHostKeys is injected', async () => {
+      const callOrder: string[] = []
+
+      const fakeWaitForSsh = async () => {
+        callOrder.push('waitForSsh')
+      }
+      const fakePinHostKeys = async () => {
+        callOrder.push('pinHostKeys')
+      }
+      const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
+      const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
+        'fake-mgmt-password'
+      const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
+
+      await performProvisioning('1.2.3.4', undefined, {
+        waitForSsh: fakeWaitForSsh,
+        pinHostKeys: fakePinHostKeys,
+        copyComposeFiles: fakeCopyComposeFiles,
+        writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        deployCompose: fakeDeployCompose,
+      })
+
+      expect(callOrder.indexOf('waitForSsh')).toBeLessThan(callOrder.indexOf('pinHostKeys'))
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // writeRemoteEnvFile — rejects on non-zero SSH exit
+  // ---------------------------------------------------------------------------
+
+  describe('writeRemoteEnvFile', () => {
+    it('rejects with an error when the SSH .env write command fails', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(255),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await expect(writeRemoteEnvFile('1.2.3.4')).rejects.toThrow(/255/)
+
+      spawnSpy.mockRestore()
     })
   })
 })

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -7,6 +7,7 @@ import {
   dropletExists,
   getDropletIpWithWait,
   getSshFingerprint,
+  materializeIdentityFile,
   pinHostKeys,
   run,
   scp,
@@ -39,6 +40,35 @@ export function validateCliproxyDomain(domain: string): string {
 
 const REMOTE_USER = process.env.REMOTE_USER ?? 'root'
 const REMOTE_DIR = '/opt/cliproxy'
+
+// ---------------------------------------------------------------------------
+// Identity resolution (exported for testability)
+// ---------------------------------------------------------------------------
+
+export interface ProvisionIdentity {
+  /** Temp file path of the materialized key, or undefined when no key was given. */
+  identityFile: string | undefined
+  /** Removes the temp file. No-op when identityFile is undefined. */
+  cleanup: () => void
+}
+
+/**
+ * Materializes the SSH private key (if provided) into a temp file and returns
+ * a cleanup handle. Returns an identity with no path and a no-op cleanup when
+ * key material is absent (ssh-agent path).
+ */
+export function resolveProvisionIdentity(privateKey: string | undefined): ProvisionIdentity {
+  if (!privateKey) {
+    return {identityFile: undefined, cleanup: () => {}}
+  }
+
+  const {path, cleanup} = materializeIdentityFile(privateKey)
+  return {identityFile: path, cleanup}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper functions — each accepts an optional identityFile
+// ---------------------------------------------------------------------------
 
 async function createDropletIfMissing(): Promise<boolean> {
   const exists = await dropletExists(DROPLET_NAME)
@@ -94,22 +124,30 @@ function resolveLocalFiles(): {compose: string; config: string; caddy: string} {
   }
 }
 
-async function copyComposeFiles(host: string): Promise<void> {
+export async function copyComposeFiles(host: string, identityFile?: string): Promise<void> {
   const files = resolveLocalFiles()
+  const opts = identityFile ? {identityFile} : undefined
 
-  await run('Creating remote directories', ssh(host, `mkdir -p ${REMOTE_DIR}/config`, REMOTE_USER))
-  await run('Uploading docker-compose.yaml', scp(host, files.compose, `${REMOTE_DIR}/docker-compose.yaml`, REMOTE_USER))
-  await run('Uploading config/config.yaml', scp(host, files.config, `${REMOTE_DIR}/config/config.yaml`, REMOTE_USER))
-  await run('Uploading config/Caddyfile', scp(host, files.caddy, `${REMOTE_DIR}/config/Caddyfile`, REMOTE_USER))
+  await run('Creating remote directories', ssh(host, `mkdir -p ${REMOTE_DIR}/config`, REMOTE_USER, opts))
+  await run(
+    'Uploading docker-compose.yaml',
+    scp(host, files.compose, `${REMOTE_DIR}/docker-compose.yaml`, REMOTE_USER, opts),
+  )
+  await run(
+    'Uploading config/config.yaml',
+    scp(host, files.config, `${REMOTE_DIR}/config/config.yaml`, REMOTE_USER, opts),
+  )
+  await run('Uploading config/Caddyfile', scp(host, files.caddy, `${REMOTE_DIR}/config/Caddyfile`, REMOTE_USER, opts))
 }
 
-async function writeRemoteEnvFile(host: string): Promise<string> {
+export async function writeRemoteEnvFile(host: string, identityFile?: string): Promise<string> {
   const managementPassword = randomBytes(32).toString('hex')
   const envFile = `CLIPROXY_DOMAIN=${CLIPROXY_DOMAIN}\nMANAGEMENT_PASSWORD=${managementPassword}\n`
+  const opts = identityFile ? {identityFile} : undefined
 
   // Pipe contents through stdin — never embed in the command string.
   // This prevents heredoc-termination injection if any env var contains newlines.
-  const proc = Bun.spawn(ssh(host, `cat > ${REMOTE_DIR}/.env`, REMOTE_USER), {
+  const proc = Bun.spawn(ssh(host, `cat > ${REMOTE_DIR}/.env`, REMOTE_USER, opts), {
     stdin: 'pipe',
     stdout: 'inherit',
     stderr: 'inherit',
@@ -129,9 +167,56 @@ async function writeRemoteEnvFile(host: string): Promise<string> {
   return managementPassword
 }
 
-async function deployCompose(host: string): Promise<void> {
-  await run('Starting Docker Compose stack', ssh(host, `cd ${REMOTE_DIR} && docker compose up -d`, REMOTE_USER))
+export async function deployCompose(host: string, identityFile?: string): Promise<void> {
+  const opts = identityFile ? {identityFile} : undefined
+  await run('Starting Docker Compose stack', ssh(host, `cd ${REMOTE_DIR} && docker compose up -d`, REMOTE_USER, opts))
 }
+
+// ---------------------------------------------------------------------------
+// Full provisioning orchestration seam (exported for testability)
+// ---------------------------------------------------------------------------
+
+export interface PerformProvisioningDeps {
+  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
+  copyComposeFiles?: (host: string, identityFile?: string) => Promise<void>
+  writeRemoteEnvFile?: (host: string, identityFile?: string) => Promise<string>
+  deployCompose?: (host: string, identityFile?: string) => Promise<void>
+}
+
+/**
+ * Performs the SSH-reliant provisioning steps after the droplet IP is known.
+ * Materializes the SSH key (if provided) into a temp file, passes it through
+ * all SSH/SCP helper calls, and cleans it up in a `finally` block.
+ *
+ * Injectable deps allow tests to assert identity file threading without live
+ * SSH connections. Production callers omit deps and get the real implementations.
+ */
+export async function performProvisioning(
+  dropletIp: string,
+  privateKey: string | undefined,
+  deps: PerformProvisioningDeps = {},
+): Promise<string> {
+  const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
+  const resolvedCopyComposeFiles = deps.copyComposeFiles ?? copyComposeFiles
+  const resolvedWriteRemoteEnvFile = deps.writeRemoteEnvFile ?? writeRemoteEnvFile
+  const resolvedDeployCompose = deps.deployCompose ?? deployCompose
+
+  const {identityFile, cleanup} = resolveProvisionIdentity(privateKey)
+
+  try {
+    await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile})
+    await resolvedCopyComposeFiles(dropletIp, identityFile)
+    const managementPassword = await resolvedWriteRemoteEnvFile(dropletIp, identityFile)
+    await resolvedDeployCompose(dropletIp, identityFile)
+    return managementPassword
+  } finally {
+    cleanup()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main orchestrator
+// ---------------------------------------------------------------------------
 
 async function provision(): Promise<void> {
   await validateDoctl({checkAuth: true})
@@ -147,7 +232,6 @@ async function provision(): Promise<void> {
   }
 
   const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
-  await waitForSsh(dropletIp, REMOTE_USER)
 
   const knownHostsPath = resolve(import.meta.dir, '..', '..', '..', '.github', 'known_hosts')
   await pinHostKeys(CLIPROXY_DOMAIN, dropletIp, knownHostsPath, {
@@ -155,9 +239,8 @@ async function provision(): Promise<void> {
   })
 
   await validateDns(dropletIp)
-  await copyComposeFiles(dropletIp)
-  const managementPassword = await writeRemoteEnvFile(dropletIp)
-  await deployCompose(dropletIp)
+
+  const managementPassword = await performProvisioning(dropletIp, process.env.CLIPROXY_SSH_KEY)
 
   console.log('\n\u001B[1;32m✓\u001B[0m CLIProxy droplet provisioned\n')
   console.log(`Droplet IP: ${dropletIp}`)

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -58,7 +58,7 @@ export interface ProvisionIdentity {
  * key material is absent (ssh-agent path).
  */
 export function resolveProvisionIdentity(privateKey: string | undefined): ProvisionIdentity {
-  if (!privateKey) {
+  if (!privateKey || privateKey.trim().length === 0) {
     return {identityFile: undefined, cleanup: () => {}}
   }
 
@@ -158,8 +158,7 @@ export async function writeRemoteEnvFile(host: string, identityFile?: string): P
 
   const exitCode = await proc.exited
   if (exitCode !== 0) {
-    console.error(`\u001B[1;31mFAILED:\u001B[0m Writing remote .env file (exit ${exitCode})`)
-    process.exit(1)
+    throw new Error(`Writing remote .env file failed (exit ${exitCode})`)
   }
 
   console.log('\u001B[1;34m==>\u001B[0m Writing remote .env file')
@@ -177,10 +176,11 @@ export async function deployCompose(host: string, identityFile?: string): Promis
 // ---------------------------------------------------------------------------
 
 export interface PerformProvisioningDeps {
-  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
-  copyComposeFiles?: (host: string, identityFile?: string) => Promise<void>
-  writeRemoteEnvFile?: (host: string, identityFile?: string) => Promise<string>
-  deployCompose?: (host: string, identityFile?: string) => Promise<void>
+  waitForSsh?: typeof waitForSsh
+  pinHostKeys?: typeof pinHostKeys
+  copyComposeFiles?: typeof copyComposeFiles
+  writeRemoteEnvFile?: typeof writeRemoteEnvFile
+  deployCompose?: typeof deployCompose
 }
 
 /**
@@ -197,6 +197,7 @@ export async function performProvisioning(
   deps: PerformProvisioningDeps = {},
 ): Promise<string> {
   const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
+  const resolvedPinHostKeys = deps.pinHostKeys ?? pinHostKeys
   const resolvedCopyComposeFiles = deps.copyComposeFiles ?? copyComposeFiles
   const resolvedWriteRemoteEnvFile = deps.writeRemoteEnvFile ?? writeRemoteEnvFile
   const resolvedDeployCompose = deps.deployCompose ?? deployCompose
@@ -205,6 +206,11 @@ export async function performProvisioning(
 
   try {
     await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile})
+    const knownHostsPath = resolve(import.meta.dir, '..', '..', '..', '.github', 'known_hosts')
+    await resolvedPinHostKeys(CLIPROXY_DOMAIN, dropletIp, knownHostsPath, {
+      marker: `# cliproxy droplet (${dropletIp} / ${CLIPROXY_DOMAIN})`,
+    })
+    await validateDns(dropletIp)
     await resolvedCopyComposeFiles(dropletIp, identityFile)
     const managementPassword = await resolvedWriteRemoteEnvFile(dropletIp, identityFile)
     await resolvedDeployCompose(dropletIp, identityFile)
@@ -232,13 +238,6 @@ async function provision(): Promise<void> {
   }
 
   const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
-
-  const knownHostsPath = resolve(import.meta.dir, '..', '..', '..', '.github', 'known_hosts')
-  await pinHostKeys(CLIPROXY_DOMAIN, dropletIp, knownHostsPath, {
-    marker: `# cliproxy droplet (${dropletIp} / ${CLIPROXY_DOMAIN})`,
-  })
-
-  await validateDns(dropletIp)
 
   const managementPassword = await performProvisioning(dropletIp, process.env.CLIPROXY_SSH_KEY)
 

--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -55,8 +55,10 @@ The deploy script materializes secrets as files on the droplet (never via argv),
 **Run:**
 
 ```bash
-bun run --cwd apps/gateway provision
+bun run provision:gateway
 ```
+
+(Root wrapper — loads the repo-root `.env`; `--cwd apps/gateway` would miss it.)
 
 The script will:
 
@@ -65,6 +67,10 @@ The script will:
 3. Create an `s-1vcpu-2gb` droplet in `nyc1`, tagged `gateway`
 4. Append unhashed domain host keys and hashed IP host keys to `.github/known_hosts` (`ssh-keyscan <domain>` + `ssh-keyscan -H <ip>`)
 5. Print operator setup steps for finalizing the GitHub Environment
+
+SSH auth during provisioning: when `GATEWAY_SSH_KEY` is set, the script materializes it to a `0600`
+temp key file and pins it with `-i` + `IdentitiesOnly=yes` (no ssh-agent needed; cleaned up after).
+When unset, it falls back to ssh-agent.
 
 After provisioning: commit the updated `.github/known_hosts`.
 
@@ -106,7 +112,7 @@ The CLI validates the archive locally first — it must contain exactly the two 
 
 **Restore — full disaster recovery (droplet destroyed):**
 
-1. Set `GATEWAY_HOST` locally and run `bun run --cwd apps/gateway provision` to create a replacement droplet.
+1. Set `GATEWAY_HOST` locally and run `bun run provision:gateway` to create a replacement droplet.
 2. Commit and push the updated `.github/known_hosts`.
 3. If the host or IP changed, update `GATEWAY_HOST` (and `GATEWAY_SSH_KEY` if re-keyed) in the `gateway` GitHub Environment.
 4. Trigger a deploy (`bunx @marcusrbrown/infra gateway deploy`) and approve the environment gate. This creates `/opt/gateway/deploy/` on the new droplet.

--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -1,9 +1,12 @@
+import {existsSync} from 'node:fs'
+
 import {dropletExists} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
 import {validateGatewayHost} from '../src/host'
 import {
   checkDropletExistence,
+  establishSshAccess,
   getGatewaySshFingerprint,
   parseProvisionArgs,
   validateRequiredEnv,
@@ -13,7 +16,7 @@ import {
 // Env helpers
 // ---------------------------------------------------------------------------
 
-const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'GATEWAY_HOST', 'GATEWAY_SSH_KEY_NAME'] as const
+const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'GATEWAY_HOST', 'GATEWAY_SSH_KEY', 'GATEWAY_SSH_KEY_NAME'] as const
 type ManagedEnvKey = (typeof managedEnvKeys)[number]
 
 let savedEnv: Partial<Record<ManagedEnvKey, string | undefined>>
@@ -60,6 +63,9 @@ function makeSpawnResult(stdout: string, exitCode: number): SpawnResult {
     exited: Promise.resolve(exitCode),
   }
 }
+
+// A fake private key for testing — not a real key, just realistic shape
+const FAKE_PRIVATE_KEY = '-----BEGIN OPENSSH PRIVATE KEY-----\nfakebase64content\n-----END OPENSSH PRIVATE KEY-----'
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -334,6 +340,73 @@ describe('provision-droplet', () => {
       expect(wouldAbort).toBe(false)
 
       spawnSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // establishSshAccess — SSH identity seam
+  // -------------------------------------------------------------------------
+
+  describe('SSH access establishment', () => {
+    it('passes identity file to waitForSsh when key material is provided', async () => {
+      let capturedPath: string | undefined
+      let fileExistedDuringCall = false
+
+      const fakeWaitForSsh = async (host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+        // Assert the file actually exists at call time (before finally cleanup)
+        fileExistedDuringCall = capturedPath !== undefined && existsSync(capturedPath)
+        expect(host).toBe('1.2.3.4')
+      }
+
+      await establishSshAccess('1.2.3.4', FAKE_PRIVATE_KEY, {waitForSsh: fakeWaitForSsh})
+
+      // Path must have been a non-empty string
+      expect(capturedPath).toBeTruthy()
+      expect(capturedPath).not.toBe('')
+      // The file must have existed at the moment waitForSsh was called
+      expect(fileExistedDuringCall).toBe(true)
+      // After the call, the finally block must have cleaned it up
+      expect(existsSync(capturedPath ?? '')).toBe(false)
+    })
+
+    it('does not pass identity file to waitForSsh when no key material is given', async () => {
+      const capturedOpts: ({identityFile?: string} | undefined)[] = []
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedOpts.push(opts)
+      }
+
+      await establishSshAccess('1.2.3.4', undefined, {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedOpts).toHaveLength(1)
+      expect(capturedOpts[0]?.identityFile).toBeUndefined()
+    })
+
+    it('cleans up the temp key file even when waitForSsh throws', async () => {
+      let capturedPath: string | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+        throw new Error('SSH connection failed')
+      }
+
+      await expect(establishSshAccess('1.2.3.4', FAKE_PRIVATE_KEY, {waitForSsh: fakeWaitForSsh})).rejects.toThrow(
+        'SSH connection failed',
+      )
+
+      // File must be cleaned up even though waitForSsh threw
+      expect(capturedPath).toBeTruthy()
+      expect(existsSync(capturedPath ?? '')).toBe(false)
+    })
+
+    it('does not create a temp file when no key material is provided', async () => {
+      let capturedPath: string | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+      }
+
+      await establishSshAccess('1.2.3.4', undefined, {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedPath).toBeUndefined()
     })
   })
 })

--- a/apps/gateway/server/provision-droplet.test.ts
+++ b/apps/gateway/server/provision-droplet.test.ts
@@ -408,5 +408,16 @@ describe('provision-droplet', () => {
 
       expect(capturedPath).toBeUndefined()
     })
+
+    it('treats a whitespace-only key as absent — no temp file, no SSH -i flag', async () => {
+      let capturedOpts: {identityFile?: string} | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedOpts = opts
+      }
+
+      await establishSshAccess('1.2.3.4', '   \n  ', {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedOpts?.identityFile).toBeUndefined()
+    })
   })
 })

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -6,6 +6,7 @@ import {
   dropletExists,
   getDropletIpWithWait,
   getSshFingerprint,
+  materializeIdentityFile,
   pinHostKeys,
   run,
   validateDoctl,
@@ -104,6 +105,33 @@ function printOperatorSetupMessage(dropletIp: string, gatewayHost: string): void
 }
 
 // ---------------------------------------------------------------------------
+// SSH identity seam (exported for testability)
+// ---------------------------------------------------------------------------
+
+export interface EstablishSshAccessDeps {
+  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
+}
+
+/**
+ * Materializes the SSH key (if provided) into a temp file and calls waitForSsh.
+ * Cleans up the temp file in a `finally` block regardless of outcome.
+ * Injectable deps allow tests to assert identity file threading without live SSH.
+ */
+export async function establishSshAccess(
+  dropletIp: string,
+  privateKey: string | undefined,
+  deps: EstablishSshAccessDeps = {},
+): Promise<void> {
+  const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
+  const identity = privateKey ? materializeIdentityFile(privateKey) : undefined
+  try {
+    await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile: identity?.path})
+  } finally {
+    identity?.cleanup()
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main orchestrator
 // ---------------------------------------------------------------------------
 
@@ -160,7 +188,7 @@ export async function main(): Promise<void> {
   }
 
   const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
-  await waitForSsh(dropletIp, REMOTE_USER)
+  await establishSshAccess(dropletIp, process.env.GATEWAY_SSH_KEY)
 
   const knownHostsPath = resolve(join(import.meta.dir, '..', '..', '..', '.github', 'known_hosts'))
   await pinHostKeys(gatewayHost, dropletIp, knownHostsPath, {

--- a/apps/gateway/server/provision-droplet.ts
+++ b/apps/gateway/server/provision-droplet.ts
@@ -109,7 +109,7 @@ function printOperatorSetupMessage(dropletIp: string, gatewayHost: string): void
 // ---------------------------------------------------------------------------
 
 export interface EstablishSshAccessDeps {
-  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
+  waitForSsh?: typeof waitForSsh
 }
 
 /**
@@ -123,7 +123,7 @@ export async function establishSshAccess(
   deps: EstablishSshAccessDeps = {},
 ): Promise<void> {
   const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
-  const identity = privateKey ? materializeIdentityFile(privateKey) : undefined
+  const identity = privateKey && privateKey.trim().length > 0 ? materializeIdentityFile(privateKey) : undefined
   try {
     await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile: identity?.path})
   } finally {

--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -152,10 +152,15 @@ admin auth-endpoint constants in `src/deploy.ts` against the new image.
 
 ## Provisioning
 
-One-time: `bun run --cwd apps/umami provision` creates the `s-1vcpu-1gb` droplet (image
-`docker-20-04`), selects the SSH key by name (`UMAMI_SSH_KEY_NAME`, default `fro-bot-umami`), waits
-for SSH, and pins both the domain and droplet-IP host keys into `.github/known_hosts` (commit the
-result before the first CI deploy). Resize to `s-1vcpu-2gb` if Postgres memory pressure appears.
+One-time: `bun run provision:umami` (root wrapper — loads the repo-root `.env`; `--cwd apps/umami`
+would miss it) creates the `s-1vcpu-1gb` droplet (image `docker-20-04`), selects the SSH key by name
+(`UMAMI_SSH_KEY_NAME`, default `fro-bot-umami`), waits for SSH, and pins both the domain and
+droplet-IP host keys into `.github/known_hosts` (commit the result before the first CI deploy).
+Resize to `s-1vcpu-2gb` if Postgres memory pressure appears.
+
+SSH auth during provisioning: when `UMAMI_SSH_KEY` is set, the script materializes it to a `0600`
+temp key file and pins it with `-i` + `IdentitiesOnly=yes` (no ssh-agent needed; cleaned up after).
+When unset, it falls back to ssh-agent.
 
 ## Anti-patterns
 

--- a/apps/umami/server/provision-droplet.test.ts
+++ b/apps/umami/server/provision-droplet.test.ts
@@ -404,5 +404,16 @@ describe('provision-droplet', () => {
 
       expect(capturedPath).toBeUndefined()
     })
+
+    it('treats a whitespace-only key as absent — no temp file, no SSH -i flag', async () => {
+      let capturedOpts: {identityFile?: string} | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedOpts = opts
+      }
+
+      await establishSshAccess('1.2.3.4', '   \n  ', {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedOpts?.identityFile).toBeUndefined()
+    })
   })
 })

--- a/apps/umami/server/provision-droplet.test.ts
+++ b/apps/umami/server/provision-droplet.test.ts
@@ -1,9 +1,12 @@
+import {existsSync} from 'node:fs'
+
 import {dropletExists} from '@marcusrbrown/infra-shared/server/droplet-helpers'
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
 import {validateUmamiHost} from '../src/host'
 import {
   checkDropletExistence,
+  establishSshAccess,
   getUmamiSshFingerprint,
   parseProvisionArgs,
   validateRequiredEnv,
@@ -13,7 +16,7 @@ import {
 // Env helpers
 // ---------------------------------------------------------------------------
 
-const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'UMAMI_DOMAIN', 'UMAMI_SSH_KEY_NAME'] as const
+const managedEnvKeys = ['DIGITALOCEAN_ACCESS_TOKEN', 'UMAMI_DOMAIN', 'UMAMI_SSH_KEY', 'UMAMI_SSH_KEY_NAME'] as const
 type ManagedEnvKey = (typeof managedEnvKeys)[number]
 
 let savedEnv: Partial<Record<ManagedEnvKey, string | undefined>>
@@ -60,6 +63,9 @@ function makeSpawnResult(stdout: string, exitCode: number): SpawnResult {
     exited: Promise.resolve(exitCode),
   }
 }
+
+// A fake private key for testing — not a real key, just realistic shape
+const FAKE_PRIVATE_KEY = '-----BEGIN OPENSSH PRIVATE KEY-----\nfakebase64content\n-----END OPENSSH PRIVATE KEY-----'
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -330,6 +336,73 @@ describe('provision-droplet', () => {
 
     it('throws on a value containing a space', () => {
       expect(() => validateUmamiHost('host name')).toThrow(/Invalid UMAMI_DOMAIN/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // establishSshAccess — SSH identity seam
+  // -------------------------------------------------------------------------
+
+  describe('SSH access establishment', () => {
+    it('passes identity file to waitForSsh when UMAMI_SSH_KEY is set', async () => {
+      let capturedPath: string | undefined
+      let fileExistedDuringCall = false
+
+      const fakeWaitForSsh = async (host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+        // Assert the file actually exists at call time (before finally cleanup)
+        fileExistedDuringCall = capturedPath !== undefined && existsSync(capturedPath)
+        expect(host).toBe('1.2.3.4')
+      }
+
+      await establishSshAccess('1.2.3.4', FAKE_PRIVATE_KEY, {waitForSsh: fakeWaitForSsh})
+
+      // Path must have been a non-empty string
+      expect(capturedPath).toBeTruthy()
+      expect(capturedPath).not.toBe('')
+      // The file must have existed at the moment waitForSsh was called
+      expect(fileExistedDuringCall).toBe(true)
+      // After the call, the finally block must have cleaned it up
+      expect(existsSync(capturedPath ?? '')).toBe(false)
+    })
+
+    it('does not pass identity file to waitForSsh when no key material is given', async () => {
+      const capturedOpts: ({identityFile?: string} | undefined)[] = []
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedOpts.push(opts)
+      }
+
+      await establishSshAccess('1.2.3.4', undefined, {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedOpts).toHaveLength(1)
+      expect(capturedOpts[0]?.identityFile).toBeUndefined()
+    })
+
+    it('cleans up the temp key file even when waitForSsh throws', async () => {
+      let capturedPath: string | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+        throw new Error('SSH connection failed')
+      }
+
+      await expect(establishSshAccess('1.2.3.4', FAKE_PRIVATE_KEY, {waitForSsh: fakeWaitForSsh})).rejects.toThrow(
+        'SSH connection failed',
+      )
+
+      // File must be cleaned up even though waitForSsh threw
+      expect(capturedPath).toBeTruthy()
+      expect(existsSync(capturedPath ?? '')).toBe(false)
+    })
+
+    it('does not create a temp file when no key material is provided', async () => {
+      let capturedPath: string | undefined
+      const fakeWaitForSsh = async (_host: string, _user: string, opts?: {identityFile?: string}) => {
+        capturedPath = opts?.identityFile
+      }
+
+      await establishSshAccess('1.2.3.4', undefined, {waitForSsh: fakeWaitForSsh})
+
+      expect(capturedPath).toBeUndefined()
     })
   })
 })

--- a/apps/umami/server/provision-droplet.ts
+++ b/apps/umami/server/provision-droplet.ts
@@ -96,7 +96,7 @@ function printOperatorSetupMessage(dropletIp: string, umamiHost: string): void {
 // ---------------------------------------------------------------------------
 
 export interface EstablishSshAccessDeps {
-  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
+  waitForSsh?: typeof waitForSsh
 }
 
 /**
@@ -110,7 +110,7 @@ export async function establishSshAccess(
   deps: EstablishSshAccessDeps = {},
 ): Promise<void> {
   const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
-  const identity = privateKey ? materializeIdentityFile(privateKey) : undefined
+  const identity = privateKey && privateKey.trim().length > 0 ? materializeIdentityFile(privateKey) : undefined
   try {
     await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile: identity?.path})
   } finally {

--- a/apps/umami/server/provision-droplet.ts
+++ b/apps/umami/server/provision-droplet.ts
@@ -6,6 +6,7 @@ import {
   dropletExists,
   getDropletIpWithWait,
   getSshFingerprint,
+  materializeIdentityFile,
   pinHostKeys,
   run,
   validateDoctl,
@@ -91,6 +92,33 @@ function printOperatorSetupMessage(dropletIp: string, umamiHost: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// SSH identity seam (exported for testability)
+// ---------------------------------------------------------------------------
+
+export interface EstablishSshAccessDeps {
+  waitForSsh?: (host: string, user: string, opts?: {identityFile?: string}) => Promise<void>
+}
+
+/**
+ * Materializes the SSH key (if provided) into a temp file and calls waitForSsh.
+ * Cleans up the temp file in a `finally` block regardless of outcome.
+ * Injectable deps allow tests to assert identity file threading without live SSH.
+ */
+export async function establishSshAccess(
+  dropletIp: string,
+  privateKey: string | undefined,
+  deps: EstablishSshAccessDeps = {},
+): Promise<void> {
+  const resolvedWaitForSsh = deps.waitForSsh ?? waitForSsh
+  const identity = privateKey ? materializeIdentityFile(privateKey) : undefined
+  try {
+    await resolvedWaitForSsh(dropletIp, REMOTE_USER, {identityFile: identity?.path})
+  } finally {
+    identity?.cleanup()
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main orchestrator
 // ---------------------------------------------------------------------------
 
@@ -147,7 +175,7 @@ export async function main(): Promise<void> {
   }
 
   const dropletIp = await getDropletIpWithWait(DROPLET_NAME)
-  await waitForSsh(dropletIp, REMOTE_USER)
+  await establishSshAccess(dropletIp, process.env.UMAMI_SSH_KEY)
 
   const knownHostsPath = resolve(join(import.meta.dir, '..', '..', '..', '.github', 'known_hosts'))
   await pinHostKeys(umamiHost, dropletIp, knownHostsPath, {

--- a/docs/plans/2026-05-28-001-fix-provision-ssh-identity-file-plan.md
+++ b/docs/plans/2026-05-28-001-fix-provision-ssh-identity-file-plan.md
@@ -1,0 +1,224 @@
+---
+title: 'fix: SSH identity-file support for droplet provisioning'
+type: fix
+status: active
+date: 2026-05-28
+---
+
+# fix: SSH identity-file support for droplet provisioning
+
+## Overview
+
+The shared SSH helpers in `packages/shared/server/droplet-helpers.ts` build `ssh`/`scp`/`waitForSsh` command arrays with `BatchMode=yes` but no identity-file flag, so they depend entirely on a loaded ssh-agent. When a provisioning key lives only in a file or in the `<APP>_SSH_KEY` environment variable (not the agent), provisioning fails. This plan adds optional identity-file support so the three provisioners can authenticate from the key material already present in the repo-root `.env`, without requiring the operator to pre-load ssh-agent.
+
+## Problem Frame
+
+Provisioning a droplet runs `provision-droplet.ts`, which calls the shared `waitForSsh` / `ssh` / `scp` helpers. Those helpers offer no way to pin a specific identity file, so SSH falls back to ssh-agent identities. Two concrete failures hit this session and previously:
+
+- **umami (this session):** `waitForSsh` timed out — the `fro-bot-umami` key was only in the key file and `.env`, never loaded into the agent. Provisioning only completed after manual `ssh -i` verification outside the script.
+- **gateway (precedent):** with many agent keys loaded, SSH offered them all and hit the server's `MaxAuthTries` → `Too many authentication failures` before reaching the right key; the workaround was `-o IdentitiesOnly=yes`.
+
+The `<APP>_SSH_KEY` env var (e.g. `UMAMI_SSH_KEY`, `GATEWAY_SSH_KEY`, `CLIPROXY_SSH_KEY`) already holds the private key and is already consumed by each app's `deploy.ts` in CI. Provisioning should use the same source.
+
+## Requirements Trace
+
+- R1. `ssh`, `scp`, and `waitForSsh` accept an optional identity-file path; when provided, the built command includes `-i <path>` and `-o IdentitiesOnly=yes`.
+- R2. When no identity file is provided, the helpers behave exactly as today (ssh-agent path) — no breaking change to existing callers or tests.
+- R3. A shared helper materializes a private key from an environment variable into a temp file with `0600` permissions and a trailing newline, and supports cleanup.
+- R4. The three provisioners (`cliproxy`, `gateway`, `umami`) materialize their `<APP>_SSH_KEY` when set, thread the identity file through `waitForSsh`/`ssh`/`scp`, and remove the temp file in a `finally`.
+- R5. When `<APP>_SSH_KEY` is unset, provisioning falls back to the current ssh-agent behavior (operators relying on agent keys are unaffected).
+- R6. Host values continue to pass through `validate<App>Host`/`validate<App>Domain` before any SSH argv construction (no regression in the host-injection guard).
+
+## Scope Boundaries
+
+- Not changing CI deploy behavior: each app's `deploy.ts` has its own SSH key materialization and does not use these shared helpers. This plan does not touch `deploy.ts`.
+- Not changing `getDropletIpWithWait` (uses `doctl`, no SSH) or `pinHostKeys` (uses `ssh-keyscan`, no auth).
+- Not introducing ssh-agent auto-loading or modifying how keys are registered with DigitalOcean.
+- Not altering `StrictHostKeyChecking=accept-new` semantics for provisioning (first-contact provisioning legitimately accepts new host keys; host-key *pinning* for CI remains `pinHostKeys` + committed `known_hosts`).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/shared/server/droplet-helpers.ts` — `ssh()` (lines 10-22), `scp()` (lines 27-39), `waitForSsh()` (line 202) are the modification targets. All build arg arrays with `BatchMode=yes`, `StrictHostKeyChecking=accept-new`, `ConnectTimeout=10`.
+- `packages/shared/server/droplet-helpers.test.ts` — existing `describe('ssh')`/`describe('scp')`/`describe('waitForSsh')` blocks assert exact arg arrays (e.g. `expect(result).toEqual([...])`) and use `spyOn` for spawn-based helpers. New scenarios extend these.
+- `apps/umami/src/deploy.ts` (lines 3-4) — the key-materialization pattern to mirror: `mkdtempSync(tmpdir())` + `writeFileSync` + `chmodSync(path, 0o600)` + trailing newline + `rmSync` in `finally`. The trailing-newline detail is the gateway `libcrypto` lesson (GitHub Actions strips trailing whitespace; an OpenSSH key file needs the final newline).
+- `apps/{cliproxy,gateway,umami}/server/provision-droplet.ts` — the three provisioners. Each already resolves its key *name* for DigitalOcean fingerprint lookup (`getSshFingerprint`) and documents `<APP>_SSH_KEY` in its prereq banner; none currently materializes the key for SSH.
+- `validateCliproxyDomain` / `validateGatewayHost` / `validateUmamiHost` — host guards already run before SSH construction in each provisioner; this plan preserves that ordering.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md` and `umami-first-deploy-cascade-2026-05-29.md` — both record the ssh-agent-vs-key-file provisioning gap and the trailing-newline `libcrypto` failure mode.
+- Memory: SSH key files written from env/secret values must append a trailing newline; never pass key bytes via argv (we pass a *file path* via `-i`, never the key bytes).
+
+### External References
+
+- None needed. `-i <identity_file>` and `-o IdentitiesOnly=yes` are stable, standard OpenSSH options.
+
+## Key Technical Decisions
+
+- **Identity source = `<APP>_SSH_KEY` env var.** Symmetric with each app's `deploy.ts`, and the value already lives in repo-root `.env`. Removes the implicit ssh-agent dependency for provisioning.
+- **Optional `opts` parameter, not a new required arg.** `ssh`/`scp`/`waitForSsh` gain an optional trailing options object (`{identityFile?: string}`). Existing callers and their exact-array assertions stay valid — additive only. When `identityFile` is set, the helper prepends `-i <path>` and `-o IdentitiesOnly=yes` so only that key is offered (fixes the `MaxAuthTries` variant).
+- **Shared materialization helper.** A single `materializeIdentityFile(privateKey: string)` (or env-name variant) in the shared package, returning `{path, cleanup}`. DRY across all three provisioners and matches the goal of consolidating provisioning helpers in `packages/shared`.
+- **`0600` + trailing newline + temp dir.** Mirror `deploy.ts` exactly; OpenSSH rejects group/world-readable key files, and the trailing newline avoids the `libcrypto` parse failure.
+- **Cleanup in `finally`.** The temp key file is removed whether provisioning succeeds or throws. Best-effort unlink (ignore ENOENT).
+- **No identity file → unchanged path.** When `<APP>_SSH_KEY` is unset, the provisioner calls the helpers with no `identityFile`, preserving today's ssh-agent behavior for operators who rely on it.
+- **Path-only in argv.** The `-i` value is a temp-file path we generate via `mkdtempSync` — never user input and never key bytes — so there is no new argv-injection surface. Host values still pass the existing validators first.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Which helpers need the identity flag? Only `ssh`, `scp`, `waitForSsh` (`waitForSsh` builds an `ssh` invocation internally). `getDropletIpWithWait` and `pinHostKeys` do not authenticate over SSH.
+- Materialize per-provisioner or shared? Shared helper — identical across all three, belongs in `packages/shared`.
+- Breaking change risk to existing tests? None — the new parameter is optional and appended; existing exact-array assertions for the no-opts case remain true.
+
+### Deferred to Implementation
+
+- Exact helper name/signature (`materializeIdentityFile` vs `writeIdentityFile`; returning a `cleanup` closure vs a path plus a separate unlink helper) — settle when writing the test.
+- Whether the materialization helper takes the raw key string or the env-var name — decide based on which keeps the provisioner call sites cleanest and most testable.
+
+## Implementation Units
+
+- [ ] **Unit 1: Optional identity-file support in `ssh`/`scp`/`waitForSsh`**
+
+**Goal:** The shared SSH arg builders and `waitForSsh` accept an optional identity file and, when provided, emit `-i <path>` + `-o IdentitiesOnly=yes`.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/server/droplet-helpers.ts`
+- Test: `packages/shared/server/droplet-helpers.test.ts`
+
+**Approach:**
+- Add an optional trailing options object to `ssh(host, command, user, opts?)` and `scp(host, source, target, user, opts?)`; when `opts.identityFile` is set, insert `-i`, the path, and `-o IdentitiesOnly=yes` into the arg array (alongside the existing `BatchMode`/`StrictHostKeyChecking`/`ConnectTimeout` flags).
+- Thread the same `opts` through `waitForSsh(host, user, opts?)` so its internal `ssh(...)` call forwards `identityFile`. Keep the existing `RetryOptions` (`maxAttempts`/`intervalMs`) — fold identity into the same options object or a separate param, whichever keeps the signature clean (decide at implementation).
+
+**Execution note:** Test-first. Write failing arg-array assertions for the `identityFile`-set case before modifying the builders; prove the no-opts case is byte-identical to today.
+
+**Technical design:** *(directional guidance, not implementation specification)*
+
+    ssh('1.2.3.4', 'echo ready', 'root', { identityFile: '/tmp/x/key' })
+    -> ['ssh', '-i', '/tmp/x/key',
+        '-o', 'IdentitiesOnly=yes',
+        '-o', 'BatchMode=yes',
+        '-o', 'StrictHostKeyChecking=accept-new',
+        '-o', 'ConnectTimeout=10',
+        'root@1.2.3.4', 'echo ready']
+    ssh('1.2.3.4', 'echo ready', 'root')   // no opts -> unchanged from today
+
+**Patterns to follow:**
+- Existing `ssh`/`scp` arg-array shape and the `describe('ssh')`/`describe('scp')` exact-array assertions in `droplet-helpers.test.ts`.
+
+**Test scenarios:**
+- Happy path: `ssh(...)` with `identityFile` set includes `-i <path>` and `-o IdentitiesOnly=yes` in the expected positions.
+- Happy path: `scp(...)` with `identityFile` set includes the same flags.
+- Edge case: `ssh(...)` / `scp(...)` with no opts (and with `opts` omitting `identityFile`) produces the exact array it produces today — regression guard for R2.
+- Happy path: `waitForSsh(host, user, {identityFile})` forwards the flag into the spawned `ssh` argv (assert via `spyOn(Bun, 'spawn')` capturing the command array).
+- Edge case: `waitForSsh` retry/timeout behavior unchanged when identity options are present (reuse existing maxAttempts/intervalMs assertions).
+
+**Verification:**
+- Identity-set and identity-unset arg arrays both match expectations; existing helper tests still pass unchanged.
+
+- [ ] **Unit 2: Shared identity-file materialization helper**
+
+**Goal:** A shared helper writes a private key into a `0600` temp file with a trailing newline and provides cleanup, for reuse by all three provisioners.
+
+**Requirements:** R3
+
+**Dependencies:** None (can land alongside Unit 1)
+
+**Files:**
+- Modify: `packages/shared/server/droplet-helpers.ts`
+- Test: `packages/shared/server/droplet-helpers.test.ts`
+
+**Approach:**
+- Add `materializeIdentityFile(privateKey)` that creates a temp dir via `mkdtempSync(join(tmpdir(), ...))`, writes the key with a guaranteed single trailing newline, `chmodSync(path, 0o600)`, and returns the path plus a `cleanup()` that best-effort removes the temp dir (ignore ENOENT).
+- Normalize the trailing newline (append one if absent) to defend against env injection stripping it — the gateway `libcrypto` lesson.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- `apps/umami/src/deploy.ts` key materialization (`mkdtempSync` + `writeFileSync` + `chmodSync(0o600)` + trailing newline + `rmSync`).
+
+**Test scenarios:**
+- Happy path: given a key string, the file exists, contains the key, ends with exactly one newline, and has mode `0600` (assert via `statSync(path).mode & 0o777`).
+- Edge case: a key string already ending in `\n` does not gain a second trailing newline.
+- Happy path: `cleanup()` removes the temp file/dir; calling it twice does not throw (idempotent / ignore ENOENT).
+
+**Verification:**
+- File mode is `0600`, content round-trips with a single trailing newline, cleanup is idempotent.
+
+- [ ] **Unit 3: Wire identity materialization into the three provisioners**
+
+**Goal:** Each provisioner materializes `<APP>_SSH_KEY` when set, passes the identity file to `waitForSsh`/`ssh`/`scp`, and cleans up in `finally`; falls back to ssh-agent when unset.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `apps/cliproxy/server/provision-droplet.ts`
+- Modify: `apps/gateway/server/provision-droplet.ts`
+- Modify: `apps/umami/server/provision-droplet.ts`
+- Test: `apps/cliproxy/server/provision-droplet.test.ts`
+- Test: `apps/gateway/server/provision-droplet.test.ts`
+- Test: `apps/umami/server/provision-droplet.test.ts`
+
+**Approach:**
+- **Seam first (required):** the SSH-using logic currently lives inside each provisioner's `main()`, which the existing tests never invoke (they only exercise exported pure helpers like `validateRequiredEnv`, `parseProvisionArgs`, `getSshFingerprint`, plus `dropletExists` via `spyOn(Bun, 'spawn')`). Before wiring identity support, extract the SSH-orchestration portion of `main()` (the `waitForSsh`/`ssh`/`scp` region, post-IP-resolution) into an exported, testable function that accepts injectable dependencies — at minimum the SSH helpers (`waitForSsh`/`ssh`/`scp` or a `SpawnFn`) and the materializer — defaulting to the real implementations. This is what makes the argv assertions below possible.
+- After host validation and before the first SSH/SCP call, read `process.env.<APP>_SSH_KEY`. If present, call `materializeIdentityFile`, capture `{path, cleanup}`, and pass `identityFile: path` through every `waitForSsh`/`ssh`/`scp` invocation; wrap the SSH-using region in `try { ... } finally { cleanup() }`.
+- If absent, call the helpers with no identity file (today's behavior) — no temp file, no cleanup.
+- Preserve the existing `validate<App>Host`/`validate<App>Domain` call ahead of any SSH argv construction.
+- Keep each provisioner's `import.meta.main` guard; the extracted function is imported by tests while `main()` stays guarded so importing does not execute live `doctl`/SSH (existing repo rule).
+
+**Execution note:** Test-first per provisioner. The injectable seam must be created as part of this unit — the current tests cannot assert SSH argv because `main()` is never called. Mirror the dependency-injection style already used by `gateway/status.ts` (injectable `SpawnFn` defaulting to `Bun.spawn`) rather than inventing a new mocking approach.
+
+**Patterns to follow:**
+- `packages/cli/src/commands/gateway/status.ts` — `SpawnFn` dependency injection with a real default, asserted in `gateway/status.test.ts`.
+- The repo's "export testable functions, guard `main()` with `import.meta.main`" convention (build.ts, the provisioners' existing exported helpers).
+- `apps/umami/src/deploy.ts` `finally`-cleanup of the temp key file.
+
+**Test scenarios:**
+- Happy path (key set): provisioner materializes a temp key and the `waitForSsh`/`ssh`/`scp` argv includes `-i <path>` + `-o IdentitiesOnly=yes`.
+- Happy path (key unset): provisioner invokes the helpers with no identity file; argv matches today's agent-based shape; no temp file created.
+- Error path: when a provisioning step throws after the key is materialized, `cleanup()` still runs (assert the temp path is removed in `finally`).
+- Edge case (R6 regression): a `-`-prefixed or out-of-alphabet host is rejected by the validator before any SSH argv is built (one per provisioner, mirroring existing host-guard tests).
+- Integration: the materialized key file is the one referenced by `-i` (path threaded end-to-end, not a second/blank file) — asserted through the extracted orchestration function with injected helpers, not via `main()`.
+
+**Verification:**
+- With `<APP>_SSH_KEY` set, provisioning builds identity-pinned SSH commands and cleans up the temp key; with it unset, behavior is unchanged; host validation still gates argv construction; all three provisioner test suites pass.
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the three `provision-droplet.ts` entry points and the shared helpers are affected. `deploy.ts` files are untouched (separate SSH path), so CI deploy flows do not change.
+- **Error propagation:** Materialization failures (bad key) surface before SSH attempts; cleanup is best-effort and must not mask the primary error (unlink errors swallowed in `finally`).
+- **State lifecycle risks:** Temp key file is the only new on-disk state; `finally` cleanup prevents leaving `0600` key material in `tmpdir`. Idempotent cleanup avoids double-unlink throws.
+- **API surface parity:** All three provisioners get the identical change — no provisioner left on the old agent-only path inconsistently.
+- **Integration coverage:** Provisioner tests assert the identity file is threaded end-to-end (materialized path === `-i` path), which unit-level arg tests alone would not prove.
+- **Unchanged invariants:** `ssh`/`scp`/`waitForSsh` no-opts behavior, `StrictHostKeyChecking=accept-new` for provisioning, `getDropletIpWithWait`, `pinHostKeys`, and all `deploy.ts` SSH paths are explicitly unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Optional-param change accidentally alters existing arg arrays | Regression test asserts the no-opts arrays are byte-identical to today (R2). |
+| Key file missing trailing newline → `libcrypto` parse failure | Materialization helper normalizes to exactly one trailing newline; covered by a test. |
+| `0600` not enforced → OpenSSH refuses the key | `chmodSync(0o600)` plus a mode assertion in the helper test. |
+| Temp key left on disk after a failed provision | `finally` cleanup with idempotent best-effort unlink; error-path test verifies removal. |
+| Operators relying on ssh-agent break | Key-unset path preserved unchanged (R5); explicit test for the no-identity case. |
+| Host-injection guard regressed by reordering | R6 scenario keeps validator ahead of argv construction in each provisioner. |
+| Unit 3 argv assertions not testable as-is — SSH logic lives in untested `main()` | Unit 3 extracts an injectable SSH-orchestration function first (mirroring `gateway/status.ts` `SpawnFn`); the seam is in-scope for the unit, not a separate prerequisite PR. |
+| Abrupt termination (SIGKILL/crash) leaves a `0600` key in `tmpdir` | Accepted residual: provision is a short-lived interactive operation; `finally` covers normal + thrown exits. Signal-handler cleanup is out of scope for v1; documented as an operational note rather than engineered around. |
+
+## Documentation / Operational Notes
+
+- Update each app's `AGENTS.md` provisioning note (and root `AGENTS.md` if it documents provisioning) to state that `bun run provision:<app>` now authenticates from `<APP>_SSH_KEY` when set, with ssh-agent as fallback — removing the manual `ssh -i` / `IdentitiesOnly` workaround called out for umami/gateway.
+- No changeset: `packages/shared` and `apps/*/server` are not part of the published `@marcusrbrown/infra` runtime (`packages/cli/src/` only). Confirm at PR time.
+
+## Sources & References
+
+- Related code: `packages/shared/server/droplet-helpers.ts`, `apps/{cliproxy,gateway,umami}/server/provision-droplet.ts`, `apps/umami/src/deploy.ts`
+- Institutional learnings: `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md`, `docs/solutions/workflow-issues/umami-first-deploy-cascade-2026-05-29.md`

--- a/packages/shared/server/droplet-helpers.test.ts
+++ b/packages/shared/server/droplet-helpers.test.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, readFileSync, writeFileSync} from 'node:fs'
+import {mkdtempSync, readFileSync, statSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
@@ -7,6 +7,7 @@ import {
   dropletExists,
   getDropletIpWithWait,
   getSshFingerprint,
+  materializeIdentityFile,
   pinHostKeys,
   runCapture,
   scp,
@@ -104,6 +105,29 @@ describe('droplet-helpers', () => {
       const result = ssh('example.com', 'ls', 'deploy-user')
       expect(result[7]).toBe('deploy-user@example.com')
     })
+
+    it('prepends -i <path> and IdentitiesOnly=yes when identityFile is set', () => {
+      const result = ssh('1.2.3.4', 'echo hello', 'root', {identityFile: '/tmp/x/key'})
+      expect(result).toEqual([
+        'ssh',
+        '-i',
+        '/tmp/x/key',
+        '-o',
+        'IdentitiesOnly=yes',
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'ConnectTimeout=10',
+        'root@1.2.3.4',
+        'echo hello',
+      ])
+    })
+
+    it('is byte-identical to the no-opts form when opts omits identityFile', () => {
+      expect(ssh('1.2.3.4', 'echo hello', 'root', {})).toEqual(ssh('1.2.3.4', 'echo hello', 'root'))
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -129,6 +153,29 @@ describe('droplet-helpers', () => {
     it('uses the provided user in user@host:target', () => {
       const result = scp('host.example.com', '/src', '/dst', 'myuser')
       expect(result[8]).toBe('myuser@host.example.com:/dst')
+    })
+
+    it('prepends -i <path> and IdentitiesOnly=yes when identityFile is set', () => {
+      const result = scp('1.2.3.4', '/local/file', '/remote/path', 'root', {identityFile: '/tmp/x/key'})
+      expect(result).toEqual([
+        'scp',
+        '-i',
+        '/tmp/x/key',
+        '-o',
+        'IdentitiesOnly=yes',
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'ConnectTimeout=10',
+        '/local/file',
+        'root@1.2.3.4:/remote/path',
+      ])
+    })
+
+    it('is byte-identical to the no-opts form when opts omits identityFile', () => {
+      expect(scp('1.2.3.4', '/src', '/dst', 'root', {})).toEqual(scp('1.2.3.4', '/src', '/dst', 'root'))
     })
   })
 
@@ -359,6 +406,54 @@ describe('droplet-helpers', () => {
       spies.push(spawnSpy)
 
       await expect(waitForSsh('1.2.3.4', 'root', {maxAttempts: 2, intervalMs: 1})).rejects.toThrow(/Timed out/)
+    })
+
+    it('forwards identityFile into the spawned ssh argv', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(makeSpawnResult('ready', 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await waitForSsh('1.2.3.4', 'root', {maxAttempts: 1, intervalMs: 1, identityFile: '/tmp/x/key'})
+
+      const argv = spawnSpy.mock.calls[0]?.[0] as string[]
+      expect(argv).toContain('-i')
+      expect(argv).toContain('/tmp/x/key')
+      expect(argv).toContain('IdentitiesOnly=yes')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // materializeIdentityFile
+  // -------------------------------------------------------------------------
+
+  describe('materializeIdentityFile', () => {
+    it('writes the key to a 0600 file ending in exactly one newline', () => {
+      const key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----'
+      const {path, cleanup} = materializeIdentityFile(key)
+      try {
+        const contents = readFileSync(path, 'utf-8')
+        expect(contents).toBe(`${key}\n`)
+        expect(statSync(path).mode & 0o777).toBe(0o600)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('does not add a second trailing newline when the key already ends in one', () => {
+      const key = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n'
+      const {path, cleanup} = materializeIdentityFile(key)
+      try {
+        expect(readFileSync(path, 'utf-8')).toBe(key)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('cleanup removes the file and is idempotent', () => {
+      const {path, cleanup} = materializeIdentityFile('key-bytes')
+      expect(statSync(path).isFile()).toBe(true)
+      cleanup()
+      expect(() => statSync(path)).toThrow()
+      expect(() => cleanup()).not.toThrow()
     })
   })
 

--- a/packages/shared/server/droplet-helpers.test.ts
+++ b/packages/shared/server/droplet-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getSshFingerprint,
   materializeIdentityFile,
   pinHostKeys,
+  run,
   runCapture,
   scp,
   sleep,
@@ -454,6 +455,29 @@ describe('droplet-helpers', () => {
       cleanup()
       expect(() => statSync(path)).toThrow()
       expect(() => cleanup()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // run — throws on non-zero exit (does NOT call process.exit)
+  // -------------------------------------------------------------------------
+
+  describe('run', () => {
+    it('rejects with an error containing the label and stderr when the command exits non-zero', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn')
+        .mockReturnValueOnce(makeSpawnResultWithStderr('connection refused', 1) as ReturnType<typeof Bun.spawn>)
+        .mockReturnValueOnce(makeSpawnResultWithStderr('connection refused', 1) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(run('copy files', ['scp', 'x', 'y'])).rejects.toThrow(/copy files/)
+      await expect(run('copy files', ['scp', 'x', 'y'])).rejects.toThrow(/connection refused/)
+    })
+
+    it('resolves without throwing when the command exits zero', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(makeSpawnResult('ok', 0) as ReturnType<typeof Bun.spawn>)
+      spies.push(spawnSpy)
+
+      await expect(run('deploy', ['docker', 'compose', 'up'])).resolves.toBeUndefined()
     })
   })
 

--- a/packages/shared/server/droplet-helpers.ts
+++ b/packages/shared/server/droplet-helpers.ts
@@ -1,15 +1,31 @@
-import {appendFileSync, readFileSync} from 'node:fs'
+import {appendFileSync, chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 
 // ---------------------------------------------------------------------------
 // Pure-logic helpers
 // ---------------------------------------------------------------------------
 
+/** Options shared by the SSH/SCP command builders. */
+export interface SshCommandOptions {
+  /** Path to a private-key file. When set, the command pins it with `-i` + `IdentitiesOnly=yes`. */
+  identityFile?: string
+}
+
+// When an identity file is provided, pin it and stop SSH from offering agent keys
+// (avoids MaxAuthTries lockout when many keys are loaded). Empty otherwise.
+function identityFlags(opts?: SshCommandOptions): string[] {
+  return opts?.identityFile ? ['-i', opts.identityFile, '-o', 'IdentitiesOnly=yes'] : []
+}
+
 /**
  * Builds an SSH command array with standard BatchMode/StrictHostKeyChecking/ConnectTimeout flags.
+ * When opts.identityFile is set, prepends `-i <path>` and `-o IdentitiesOnly=yes`.
  */
-export function ssh(host: string, command: string, user: string): string[] {
+export function ssh(host: string, command: string, user: string, opts?: SshCommandOptions): string[] {
   return [
     'ssh',
+    ...identityFlags(opts),
     '-o',
     'BatchMode=yes',
     '-o',
@@ -23,10 +39,12 @@ export function ssh(host: string, command: string, user: string): string[] {
 
 /**
  * Builds an SCP command array with standard BatchMode/StrictHostKeyChecking/ConnectTimeout flags.
+ * When opts.identityFile is set, prepends `-i <path>` and `-o IdentitiesOnly=yes`.
  */
-export function scp(host: string, source: string, target: string, user: string): string[] {
+export function scp(host: string, source: string, target: string, user: string, opts?: SshCommandOptions): string[] {
   return [
     'scp',
+    ...identityFlags(opts),
     '-o',
     'BatchMode=yes',
     '-o',
@@ -36,6 +54,35 @@ export function scp(host: string, source: string, target: string, user: string):
     source,
     `${user}@${host}:${target}`,
   ]
+}
+
+/** A materialized private-key file plus a best-effort cleanup callback. */
+export interface MaterializedIdentity {
+  path: string
+  cleanup: () => void
+}
+
+/**
+ * Writes a private key to a 0600 temp file (with a guaranteed single trailing newline)
+ * and returns its path plus an idempotent best-effort cleanup callback. The trailing
+ * newline guards against env/secret injection stripping it (OpenSSH rejects keys without it).
+ */
+export function materializeIdentityFile(privateKey: string): MaterializedIdentity {
+  const dir = mkdtempSync(join(tmpdir(), 'infra-ssh-key-'))
+  const path = join(dir, 'id')
+  const contents = privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`
+  writeFileSync(path, contents, {mode: 0o600})
+  chmodSync(path, 0o600)
+  return {
+    path,
+    cleanup: () => {
+      try {
+        rmSync(dir, {recursive: true, force: true})
+      } catch {
+        // Best-effort: a missing temp dir (already cleaned) is fine.
+      }
+    },
+  }
 }
 
 /**
@@ -199,12 +246,13 @@ export async function getDropletIpWithWait(dropletName: string, opts?: RetryOpti
  * Waits for SSH connectivity to the given host.
  * Defaults: 24 attempts × 5000ms.
  */
-export async function waitForSsh(host: string, user: string, opts?: RetryOptions): Promise<void> {
+export async function waitForSsh(host: string, user: string, opts?: RetryOptions & SshCommandOptions): Promise<void> {
   const maxAttempts = opts?.maxAttempts ?? 24
   const intervalMs = opts?.intervalMs ?? 5_000
+  const sshOpts: SshCommandOptions = {identityFile: opts?.identityFile}
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const proc = Bun.spawn(ssh(host, 'echo ready', user), {stdout: 'pipe', stderr: 'pipe'})
+    const proc = Bun.spawn(ssh(host, 'echo ready', user, sshOpts), {stdout: 'pipe', stderr: 'pipe'})
     const code = await proc.exited
     if (code === 0) {
       return

--- a/packages/shared/server/droplet-helpers.ts
+++ b/packages/shared/server/droplet-helpers.ts
@@ -70,19 +70,23 @@ export interface MaterializedIdentity {
 export function materializeIdentityFile(privateKey: string): MaterializedIdentity {
   const dir = mkdtempSync(join(tmpdir(), 'infra-ssh-key-'))
   const path = join(dir, 'id')
-  const contents = privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`
-  writeFileSync(path, contents, {mode: 0o600})
-  chmodSync(path, 0o600)
-  return {
-    path,
-    cleanup: () => {
-      try {
-        rmSync(dir, {recursive: true, force: true})
-      } catch {
-        // Best-effort: a missing temp dir (already cleaned) is fine.
-      }
-    },
+  const cleanup = (): void => {
+    try {
+      rmSync(dir, {recursive: true, force: true})
+    } catch {
+      // Best-effort: a missing temp dir (already cleaned) is fine.
+    }
   }
+  try {
+    const contents = privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`
+    writeFileSync(path, contents, {mode: 0o600})
+    chmodSync(path, 0o600)
+  } catch (error) {
+    // Don't leave a partial 0600 key (or its temp dir) behind on write failure.
+    cleanup()
+    throw error
+  }
+  return {path, cleanup}
 }
 
 /**
@@ -109,7 +113,7 @@ export async function run(label: string, command: string[]): Promise<void> {
   if (code !== 0) {
     console.error(`\u001B[1;31mFAILED:\u001B[0m ${label}`)
     if (stderr.trim()) console.error(stderr.trim())
-    process.exit(1)
+    throw new Error(`${label} failed: ${stderr.trim() || `exit code ${code}`}`)
   }
 }
 
@@ -242,11 +246,14 @@ export async function getDropletIpWithWait(dropletName: string, opts?: RetryOpti
   throw new Error('Timed out waiting for droplet IPv4 address')
 }
 
+/** Options for `waitForSsh`: retry policy plus optional SSH identity pinning. */
+export interface WaitForSshOptions extends RetryOptions, SshCommandOptions {}
+
 /**
  * Waits for SSH connectivity to the given host.
  * Defaults: 24 attempts × 5000ms.
  */
-export async function waitForSsh(host: string, user: string, opts?: RetryOptions & SshCommandOptions): Promise<void> {
+export async function waitForSsh(host: string, user: string, opts?: WaitForSshOptions): Promise<void> {
   const maxAttempts = opts?.maxAttempts ?? 24
   const intervalMs = opts?.intervalMs ?? 5_000
   const sshOpts: SshCommandOptions = {identityFile: opts?.identityFile}


### PR DESCRIPTION
## Summary

Droplet provisioning (`bun run provision:<app>`) authenticated only through ssh-agent. When the provisioning key lived in a file or in the `<APP>_SSH_KEY` environment variable — but wasn't loaded into the agent — provisioning failed: `waitForSsh` timed out, or SSH offered every agent key and hit the server's `MaxAuthTries` (`Too many authentication failures`) before reaching the right one. Both failure modes hit real provisions (gateway, then umami), each needing a manual `ssh -i … -o IdentitiesOnly=yes` workaround outside the script.

This makes provisioning authenticate from `<APP>_SSH_KEY` directly — the same key material the deploy workflows already use — with ssh-agent as the fallback when the variable is unset.

## Changes

- **Shared helpers** (`packages/shared/server/droplet-helpers.ts`): `ssh`/`scp`/`waitForSsh` take an optional `{ identityFile }`; when set they emit `-i <path> -o IdentitiesOnly=yes` (pins the key, stops SSH from spraying agent keys). New `materializeIdentityFile()` writes a private key to a `0600` temp file with a guaranteed trailing newline (the GitHub-Actions-strips-whitespace / `libcrypto` lesson) and an idempotent cleanup.
- **Provisioners** (cliproxy, gateway, umami): each materializes `<APP>_SSH_KEY` when set, threads the identity through every SSH/SCP call, and cleans up the temp key in a `finally`. Unset → unchanged ssh-agent behavior. A whitespace-only value is treated as absent rather than materializing a malformed key.
- **Testability:** extracted injectable SSH-orchestration seams (`establishSshAccess` for gateway/umami; `performProvisioning` + `resolveProvisionIdentity` for cliproxy) so identity threading, ordering, and cleanup are unit-tested without live SSH.
- **Hardening:** the shared `run()` and cliproxy's remote-`.env` write now throw instead of `process.exit`, so the `finally` cleanup always runs (no leaked `0600` key on a failed step). `performProvisioning` waits for SSH readiness *before* host-key pinning.
- **Docs:** each app's AGENTS.md notes the new auth behavior and the `bun run provision:<app>` root wrapper.

Behavior is unchanged when `<APP>_SSH_KEY` is unset; the no-identity SSH/SCP argv is byte-identical to before.

## Verification

- `bun test --recursive` → 968 pass, 0 fail
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors
