### PR TITLE
feat(cliproxy): clarify codex login failure on version skew

### DIFF
--- a/.changeset/cliproxy-codex-login-version-skew.md
+++ b/.changeset/cliproxy-codex-login-version-skew.md
@@ -1,0 +1,5 @@
+---
+"@marcusrbrown/infra": patch
+---
+
+`cliproxy login codex` now surfaces a clear error when the remote CLIProxyAPI binary predates `--codex-device-login` support (requires v6.10.9+), pointing to a new provider-version-skew runbook instead of a cryptic SSH exit code.

--- a/docs/runbooks/cliproxy-provider-version-skew.md
+++ b/docs/runbooks/cliproxy-provider-version-skew.md
@@ -1,0 +1,90 @@
+# CLIProxyAPI Provider Version Skew
+
+When a provider flag introduced in a newer CLIProxyAPI release is passed to a droplet running an older image, the remote binary exits non-zero with an "unknown flag" error on stderr. The CLI surfaces a descriptive error pointing here.
+
+---
+
+## Symptom
+
+`bunx @marcusrbrown/infra cliproxy login codex` fails with:
+
+```
+Remote login command failed with exit code 1. The most likely cause is that the droplet's
+CLIProxyAPI binary predates --codex-device-login support (requires v6.10.9+). See
+docs/runbooks/cliproxy-provider-version-skew.md for diagnosis and remediation steps.
+```
+
+The remote stderr (visible in the terminal because SSH inherits stdio) typically contains something like:
+
+```
+unknown flag: --codex-device-login
+```
+
+---
+
+## Cause
+
+The `cliproxy login codex` flow passes `--codex-device-login` to the CLIProxyAPI binary running inside the `cli-proxy-api` Docker container on the droplet. This flag was introduced in **CLIProxyAPI v6.10.9**. If the droplet's `eceasy/cli-proxy-api` image is pinned to an earlier version, the binary does not recognize the flag and exits with a non-zero code.
+
+The production droplet (`cliproxy.fro.bot`) is on a current v7.x image and is not affected. This skew only arises on older or custom pins.
+
+---
+
+## Diagnosis
+
+Check the live version reported by the status command:
+
+```bash
+bunx @marcusrbrown/infra cliproxy status
+```
+
+The output includes the CLIProxyAPI version. Alternatively, SSH directly and inspect the binary:
+
+```bash
+ssh root@cliproxy.fro.bot \
+  'cd /opt/cliproxy && docker compose exec cli-proxy-api /CLIProxyAPI/CLIProxyAPI --version'
+```
+
+Or check the current image pin:
+
+```bash
+grep 'cli-proxy-api' apps/cliproxy/docker-compose.yaml
+```
+
+If the pinned tag is below `v6.10.9`, that is the cause.
+
+---
+
+## Remediation
+
+1. **Bump the image pin** in `apps/cliproxy/docker-compose.yaml`. Find the `cli-proxy-api` service image line and update the tag to a version ≥ v6.10.9 (Renovate normally proposes this automatically; it can also be done manually):
+
+   ```yaml
+   image: eceasy/cli-proxy-api:v7.x.y  # bump from the old tag to ≥ v6.10.9
+   ```
+
+2. **Deploy** via the standard cliproxy deploy flow:
+
+   ```bash
+   bunx @marcusrbrown/infra cliproxy deploy
+   ```
+
+   Or trigger the GitHub Actions workflow manually.
+
+3. **Re-run the login**:
+
+   ```bash
+   bunx @marcusrbrown/infra cliproxy login codex
+   ```
+
+---
+
+## Related
+
+- [`apps/cliproxy/AGENTS.md`](../../apps/cliproxy/AGENTS.md) — deploy flow, provisioning, anti-patterns
+- [`packages/cli/src/commands/cliproxy/login.ts`](../../packages/cli/src/commands/cliproxy/login.ts) — where the enriched error is thrown
+- `PROVIDER_FLAGS` in `login.ts` — maps each provider name to its CLI flag; update here when upstream adds new flags
+
+---
+
+_Last verified: 2026-06-01_

--- a/packages/cli/src/commands/cliproxy/login.test.ts
+++ b/packages/cli/src/commands/cliproxy/login.test.ts
@@ -276,6 +276,32 @@ describe('cliproxy login', () => {
       )
       expect(calls).toHaveLength(1)
     })
+
+    it('codex non-zero exit: error message includes exit code and v6.10.9 version requirement', async () => {
+      const {cliproxyLoginAction} = await import('./login')
+      const {spawnFn} = makeSpawnOk(1)
+      setValidEnv()
+
+      const error = await cliproxyLoginAction('codex', {}, spawnFn).catch((error_: unknown) => error_)
+      expect(error).toBeInstanceOf(Error)
+      const message = (error as Error).message
+      expect(message).toMatch(/exit code 1/)
+      expect(message).toMatch(/v6\.10\.9/)
+      expect(message).toMatch(/cliproxy-provider-version-skew\.md/)
+    })
+
+    it('codex non-zero exit: error message does not bleed into claude non-zero exit', async () => {
+      const {cliproxyLoginAction} = await import('./login')
+      const {spawnFn} = makeSpawnOk(2)
+      setValidEnv()
+
+      const error = await cliproxyLoginAction('claude', {}, spawnFn).catch((error_: unknown) => error_)
+      expect(error).toBeInstanceOf(Error)
+      const message = (error as Error).message
+      expect(message).toMatch(/Remote login command failed with exit code 2/)
+      expect(message).not.toMatch(/v6\.10\.9/)
+      expect(message).not.toMatch(/cliproxy-provider-version-skew/)
+    })
   })
 
   describe('ssh spawn contract', () => {

--- a/packages/cli/src/commands/cliproxy/login.ts
+++ b/packages/cli/src/commands/cliproxy/login.ts
@@ -97,6 +97,14 @@ export async function cliproxyLoginAction(
 
   const exitCode = await child.exited
   if (exitCode !== 0) {
+    if (provider === 'codex') {
+      throw new Error(
+        `Remote login command failed with exit code ${exitCode}. ` +
+          `The most likely cause is that the droplet's CLIProxyAPI binary predates --codex-device-login support (requires v6.10.9+). ` +
+          `See docs/runbooks/cliproxy-provider-version-skew.md for diagnosis and remediation steps.`,
+      )
+    }
+
     throw new Error(`Remote login command failed with exit code ${exitCode}`)
   }
 


### PR DESCRIPTION
## What

`cliproxy login codex` now fails with a clear, actionable message when the remote CLIProxyAPI binary is too old to understand `--codex-device-login`. Previously the operator saw only a generic non-zero SSH exit code and had to dig through remote stderr to figure out the binary predated codex device-login support.

On a codex login failure, the error now names the likely cause (the droplet's CLIProxyAPI binary predates `--codex-device-login`, which needs v6.10.9+) and points to a new runbook. Other providers keep the existing generic message — the guidance is codex-scoped.

## Why this approach

This is pure local error-message enrichment on the existing failure path — no extra SSH round-trip, no new remote command, no added argv surface. A pre-flight `--help` probe was considered but rejected: it would add a round-trip to every login for a check that only matters on outdated pins, and the production droplet already runs a current image.

## Changes

- `packages/cli/src/commands/cliproxy/login.ts` — codex-scoped enriched error on non-zero exit.
- `docs/runbooks/cliproxy-provider-version-skew.md` — new operator runbook (symptom, cause, diagnosis via `cliproxy status`, remediation by bumping the image pin and redeploying).
- Tests cover the codex enriched message and prove it doesn't bleed into other providers' failures.

Closes #302.
