### PR TITLE
fix(cli): prevent secret redirection via status command flags

### DIFF
--- a/.changeset/harden-mcp-status-secret-redirection.md
+++ b/.changeset/harden-mcp-status-secret-redirection.md
@@ -1,0 +1,24 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Harden MCP-exposed status tools against parameter-driven secret redirection.
+
+Three independent vectors were addressed:
+
+- **cliproxy status**: ambient `CLIPROXY_MANAGEMENT_KEY` no longer follows an
+  agent-supplied `--url` to a non-trusted host. The ambient key is only forwarded
+  when the resolved base URL matches the configured/default trusted URL. Explicit
+  `--key` is always honored regardless of URL.
+
+- **gateway status / umami status**: SSH error messages now redact the resolved
+  host value before returning. An agent passing `--key=SOME_SECRET` would cause
+  the secret value to be the SSH target; if SSH failed, the raw value previously
+  appeared in the error string. It is now replaced with `<host>`.
+
+- **gateway/host.ts and umami/host.ts**: validation error messages no longer echo
+  any portion of the rejected value, preventing partial secret disclosure through
+  error propagation.
+
+All fixes are universal — behavior is identical for CLI operator use and MCP/agent
+invocation.

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -717,3 +717,125 @@ describe('management auth probe (ban-awareness)', () => {
     expect(managementFetchUrls.length).toBe(1)
   })
 })
