### PR TITLE
ci(renovate): use managerFilePatterns (supersedes deprecated fileMatch)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,9 +60,9 @@
   customManagers: [
     {
       customType: 'regex',
-      // fileMatch is a regex (not a glob) and is the current field for the renovate
-      // version this repo runs; the `managerFilePatterns` rename is renovate 40+ only.
-      fileMatch: ['apps/.+/upstream\\.json$'],
+      // managerFilePatterns treats bare strings as globs, so the path regex is wrapped in
+      // /.../ delimiters to keep regex semantics. (Renovate 40+ field; supersedes fileMatch.)
+      managerFilePatterns: ['/apps/.+/upstream\\.json$/'],
       matchStrings: ['"repo":\\s*"(?<depName>[^"]+)"[^}]*"ref":\\s*"(?<currentValue>[^"]+)"'],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'semver-coerced',


### PR DESCRIPTION
## Summary

Switches the `apps/*/upstream.json` custom manager from the deprecated `fileMatch` field to the current `managerFilePatterns`, the field current Renovate (40+) expects.

`managerFilePatterns` treats bare strings as globs, so the path regex is wrapped in `/.../ ` delimiters to keep regex semantics: `['/apps/.+/upstream\.json$/']`. Validated against `renovate@latest` (`renovate-config-validator` → config validated successfully) and confirmed the pattern still matches `apps/gateway/upstream.json` (and a future `apps/umami/upstream.json`) while rejecting `package.json`; extraction still yields `fro-bot/agent`.

This applies the rename manually so the explanatory comments in `renovate.json5` are preserved — Renovate's own config-migration PR strips all comments and trailing commas, so I'm closing that in favor of this.

Config-only: no changeset, no deploy trigger.
