### PR TITLE
fix(gateway): revert daemon pin to v0.46.3 after v0.50.0 crash-loop

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -2606,3 +2606,88 @@ describe('main() — validation aborts before any SSH mutation', () => {
 })
 
 // Note: getGatewayDeployEnv CLI parity tests live in packages/cli/src/commands/gateway/deploy.test.ts
+
+// ─── normalizePemPrivateKey ───────────────────────────────────────────────────
+
+describe('normalizePemPrivateKey', () => {
+  test(String.raw`single-line value with literal \n sequences → converted to real newlines`, async () => {
+    const {normalizePemPrivateKey} = await import('./deploy')
+    const singleLine = String.raw`-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----`
+    const result = normalizePemPrivateKey(singleLine)
+    // Must contain real newlines
+    expect(result.includes('\n')).toBe(true)
+    // Must NOT contain literal backslash-n
+    expect(result.includes(String.raw`\n`)).toBe(false)
+    // Exact expected multi-line output (trailing newline ensured)
+    const expected = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----\n'
+    expect(result).toBe(expected)
+  })
+
+  test('value already containing real newlines → returned unchanged except trailing newline ensured', async () => {
+    const {normalizePemPrivateKey} = await import('./deploy')
+    const multiLine = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----\n'
+    const result = normalizePemPrivateKey(multiLine)
+    // Body is unchanged — no literal \n present, no double-newline added
+    expect(result).toBe(multiLine)
+    expect(result.includes(String.raw`\n`)).toBe(false)
+  })
+
+  test('value without trailing newline → gets exactly one trailing newline', async () => {
+    const {normalizePemPrivateKey} = await import('./deploy')
+    const noTrailing = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----'
+    const result = normalizePemPrivateKey(noTrailing)
+    expect(result.endsWith('\n')).toBe(true)
+    expect(result.endsWith('\n\n')).toBe(false)
+    expect(result).toBe(`${noTrailing}\n`)
+  })
+
+  test(String.raw`value with literal \r\n sequences → normalized to real \n`, async () => {
+    const {normalizePemPrivateKey} = await import('./deploy')
+    const crlfEscaped = String.raw`-----BEGIN RSA PRIVATE KEY-----\r\nMIIEow...\r\nAB==\r\n-----END RSA PRIVATE KEY-----`
+    const result = normalizePemPrivateKey(crlfEscaped)
+    // Must not contain literal \r\n or \n
+    expect(result.includes(String.raw`\r\n`)).toBe(false)
+    expect(result.includes(String.raw`\n`)).toBe(false)
+    // Must contain real newlines only
+    expect(result.includes('\n')).toBe(true)
+    expect(result.includes('\r')).toBe(false)
+    const expected = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----\n'
+    expect(result).toBe(expected)
+  })
+
+  test('empty string → returns empty string (no trailing newline added)', async () => {
+    const {normalizePemPrivateKey} = await import('./deploy')
+    expect(normalizePemPrivateKey('')).toBe('')
+  })
+})
+
+// ─── buildSecretFileList — normalizePemPrivateKey wiring ─────────────────────
+
+describe('buildSecretFileList — normalizePemPrivateKey wiring', () => {
+  test(String.raw`github-app-private-key: single-line \n-escaped env value → content has real newlines`, async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    const singleLineKey = String.raw`-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----`
+    const secrets = buildSecretFileList(makeEnv({GH_APP_PRIVATE_KEY: singleLineKey}))
+    const entry = secrets.find(s => s.name === 'github-app-private-key')
+    expect(entry).toBeDefined()
+    // Transform must have been applied: real newlines present
+    expect(entry!.content.includes('\n')).toBe(true)
+    // No literal backslash-n remaining
+    expect(entry!.content.includes(String.raw`\n`)).toBe(false)
+    // Exact expected output
+    const expected = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\nAB==\n-----END RSA PRIVATE KEY-----\n'
+    expect(entry!.content).toBe(expected)
+  })
+
+  test('discord-token: NOT transformed — value passed through verbatim', async () => {
+    const {buildSecretFileList} = await import('./deploy')
+    // A value with literal \n that would be transformed if normalizePemPrivateKey were applied
+    const rawToken = String.raw`tok\nwith\nliteral\nescapes`
+    const secrets = buildSecretFileList(makeEnv({DISCORD_TOKEN: rawToken}))
+    const entry = secrets.find(s => s.name === 'discord-token')
+    expect(entry).toBeDefined()
+    // discord-token has no transform — content must be verbatim
+    expect(entry!.content).toBe(rawToken)
+    expect(entry!.content.includes(String.raw`\n`)).toBe(true)
+  })
+})

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -419,12 +419,38 @@ export function validateObjectStoreHosts(value: string): void {
 }
 
 /**
+ * Normalizes a PEM private key that may be stored single-line with literal `\n`
+ * escape sequences (the convenient form for a .env file) into a real multi-line
+ * PEM, and ensures a trailing newline.
+ *
+ * Safe for both sources: a valid PEM body is base64 + header/footer dashes and
+ * never contains a literal backslash-n, so the unescape is a no-op for a value
+ * that already has real newlines (e.g. a GitHub Environment secret). The trailing
+ * newline also repairs GitHub Actions stripping trailing whitespace from secrets.
+ */
+export function normalizePemPrivateKey(value: string): string {
+  if (!value) return value
+  let normalized = value
+  if (normalized.includes(String.raw`\n`)) {
+    normalized = normalized.replaceAll(String.raw`\r\n`, '\n').replaceAll(String.raw`\n`, '\n')
+  }
+  if (!normalized.endsWith('\n')) {
+    normalized = `${normalized}\n`
+  }
+  return normalized
+}
+
+/**
  * Builds the list of secret files to materialize on the droplet.
  * Required secrets get the actual value; optional secrets that are
  * unset get '' (empty placeholder).
+ *
+ * `github-app-private-key` is run through normalizePemPrivateKey so the PEM can
+ * be supplied either as a real multi-line value (CI / GitHub Environment) or as
+ * a single-line `\n`-escaped value (convenient in a local .env).
  */
 export function buildSecretFileList(env: Record<string, string>): SecretFile[] {
-  const required: {name: string; envKey: string}[] = [
+  const required: {name: string; envKey: string; transform?: (value: string) => string}[] = [
     {name: 'discord-token', envKey: 'DISCORD_TOKEN'},
     {name: 'discord-application-id', envKey: 'DISCORD_APPLICATION_ID'},
     {name: 'discord-guild-id', envKey: 'DISCORD_GUILD_ID'},
@@ -433,12 +459,12 @@ export function buildSecretFileList(env: Record<string, string>): SecretFile[] {
     {name: 's3-bucket', envKey: 'S3_BUCKET'},
     {name: 's3-region', envKey: 'S3_REGION'},
     {name: 'github-app-id', envKey: 'GH_APP_ID'},
-    {name: 'github-app-private-key', envKey: 'GH_APP_PRIVATE_KEY'},
+    {name: 'github-app-private-key', envKey: 'GH_APP_PRIVATE_KEY', transform: normalizePemPrivateKey},
     {name: 'workspace-opencode-token', envKey: 'WORKSPACE_OPENCODE_TOKEN'},
     {name: 'workspace-opencode-auth', envKey: 'WORKSPACE_OPENCODE_AUTH'},
   ]
 
-  const optional: {name: string; envKey: string}[] = [
+  const optional: {name: string; envKey: string; transform?: (value: string) => string}[] = [
     {name: 's3-endpoint', envKey: 'S3_ENDPOINT'},
     {name: 'aws-session-token', envKey: 'AWS_SESSION_TOKEN'},
     {name: 'discord-privileged-intents', envKey: 'DISCORD_PRIVILEGED_INTENTS'},
@@ -451,12 +477,14 @@ export function buildSecretFileList(env: Record<string, string>): SecretFile[] {
 
   const secrets: SecretFile[] = []
 
-  for (const {name, envKey} of required) {
-    secrets.push({name, content: env[envKey] ?? '', required: true})
+  for (const {name, envKey, transform} of required) {
+    const raw = env[envKey] ?? ''
+    secrets.push({name, content: transform ? transform(raw) : raw, required: true})
   }
 
-  for (const {name, envKey} of optional) {
-    secrets.push({name, content: env[envKey] ?? '', required: false})
+  for (const {name, envKey, transform} of optional) {
+    const raw = env[envKey] ?? ''
+    secrets.push({name, content: transform ? transform(raw) : raw, required: false})
   }
 
   return secrets

--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.50.0"
+  "ref": "v0.46.3"
 }


### PR DESCRIPTION
## Summary

Rolls the gateway daemon pin back to `v0.46.3` after the v0.50.0 cutover crash-looped in production: v0.50.0 requires `GATEWAY_WEBHOOK_SECRET` (and `GATEWAY_PRESENCE_CHANNEL_ID`) to boot, which were not materialized, so the gateway container failed its healthcheck and `/fro-bot` went down. Production has been restored to v0.46.3 (healthy) via the deploy materializer; this reverts the pin on `main` so a CI deploy can't re-break it.

## Changes

- `apps/gateway/upstream.json`: `ref` reverted to `v0.46.3`.
- `apps/gateway/src/deploy.ts`: `github-app-private-key` is now normalized through `normalizePemPrivateKey`, accepting the PEM either as a real multi-line value (CI/GitHub Environment) or a single-line `\n`-escaped value (convenient in a local `.env`); a trailing newline is ensured. No-op for a value that already has real newlines.
- `apps/gateway/src/deploy.test.ts`: regression tests for the PEM normalization and its wiring.

## Verification

- 1088 tests pass; `tsc --noEmit` clean; lint 0 errors.
- Live droplet: gateway `running (healthy)` on `v0.46.3`, Discord shard ready, `/fro-bot` registered.

Re-adopting v0.50.0 (the workspace mention loop) is separate planned work that must first materialize `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` and decide on the new `:3000` ingress.