+
+// ─── Ambient management key trusted-URL binding ───────────────────────────────
+
+describe('cliproxyStatusAction — ambient key does not follow agent-supplied URLs', () => {
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalEnv = {
+      CLIPROXY_URL: process.env.CLIPROXY_URL,
+      CLIPROXY_MANAGEMENT_KEY: process.env.CLIPROXY_MANAGEMENT_KEY,
+    }
+    process.env.CLIPROXY_MANAGEMENT_KEY = 'secret-ambient-key'
+    delete process.env.CLIPROXY_URL
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = v
+      }
+    }
+    globalThis.fetch = originalFetch
+  })
+
+  it('does NOT send the ambient management key to a non-trusted --url override', async () => {
+    const capturedRequestsByHost: Record<string, string[]> = {}
+
+    globalThis.fetch = createFetchImplementation(async (url, init) => {
+      const {hostname} = new URL(url)
+      const hdrs = init?.headers
+      const key = hdrs instanceof Headers ? hdrs.get('x-management-key') : null
+
+      if (!capturedRequestsByHost[hostname]) capturedRequestsByHost[hostname] = []
+      if (key) capturedRequestsByHost[hostname].push(key)
+
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v0/management/'))
+        return new Response('[]', {status: 200, headers: {'content-type': 'application/json'}})
+      return new Response('ok', {status: 200})
+    })
+
+    const {ctx} = createCapturedCtx()
+    try {
+      await cliproxyStatusAction({url: 'https://evil.example.com'}, ctx)
+    } catch {
+      // exit(1) expected or not — either way, we just care about key leakage
+    }
+
+    // The ambient secret key must NOT appear in any request to the evil host
+    expect(capturedRequestsByHost['evil.example.com'] ?? []).not.toContain('secret-ambient-key')
+  })
+
+  it('still uses the ambient key when --url matches the default trusted URL', async () => {
+    const capturedManagementKeys: string[] = []
+
+    globalThis.fetch = createFetchImplementation(async (url, init) => {
+      const hdrs = init?.headers
+      const key = hdrs instanceof Headers ? hdrs.get('x-management-key') : null
+      if (url.includes('/v0/management/') && key) capturedManagementKeys.push(key)
+
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v0/management/config'))
+        return new Response('{}', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/usage-queue'))
+        return new Response('[]', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/latest-version'))
+        return new Response(JSON.stringify({'latest-version': 'v1.0.0'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      return new Response('ok', {status: 200})
+    })
+
+    const {ctx} = createCapturedCtx()
+    // Default URL is https://cliproxy.fro.bot — pass it explicitly
+    await cliproxyStatusAction({url: 'https://cliproxy.fro.bot'}, ctx)
+
+    expect(capturedManagementKeys).toContain('secret-ambient-key')
+  })
+
+  it('uses an explicit --key even when --url is a non-trusted host', async () => {
+    const capturedManagementKeys: string[] = []
+
+    globalThis.fetch = createFetchImplementation(async (url, init) => {
+      const hdrs = init?.headers
+      const key = hdrs instanceof Headers ? hdrs.get('x-management-key') : null
+      if (url.includes('/v0/management/') && key) capturedManagementKeys.push(key)
+
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v0/management/config'))
+        return new Response('{}', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/usage-queue'))
+        return new Response('[]', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/latest-version'))
+        return new Response(JSON.stringify({'latest-version': 'v1.0.0'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      return new Response('ok', {status: 200})
+    })
+
+    const {ctx} = createCapturedCtx()
+    await cliproxyStatusAction({url: 'https://other-cliproxy.example.com', key: 'explicit-key'}, ctx)
+
+    expect(capturedManagementKeys).toContain('explicit-key')
+  })
+
+  it('falls through to the no-key warning path when URL is untrusted and no --key given', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      return new Response('[]', {status: 200})
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyStatusAction({url: 'https://other-cliproxy.example.com'}, ctx)
+
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toMatch(/CLIPROXY_MANAGEMENT_KEY|no key|skipping/i)
+  })
+})

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -385,7 +385,16 @@ export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCt
   try {
     const verbose = options.verbose === true
     const baseUrl = stripTrailingSlash(options.url ?? process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
-    const managementKey = options.key ?? process.env.CLIPROXY_MANAGEMENT_KEY
+
+    // Trusted URL: the canonical configured/default host, trailing-slash-normalized.
+    // Ambient env keys must ONLY follow to this trusted destination to prevent
+    // secret exfiltration when an agent passes an attacker-controlled --url.
+    const trustedUrl = stripTrailingSlash(process.env.CLIPROXY_URL ?? DEFAULT_CLIPROXY_URL)
+    const urlIsExplicitlyOverridden = options.url !== undefined && baseUrl !== trustedUrl
+
+    // An explicit --key is always honored (operator knows what they're doing).
+    // An ambient env key is only forwarded when the resolved baseUrl is trusted.
+    const managementKey = options.key ?? (urlIsExplicitlyOverridden ? undefined : process.env.CLIPROXY_MANAGEMENT_KEY)
 
     ctx.console.log('CLIProxyAPI status')
     ctx.console.log('')

--- a/packages/cli/src/commands/gateway/host.test.ts
+++ b/packages/cli/src/commands/gateway/host.test.ts
@@ -58,7 +58,7 @@ describe('validateGatewayHost', () => {
 
   // ── Error message sanitization ──────────────────────────────────────────────
 
-  it('truncates the invalid value in the error message to ~30 chars', () => {
+  it('omits the rejected value entirely from the error message', () => {
     const longMalicious = `-oProxyCommand=${'A'.repeat(100)}`
     let message = ''
     try {
@@ -66,8 +66,24 @@ describe('validateGatewayHost', () => {
     } catch (error) {
       message = error instanceof Error ? error.message : String(error)
     }
-    // The excerpt in the message should not exceed 30 chars of the original value
+    // The value is never echoed (it may be a misdirected secret) — only the constraint is shown.
     expect(message).toContain('Invalid GATEWAY_HOST')
-    expect(message.length).toBeLessThan(longMalicious.length + 50)
+    expect(message).not.toContain('ProxyCommand')
+    expect(message).not.toContain('AAAA')
+  })
+
+  // ── Secret value redaction ───────────────────────────────────────────────────
+
+  it('does not echo the rejected value in the error message', () => {
+    const secretValue = 'AWS_SECRET_KEY=AKIA1234567890EXAMPLE'
+    let message = ''
+    try {
+      validateGatewayHost(secretValue)
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toContain('Invalid GATEWAY_HOST')
+    expect(message).not.toContain('AKIA1234567890EXAMPLE')
+    expect(message).not.toContain('AWS_SECRET_KEY')
   })
 })

--- a/packages/cli/src/commands/gateway/host.ts
+++ b/packages/cli/src/commands/gateway/host.ts
@@ -13,7 +13,8 @@ const VALID_HOST_RE = /^[a-z\d][a-z\d.\-]*$/i
  * Rejects: empty strings, values starting with `-`, and anything containing
  * characters outside `[A-Za-z0-9.-]`.
  *
- * @throws {Error} with a sanitized excerpt of the invalid value.
+ * @throws {Error} when empty or not a valid hostname. The rejected value is
+ *   never included in the message (it may be a misdirected secret).
  * @returns The validated host string (unchanged).
  */
 export function validateGatewayHost(host: string): string {
@@ -22,9 +23,10 @@ export function validateGatewayHost(host: string): string {
   }
 
   if (!VALID_HOST_RE.test(host)) {
-    // Truncate to 30 chars and strip non-printable bytes before echoing back
-    const excerpt = host.slice(0, 30).replaceAll(/[^\u0020-\u007E]/g, '?')
-    throw new Error(`Invalid GATEWAY_HOST: "${excerpt}" — must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`}`)
+    // Do NOT echo the value — it may be a secret that was redirected via --key
+    throw new Error(
+      `Invalid GATEWAY_HOST: value is not a valid hostname (must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`})`,
+    )
   }
 
   return host

--- a/packages/cli/src/commands/gateway/status.test.ts
+++ b/packages/cli/src/commands/gateway/status.test.ts
@@ -481,3 +481,70 @@ describe('gatewayStatusAction — ctx capture (Tier-2)', () => {
     expect(captured.exit?.code).toBe(1)
   })
 })
+
+// ─── SSH error redaction — host value must not leak in returned error strings ──
+
+describe('getGatewayComposeStatus — SSH error redaction', () => {
+  it('does not include the resolved host value in the error when SSH fails', async () => {
+    const {getGatewayComposeStatus} = await import('./status')
+    const secretLookingHost = 'TOPSECRETHOSTNAME'
+
+    const mockSpawn = (_cmd: string[], _opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'}) => {
+      const encoder = new TextEncoder()
+      return {
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(''))
+            c.close()
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(`ssh: Could not resolve hostname ${secretLookingHost}: Name or service not known`))
+            c.close()
+          },
+        }),
+        exited: Promise.resolve(255),
+      }
+    }
+
+    const result = await getGatewayComposeStatus(secretLookingHost, mockSpawn)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error).not.toContain(secretLookingHost)
+  })
+
+  it('does not leak the host even when OpenSSH lowercases it in stderr', async () => {
+    const {getGatewayComposeStatus} = await import('./status')
+    // A misdirected secret-shaped value passes the hostname regex and becomes the host;
+    // OpenSSH lowercases it in the "Could not resolve hostname" stderr line.
+    const secretHost = 'AKIAIOSFODNN7EXAMPLE'
+
+    const mockSpawn = (_cmd: string[], _opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'}) => {
+      const encoder = new TextEncoder()
+      return {
+        stdout: new ReadableStream({
+          start(c) {
+            c.close()
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(
+              encoder.encode(`ssh: Could not resolve hostname ${secretHost.toLowerCase()}: Name or service not known`),
+            )
+            c.close()
+          },
+        }),
+        exited: Promise.resolve(255),
+      }
+    }
+
+    const result = await getGatewayComposeStatus(secretHost, mockSpawn)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).not.toContain(secretHost)
+    expect(result.error).not.toContain(secretHost.toLowerCase())
+  })
+})

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -1,11 +1,10 @@
 import type {goke} from 'goke'
 import type {ActionCtx} from '../../lib/action-ctx'
 import type {StatusSummary} from '../status'
-
 import {z} from 'zod'
 
+import {redactHost} from '../../lib/redact'
 // ─── Minimal ctx interface (subset of GokeExecutionContext used by this action) ─
-
 import {validateGatewayHost} from './host'
 
 declare const process: {
@@ -128,10 +127,11 @@ export async function getGatewayComposeStatus(
   ])
 
   if (exitCode !== 0) {
+    const redacted = redactHost(stderrText.trim(), host) || 'unknown error'
     return {
       ok: false,
       services: [],
-      error: `SSH command failed (exit ${exitCode}): ${stderrText.trim() || 'unknown error'}`,
+      error: `SSH command failed (exit ${exitCode}): ${redacted}`,
     }
   }
 
@@ -140,7 +140,11 @@ export async function getGatewayComposeStatus(
   try {
     entries = parseComposePsOutput(stdoutText)
   } catch {
-    return {ok: false, services: [], error: `Failed to parse docker compose ps output: ${stdoutText.slice(0, 200)}`}
+    return {
+      ok: false,
+      services: [],
+      error: `Failed to parse docker compose ps output: ${redactHost(stdoutText.slice(0, 200), host)}`,
+    }
   }
 
   const services = parseComposePs(entries)

--- a/packages/cli/src/commands/umami/host.test.ts
+++ b/packages/cli/src/commands/umami/host.test.ts
@@ -48,7 +48,7 @@ describe('validateUmamiHost', () => {
     expect(() => validateUmamiHost('')).toThrow('Invalid UMAMI_DOMAIN')
   })
 
-  it('truncates the invalid value in the error message to ~30 chars', () => {
+  it('omits the rejected value entirely from the error message', () => {
     const longMalicious = `-oProxyCommand=${'A'.repeat(100)}`
     let message = ''
     try {
@@ -56,7 +56,24 @@ describe('validateUmamiHost', () => {
     } catch (error) {
       message = error instanceof Error ? error.message : String(error)
     }
+    // The value is never echoed (it may be a misdirected secret) — only the constraint is shown.
     expect(message).toContain('Invalid UMAMI_DOMAIN')
-    expect(message.length).toBeLessThan(longMalicious.length + 50)
+    expect(message).not.toContain('ProxyCommand')
+    expect(message).not.toContain('AAAA')
+  })
+
+  // ── Secret value redaction ───────────────────────────────────────────────────
+
+  it('does not echo the rejected value in the error message', () => {
+    const secretValue = 'AWS_SECRET_KEY=AKIA1234567890EXAMPLE'
+    let message = ''
+    try {
+      validateUmamiHost(secretValue)
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toContain('Invalid UMAMI_DOMAIN')
+    expect(message).not.toContain('AKIA1234567890EXAMPLE')
+    expect(message).not.toContain('AWS_SECRET_KEY')
   })
 })

--- a/packages/cli/src/commands/umami/host.ts
+++ b/packages/cli/src/commands/umami/host.ts
@@ -13,7 +13,8 @@ const VALID_HOST_RE = /^[a-z\d][a-z\d.\-]*$/i
  * Rejects: empty strings, values starting with `-`, and anything containing
  * characters outside `[A-Za-z0-9.-]`.
  *
- * @throws {Error} with a sanitized excerpt of the invalid value.
+ * @throws {Error} when empty or not a valid hostname. The rejected value is
+ *   never included in the message (it may be a misdirected secret).
  * @returns The validated host string (unchanged).
  */
 export function validateUmamiHost(host: string): string {
@@ -22,9 +23,10 @@ export function validateUmamiHost(host: string): string {
   }
 
   if (!VALID_HOST_RE.test(host)) {
-    // Truncate to 30 chars and strip non-printable bytes before echoing back
-    const excerpt = host.slice(0, 30).replaceAll(/[^\u0020-\u007E]/g, '?')
-    throw new Error(`Invalid UMAMI_DOMAIN: "${excerpt}" — must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`}`)
+    // Do NOT echo the value — it may be a secret that was redirected via --key
+    throw new Error(
+      `Invalid UMAMI_DOMAIN: value is not a valid hostname (must match ${String.raw`[A-Za-z0-9][A-Za-z0-9.\-]*`})`,
+    )
   }
 
   return host

--- a/packages/cli/src/commands/umami/status.test.ts
+++ b/packages/cli/src/commands/umami/status.test.ts
@@ -385,3 +385,68 @@ describe('status command', () => {
     expect(captured.exit).toBeNull()
   })
 })
+
+// ─── SSH error redaction — host value must not leak in returned error strings ──
+
+describe('getUmamiComposeStatus — SSH error redaction', () => {
+  it('does not include the resolved host value in the error when SSH fails', async () => {
+    const {getUmamiComposeStatus} = await import('./status')
+    const secretLookingHost = 'TOPSECRETHOSTNAME'
+
+    const mockSpawn = (_cmd: string[], _opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'}) => {
+      const encoder = new TextEncoder()
+      return {
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(''))
+            c.close()
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(`ssh: Could not resolve hostname ${secretLookingHost}: Name or service not known`))
+            c.close()
+          },
+        }),
+        exited: Promise.resolve(255),
+      }
+    }
+
+    const result = await getUmamiComposeStatus(secretLookingHost, mockSpawn)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error).not.toContain(secretLookingHost)
+  })
+
+  it('does not leak the host even when OpenSSH lowercases it in stderr', async () => {
+    const {getUmamiComposeStatus} = await import('./status')
+    const secretHost = 'AKIAIOSFODNN7EXAMPLE'
+
+    const mockSpawn = (_cmd: string[], _opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'}) => {
+      const encoder = new TextEncoder()
+      return {
+        stdout: new ReadableStream({
+          start(c) {
+            c.close()
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(
+              encoder.encode(`ssh: Could not resolve hostname ${secretHost.toLowerCase()}: Name or service not known`),
+            )
+            c.close()
+          },
+        }),
+        exited: Promise.resolve(255),
+      }
+    }
+
+    const result = await getUmamiComposeStatus(secretHost, mockSpawn)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).not.toContain(secretHost)
+    expect(result.error).not.toContain(secretHost.toLowerCase())
+  })
+})

--- a/packages/cli/src/commands/umami/status.ts
+++ b/packages/cli/src/commands/umami/status.ts
@@ -1,9 +1,9 @@
 import type {goke} from 'goke'
 import type {ActionCtx} from '../../lib/action-ctx'
 import type {StatusSummary} from '../status'
-
 import {z} from 'zod'
 
+import {redactHost} from '../../lib/redact'
 import {validateUmamiHost} from './host'
 
 declare const process: {
@@ -124,7 +124,7 @@ export async function getUmamiComposeStatus(host: string, spawn: SpawnFn = defau
     return {
       ok: false,
       services: [],
-      error: `SSH command failed (exit ${exitCode}): ${stderrText.trim() || 'unknown error'}`,
+      error: `SSH command failed (exit ${exitCode}): ${redactHost(stderrText.trim(), host) || 'unknown error'}`,
     }
   }
 
@@ -133,7 +133,11 @@ export async function getUmamiComposeStatus(host: string, spawn: SpawnFn = defau
   try {
     entries = parseComposePsOutput(stdoutText)
   } catch {
-    return {ok: false, services: [], error: `Failed to parse docker compose ps output: ${stdoutText.slice(0, 200)}`}
+    return {
+      ok: false,
+      services: [],
+      error: `Failed to parse docker compose ps output: ${redactHost(stdoutText.slice(0, 200), host)}`,
+    }
   }
 
   const services = parseComposePs(entries)

--- a/packages/cli/src/lib/redact.ts
+++ b/packages/cli/src/lib/redact.ts
@@ -1,0 +1,21 @@
+/**
+ * Redact every occurrence of a host value from text, case-insensitively.
+ *
+ * Used to scrub a resolved SSH host out of error output before it surfaces to an
+ * MCP consumer. The host can be a misdirected secret (an agent may point the
+ * `--key` env-var selector at, e.g., `AWS_SECRET_ACCESS_KEY`), so its value must
+ * never appear in returned errors.
+ *
+ * Two subtleties this handles that a plain `replaceAll(host, ...)` does not:
+ *   1. OpenSSH lowercases the hostname in "Could not resolve hostname <name>"
+ *      stderr, so the match must be case-insensitive.
+ *   2. Validated hosts contain `.` and `-`, which are regex-significant, so the
+ *      host is escaped before building the matcher (no over-redaction).
+ *
+ * An empty/falsy host is a no-op (an empty matcher would match everywhere).
+ */
+export function redactHost(text: string, host: string): string {
+  if (!host) return text
+  const escaped = host.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+  return text.replaceAll(new RegExp(escaped, 'gi'), '<host>')
+}


### PR DESCRIPTION
Hardens the three status commands against secret redirection through caller-supplied connection targets — the surface that opened up once these tools became agent-reachable.

## The problem

The status commands take connection targets a caller controls:

- `cliproxy status --url <host>` chooses the base URL the management key is sent to.
- `gateway status --key <ENV>` / `umami status --key <ENV>` resolve the SSH host from the named environment variable.

Two ways that leaked a secret:

1. **Management key followed an arbitrary URL.** `cliproxy status` auto-attached the local `CLIPROXY_MANAGEMENT_KEY` even when `--url` pointed somewhere other than the configured host — so an overridden URL shipped the key off-box.
2. **A misdirected secret echoed back in errors.** Pointing `--key` at, say, `AWS_SECRET_ACCESS_KEY` makes the secret's value the SSH host; its value then surfaced through SSH stderr (`Could not resolve hostname …`) and validator error messages.

## The fix

- `cliproxy status` only auto-attaches the ambient management key for the configured/default URL. An overridden `--url` requires an explicit `--key` or skips the management checks entirely — the local key never follows a caller-supplied host.
- `gateway`/`umami status` redact the resolved host from every returned error, case-insensitively (OpenSSH lowercases the hostname in resolution failures), and the host validators no longer echo the rejected value.

Direct CLI use is unchanged — `--url`/`--key` remain available for operators checking another instance.

## Verification

- 1020 tests pass (added regressions for the URL-binding, host redaction, and the lowercased-stderr case)
- type-check and lint clean

Closes #375.
