### PR TITLE
fix(gateway): rebuild image on every deploy so the upstream pin takes effect

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -602,6 +602,7 @@ describe('main', () => {
     const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
     expect(composeCall).toBeDefined()
     expect(composeCall?.join(' ')).not.toContain('--force-recreate')
+    expect(composeCall?.join(' ')).toContain('--build')
   })
 
   test('edge case (secrets changed): checksum differs → --force-recreate added', async () => {
@@ -621,6 +622,45 @@ describe('main', () => {
     const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
     expect(composeCall).toBeDefined()
     expect(composeCall?.join(' ')).toContain('--force-recreate')
+    expect(composeCall?.join(' ')).toContain('--build')
+  })
+
+  test('rebuilds the image from pinned source on every deploy regardless of --force-recreate', async () => {
+    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+    const env = makeEnv()
+    const expectedChecksum = computeSecretsChecksum(buildSecretFileList(env))
+
+    // Secrets unchanged path — no --force-recreate
+    const {spawnFn: spawnFnA, calls: callsA} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes('cat')) {
+        return makeSpawnResult({stdout: expectedChecksum})
+      }
+      return undefined
+    })
+    const mockFetchA = makeDiscordFetch([{name: 'ping'}])
+    await main({env, args: [], fetch: mockFetchA, sleep: async () => {}, spawn: spawnFnA})
+
+    const composeCallA = callsA.find(cmd => cmd.some(s => s.includes('docker compose')))
+    expect(composeCallA).toBeDefined()
+    expect(composeCallA?.join(' ')).toContain('--build')
+    expect(composeCallA?.join(' ')).not.toContain('--force-recreate')
+
+    // Secrets changed path — --force-recreate present alongside --build
+    const {spawnFn: spawnFnB, calls: callsB} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes('cat')) {
+        return makeSpawnResult({stdout: 'old-checksum-that-differs'})
+      }
+      return undefined
+    })
+    const mockFetchB = makeDiscordFetch([{name: 'ping'}])
+    await main({env: makeEnv(), args: [], fetch: mockFetchB, sleep: async () => {}, spawn: spawnFnB})
+
+    const composeCallB = callsB.find(cmd => cmd.some(s => s.includes('docker compose')))
+    expect(composeCallB).toBeDefined()
+    expect(composeCallB?.join(' ')).toContain('--build')
+    expect(composeCallB?.join(' ')).toContain('--force-recreate')
   })
 
   test('readRemoteChecksum: SSH exits 0 with checksum → returns checksum string', async () => {

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -667,7 +667,9 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     console.warn(`  3. Materialize ${buildSecretFileList(env).length} secret files under ${SECRETS_DIR}`)
     console.warn(`  4. Write .env to ${ENV_PATH}`)
     console.warn(`  5. Run init-certs.sh (idempotent)`)
-    console.warn(`  6. docker compose up -d --wait --wait-timeout 120${forceRecreate ? ' --force-recreate' : ''}`)
+    console.warn(
+      `  6. docker compose up -d --build --wait --wait-timeout 120${forceRecreate ? ' --force-recreate' : ''}`,
+    )
     console.warn(
       `  7. Poll Discord slash command registration (app=${env.DISCORD_APPLICATION_ID} guild=${env.DISCORD_GUILD_ID})`,
     )
@@ -808,6 +810,7 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       DEPLOY_DIR,
       'up',
       '-d',
+      '--build',
       '--wait',
       '--wait-timeout',
       '120',


### PR DESCRIPTION
## Summary

Gateway deploys never rebuilt the daemon image, so moving the `upstream.json` pin had no effect on the running container.

The gateway and workspace services build from source (`deploy/gateway.Dockerfile`). The deploy ran `docker compose up -d --wait` without `--build`, and `compose up` only builds a `build:` service when its image is absent — it does not rebuild on changed source. So every deploy did `git reset --hard <pinned ref>` to update the source on the droplet, then started a container from a previously-built image. The pin moved forward; the running daemon did not.

This surfaced when the v0.46.1 cutover left the daemon registering only the old `/fro-bot ping` command set — the live container was still running an image built before `add-project` existed, even though the source on disk was v0.46.1.

## Fix

Add `--build` to the compose-up command unconditionally, so every deploy rebuilds the gateway and workspace images from the freshly-reset source. Docker's layer cache keeps a no-change rebuild cheap. The dry-run preview line is updated to match.

## Verification

- New test proves `--build` is present on every deploy, independent of `--force-recreate` (both the secrets-changed and secrets-unchanged paths).
- 1003 tests pass; type-check and lint clean.

## Deploy note

Merging triggers a gated Deploy Gateway run. Approving it will, for the first time, rebuild the image to the pinned v0.46.1 source — at which point `/fro-bot add-project` registers (it is unconditionally registered in v0.46.1, confirmed in the upstream source).
