### PR TITLE
ci(gateway): hold fro-bot/agent at v0.44.2 pending v0.46.x prerequisites

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,9 +50,11 @@
       matchDatasources: ['github-releases'],
       matchPackageNames: ['fro-bot/agent'],
       groupName: null,
-      // Hold at v0.44.x until v0.46.x deploy-side prerequisites land (GitHub App secret
-      // materialization in deploy.ts + droplet GitHub App credentials). See issue #341.
-      allowedVersions: '<0.45.0',
+      // Hold at v0.44.2 until v0.46.x deploy-side prerequisites land (GitHub App secret
+      // materialization in deploy.ts + droplet GitHub App credentials). v0.44.3 already adds
+      // the discord-privileged-intents bind-mount (create_host_path: false) that deploy.ts does
+      // not materialize, so the ceiling must exclude it too. See issue #341.
+      allowedVersions: '<0.44.3',
     },
   ],
   // Track the upstream daemon source pin (`ref`) in each apps/*/upstream.json so new

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,9 @@
       matchDatasources: ['github-releases'],
       matchPackageNames: ['fro-bot/agent'],
       groupName: null,
+      // Hold at v0.44.x until v0.46.x deploy-side prerequisites land (GitHub App secret
+      // materialization in deploy.ts + droplet GitHub App credentials). See issue #341.
+      allowedVersions: '<0.45.0',
     },
   ],
   // Track the upstream daemon source pin (`ref`) in each apps/*/upstream.json so new

--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.46.1"
+  "ref": "v0.44.2"
 }


### PR DESCRIPTION
## Summary

Holds the gateway daemon pin at `fro-bot/agent` **v0.44.2** (the version running live) and adds a Renovate `allowedVersions: '<0.45.0'` ceiling so it stops proposing v0.45.x+ until the deploy side is ready.

## Why

v0.46.1's `deploy/compose.yaml` bind-mounts three secret files (`create_host_path: false`) that `apps/gateway/src/deploy.ts` does not materialize:

- `github-app-id` / `github-app-private-key` — **required**: `loadConfig` calls `readSecret`/`readMultilineSecret`, which throw on a missing or empty file, so the daemon hard-fails on boot without real values.
- `discord-privileged-intents` — optional (empty = baseline intents).

A blind cutover would fail `docker compose up`, and empty-file materialization isn't enough for the github-app pair — they need a real GitHub App. Adopting v0.46.1 also opts into the new `/fro-bot add-project` capability, which is its own piece of work.

Holding at v0.44.2 keeps the repo pin and the live droplet in agreement and unblocks routine gateway deploys. Full v0.46.1 adoption is tracked in #341.

Config-only: no changeset, no runtime code change.
