### PR TITLE
ci(fro-bot): forbid ce:* skills in PR review prompt

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -39,6 +39,15 @@ env:
     monorepo that deploys KeeWeb to box.heatvision.co via SSH/rsync.
     Read AGENTS.md for full project conventions before reviewing.
 
+    Review the diff directly. Do NOT invoke `ce:review` or any other `ce:*`
+    skill (ce:work, ce:plan, ce:brainstorm, ce:compound, etc.). Those are
+    heavy multi-agent workflows meant for authoring changes, not reviewing
+    them — `ce:review` in particular is run by the author before pushing, so
+    repeating it here is redundant and makes the review take far too long.
+    Read the changed files yourself and form your own assessment with the
+    standard tools (read, grep, git diff). A focused single-pass review is
+    the goal.
+
     Focus your review on:
     - Correctness and edge cases
     - Security implications (secret exposure, SSH config, deploy safety)


### PR DESCRIPTION
PR review runs have been taking ~40 minutes because the reviewer was running the full `ce:review` multi-agent workflow on every pull request. That workflow is meant for authoring changes — and `ce:review` already runs before pushing — so repeating it during review is redundant and dramatically slows the run.

This adds an explicit constraint to `PR_REVIEW_PROMPT`: review the diff directly with standard tools (read, grep, git diff), and do not invoke `ce:review` or any other `ce:*` skill. The goal is a focused single-pass review.

Scoped to `PR_REVIEW_PROMPT` only — the autohealing `SCHEDULE_PROMPT` legitimately performs heavier multi-step work and is unchanged.
