### PR TITLE
ci(renovate): track apps/*/upstream.json daemon-source pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,32 @@
       changelogUrl: 'https://www.postgresql.org/docs/release/',
       groupName: null,
     },
+    {
+      // The github-releases datasource auto-derives source URL + release notes from depName
+      // (= the GitHub repo), so no sourceUrl/changelogUrl needed. This rule exists ONLY to keep
+      // each release a standalone PR (each fro-bot/agent bump = a gateway daemon rebuild+redeploy)
+      // instead of being grouped into group:allNonMajor.
+      description: ['Keep fro-bot/agent upstream.json releases as standalone PRs'],
+      matchDatasources: ['github-releases'],
+      matchPackageNames: ['fro-bot/agent'],
+      groupName: null,
+    },
+  ],
+  // Track the upstream daemon source pin (`ref`) in each apps/*/upstream.json so new
+  // releases of the named `repo` surface as PRs. This is independent of the fro-bot/agent
+  // GitHub Action SHA-pin in .github/workflows/ (a separate consumer Renovate already tracks).
+  // depName is captured dynamically from the `repo` field, so any future apps/*/upstream.json
+  // is tracked with no additional config.
+  customManagers: [
+    {
+      customType: 'regex',
+      // fileMatch is a regex (not a glob) and is the current field for the renovate
+      // version this repo runs; the `managerFilePatterns` rename is renovate 40+ only.
+      fileMatch: ['apps/.+/upstream\\.json$'],
+      matchStrings: ['"repo":\\s*"(?<depName>[^"]+)"[^}]*"ref":\\s*"(?<currentValue>[^"]+)"'],
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver-coerced',
+    },
   ],
   // postUpgradeTasks run after Renovate applies file changes but before the commit.
   // For github-actions manager updates (workflow SHA pins), Renovate does NOT run


### PR DESCRIPTION
## Summary

Renovate now tracks the upstream daemon-source pin (`ref`) in `apps/*/upstream.json`, so new releases of the named `repo` surface as PRs automatically. Today that's `apps/gateway/upstream.json` (`fro-bot/agent`), but the manager captures `depName` from the `repo` field, so any future `apps/*/upstream.json` is tracked with zero additional config.

This closes a real gap: the `fro-bot/agent` **GitHub Action SHA-pin** in `.github/workflows/` is already Renovate-tracked, but the **daemon source pin** in `upstream.json` (the version the gateway clones and builds on the droplet) was invisible — a separate consumer that could silently drift behind upstream.

## Details

- **Custom manager** (regex) extracts `repo` → `depName` and `ref` → `currentValue`, using the `github-releases` datasource (auto-derives source URL + release notes) and `semver-coerced` versioning (handles the `v` prefix).
- **One package rule** keeps each `fro-bot/agent` release a standalone PR rather than folding it into the `group:allNonMajor` batch — each bump triggers a gateway daemon rebuild + redeploy, so it warrants its own reviewable PR, consistent with how the Docker image pins are treated.

Validated with `renovate-config-validator` (config validated successfully) and confirmed the extraction yields `fro-bot/agent` / `v0.44.2` against the real file.

Config-only: no changeset, no deploy trigger.
