### PR TITLE
docs(changeset): correct gateway v0.50.0 note to reflect held daemon pin

### DIFF
--- a/.changeset/gateway-v0500-workspace-mention-loop.md
+++ b/.changeset/gateway-v0500-workspace-mention-loop.md
@@ -2,4 +2,4 @@
 '@marcusrbrown/infra': patch
 ---
 
-Gateway deploy provisions the fro-bot/agent v0.50.0 workspace executor: `gateway deploy` now forwards the workspace OpenCode token, provider auth, model, config, and the Discord trigger-role authorization gate so the `@fro-bot` mention loop and `/fro-bot add-project` cloning work end-to-end. The trigger-role gate is enforced non-empty (fail-closed) and the provider config is JSON-validated before deploy.
+Gateway deploy materializes the fro-bot/agent v0.50.0 workspace executor secrets: `gateway deploy` now forwards the workspace OpenCode token, provider auth, model, config, and the Discord trigger-role authorization gate. The trigger-role gate is enforced non-empty (fail-closed) and the provider config is JSON-validated before deploy. The gateway daemon remains pinned at v0.46.3 pending upstream fro-bot/agent#738, so the v0.50.0 mention loop and `/fro-bot add-project` cloning are staged but not yet live in production.


### PR DESCRIPTION
## Summary

Corrects the queued `0.9.10` changeset for the gateway workspace-executor wiring so the release note matches production reality.

The original note claimed the v0.50.0 `@fro-bot` mention loop and `/fro-bot add-project` cloning "work end-to-end." They don't yet — the gateway daemon is held at v0.46.3 pending upstream `fro-bot/agent#738` (v0.50.0 is undeployable as shipped: its daemon requires `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` but its compose wires neither).

The deploy-side wiring from #387 is real and merged — it forwards the workspace OpenCode token, provider auth, model, config, and the fail-closed trigger-role gate — but it stays dormant until the daemon can move to v0.50.0+. The reworded note describes the wiring accurately and states it's staged, not yet live.

## Scope

Changeset wording only — no code, no version change. Release PR #384 will regenerate with the corrected note.
