### PR TITLE
fix(gateway): root SSH ControlPath under /tmp to avoid macOS 104-byte limit

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1797,19 +1797,12 @@ describe('SSH ControlMaster multiplexing', () => {
     }
   })
 
-  test('CI mode: every ssh argv includes ControlPath under the key tmpdir', async () => {
+  test('CI mode: every ssh argv includes ControlPath under /tmp/gw-cm-* (not the key tmpdir)', async () => {
+    // After the macOS ControlPath-length fix, the control socket lives under a short
+    // /tmp-rooted dir (gw-cm-*) separate from the key tmpdir (gateway-deploy-key-*).
     const {main} = await import('./deploy')
-    let capturedKeyDir: string | undefined
 
-    const {spawnFn, calls} = makeSpawnMock(cmd => {
-      // Capture the tmpdir from the -i path on the first ssh call
-      const iIdx = cmd.indexOf('-i')
-      if (iIdx !== -1 && capturedKeyDir === undefined) {
-        const keyPath = cmd[iIdx + 1]
-        if (keyPath) capturedKeyDir = keyPath.replace(/\/id$/, '')
-      }
-      return undefined
-    })
+    const {spawnFn, calls} = makeSpawnMock()
 
     await main({
       env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: 'fake-key'}),
@@ -1819,17 +1812,14 @@ describe('SSH ControlMaster multiplexing', () => {
       spawn: spawnFn,
     })
 
-    expect(capturedKeyDir).toBeDefined()
-
     const sshCalls = calls.filter(cmd => cmd[0] === 'ssh')
     expect(sshCalls.length).toBeGreaterThan(0)
 
     for (const cmd of sshCalls) {
       const controlPathArg = cmd.find(arg => arg.startsWith('ControlPath='))
       expect(controlPathArg).toBeDefined()
-      if (capturedKeyDir) {
-        expect(controlPathArg).toContain(capturedKeyDir)
-      }
+      // Control socket must be under /tmp/gw-cm-*, not under the key tmpdir
+      expect(controlPathArg).toMatch(/^ControlPath=\/tmp\/gw-cm-/)
     }
   })
 
@@ -1892,6 +1882,67 @@ describe('SSH ControlMaster multiplexing', () => {
     for (const cmd of sshCalls) {
       const controlPathArg = cmd.find(arg => arg.startsWith('ControlPath='))
       expect(controlPathArg).toBeDefined()
+    }
+  })
+
+  test('macOS long TMPDIR: ControlPath is rooted at /tmp, not the long TMPDIR, and stays under 104 bytes', async () => {
+    // Regression test for macOS sun_path limit (104 bytes).
+    // On macOS, os.tmpdir() returns a long path like /var/folders/td/f1mm.../T/
+    // which causes the ControlPath unix-domain socket to exceed 104 bytes → ssh exits 255.
+    // The fix: root the control socket under /tmp (short) regardless of os.tmpdir().
+    //
+    // Strategy: create a real long-named dir under the actual tmpdir so mkdtempSync
+    // succeeds (simulating macOS where the long path exists), then assert the captured
+    // ControlPath is rooted at /tmp/ and stays under 104 bytes.
+    const {main} = await import('./deploy')
+    const {mkdtempSync: realMkdtemp, rmSync: realRmSync} = await import('node:fs')
+    const {tmpdir: realTmpdir} = await import('node:os')
+    const {join: realJoin} = await import('node:path')
+
+    // Create a real long-named parent dir under the actual tmpdir to simulate macOS.
+    // The name is long enough that a socket path rooted here would exceed 104 bytes.
+    const longParent = realMkdtemp(realJoin(realTmpdir(), 'gateway-deploy-macos-sim-long-path-xxxxxxxx-'))
+    const originalTmpdir = process.env.TMPDIR
+    process.env.TMPDIR = longParent
+
+    const capturedControlPaths: string[] = []
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const controlPathArg = cmd.find(arg => arg.startsWith('ControlPath='))
+      if (controlPathArg) {
+        capturedControlPaths.push(controlPathArg.slice('ControlPath='.length))
+      }
+      return undefined
+    })
+
+    try {
+      await main({
+        env: makeEnv({CI: 'true', GATEWAY_SSH_KEY: 'fake-key'}),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      })
+    } finally {
+      if (originalTmpdir === undefined) {
+        delete process.env.TMPDIR
+      } else {
+        process.env.TMPDIR = originalTmpdir
+      }
+      realRmSync(longParent, {recursive: true, force: true})
+    }
+
+    expect(capturedControlPaths.length).toBeGreaterThan(0)
+
+    for (const controlPath of capturedControlPaths) {
+      // (a) Must be rooted at /tmp/, NOT under the long TMPDIR
+      expect(controlPath.startsWith('/tmp/')).toBe(true)
+      expect(controlPath.startsWith(longParent)).toBe(false)
+
+      // (b) Worst-case resolved length must stay under 104 bytes.
+      // Replace %C with a 40-char placeholder (SHA1 hex hash length) to simulate expansion.
+      const worstCase = controlPath.replace('%C', 'a'.repeat(40))
+      expect(worstCase.length).toBeLessThan(104)
     }
   })
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -882,13 +882,22 @@ export async function main(opts: MainOpts = {}): Promise<void> {
 
   // CI mode: write GATEWAY_SSH_KEY to a tmp file with mode 0o600.
   // Local mode: keyPath stays undefined; SSH_AUTH_SOCK is forwarded via deployEnv.
-  // A tmpdir is always created (CI or local) to hold the ControlMaster socket.
   let keyPath: string | undefined
   let keyTmpDir: string | undefined
+  // ControlMaster socket lives under a SHORT /tmp-rooted dir to stay well under the
+  // 104-byte sun_path limit for unix-domain sockets. On macOS, os.tmpdir() returns a
+  // long path like /var/folders/td/f1mm.../T/ which causes ControlPath to exceed 104
+  // bytes → ssh fails with "ControlPath too long". The private key file stays in the
+  // secure os.tmpdir()-rooted dir (user-owned mode-700); only the socket moves to /tmp.
+  let controlTmpDir: string | undefined
 
   try {
-    // Always create a tmpdir — used for ControlPath socket in both CI and local mode.
+    // Key dir: secure, user-owned, under os.tmpdir() (may be long on macOS — that's fine
+    // for a regular file path; the 104-byte limit only applies to unix-domain sockets).
     keyTmpDir = mkdtempSync(join(tmpdir(), 'gateway-deploy-key-'))
+
+    // Control socket dir: always under /tmp so the socket path stays short.
+    controlTmpDir = mkdtempSync(join('/tmp', 'gw-cm-'))
 
     if (env.CI === 'true' && env.GATEWAY_SSH_KEY) {
       try {
@@ -906,8 +915,9 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       }
     }
 
-    // ControlPath socket lives inside keyTmpDir; %C expands to a hash of the connection tuple.
-    const controlPath = join(keyTmpDir, 'cm-%C')
+    // ControlPath socket lives inside controlTmpDir (short /tmp-rooted path).
+    // %C expands to a hash of the connection tuple.
+    const controlPath = join(controlTmpDir, 'cm-%C')
 
     // Phase 4: Ensure droplet workspace
     await runCommand(
@@ -1068,9 +1078,12 @@ export async function main(opts: MainOpts = {}): Promise<void> {
 
     console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
   } finally {
-    // Clean up the tmp key directory regardless of success or failure
+    // Clean up both tmp directories regardless of success or failure.
     if (keyTmpDir) {
       rmSync(keyTmpDir, {recursive: true, force: true})
+    }
+    if (controlTmpDir) {
+      rmSync(controlTmpDir, {recursive: true, force: true})
     }
   }
 }


### PR DESCRIPTION
## Summary

Local gateway deploys (`bunx @marcusrbrown/infra gateway deploy --local`) fail on macOS at the first SSH call with `ControlPath too long (... >= 104 bytes)` and exit 255. The SSH ControlMaster socket path was rooted under `os.tmpdir()`, which on macOS is a long `/var/folders/.../T/` path; combined with the `%C` connection-hash expansion it pushes the unix-domain socket path past the 104-byte `sun_path` limit. Linux CI never hit this because its `tmpdir()` is `/tmp`.

## Change

- The ControlMaster socket now lives in a dedicated short `/tmp`-rooted dir (`mkdtempSync('/tmp/gw-cm-…')`) on all platforms, keeping the socket path well under the 104-byte limit.
- The SSH private key still materializes into the user-owned `mkdtempSync(os.tmpdir(), 'gateway-deploy-key-…')` dir at mode `0600` — only the socket moved, not the key.
- Both temp dirs are cleaned up in the existing `finally` block.

No behavior change on Linux CI (paths stay short either way).

## Verification

- New regression test drives `main()` with a long simulated `TMPDIR` and asserts the resolved `ControlPath` is `/tmp`-rooted and stays under 104 bytes (red before the fix, green after).
- 1089 tests pass; `tsc --noEmit` clean; lint 0 errors.
