### PR TITLE
docs(gateway): mention-loop model-config lessons + fix stale model-id examples

### DIFF
--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -91,7 +91,7 @@ After provisioning: commit the updated `.github/known_hosts`.
 | `GH_APP_PRIVATE_KEY` | ✓ | GitHub App private key PEM (materializes to `github-app-private-key`) |
 | `WORKSPACE_OPENCODE_TOKEN` | ✓ | Internal shared bearer between the gateway and the workspace `:9200` OpenCode proxy (random value; fail-closed if empty) |
 | `WORKSPACE_OPENCODE_AUTH` | ✓ | OpenCode provider `auth.json` for the workspace — a **dedicated scoped cliproxy key**, not the repo's `OPENCODE_AUTH_JSON` (separate revocation + blast radius) |
-| `WORKSPACE_OPENCODE_MODEL` | ✓ | OpenCode model id for the mention loop (e.g. `openai/gpt-5.5-fast`); an OpenCode harness string, not a `/v1/models` catalog id. Written to `.env` |
+| `WORKSPACE_OPENCODE_MODEL` | ✓ | OpenCode model id for the mention loop (e.g. `openai/gpt-5.5`). MUST be a real cliproxy `/v1/models` catalog id — an unlisted id (e.g. `gpt-5.5-fast`) 502s and OpenCode retries silently, yielding an empty run. Written to `.env` |
 | `WORKSPACE_OPENCODE_CONFIG` | ✓ | OpenCode provider/baseURL config JSON routing through `cliproxy.fro.bot/v1`; JSON-validated, `$`-escaped, written to `.env` |
 | `GATEWAY_TRIGGER_ROLE_ID` | ✓ | Discord role ID allowed to trigger the `@fro-bot` mention loop — required (fail-closed); empty would open LLM execution to every guild member |
 | `S3_ENDPOINT` | — | Custom endpoint URL (R2, MinIO, etc.) |

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -273,7 +273,7 @@ export function buildGatewayEnvFileContents(opts: {objectStoreHosts: string; mod
     throw new Error(
       `WORKSPACE_OPENCODE_MODEL "${model}" is not a valid provider/model identifier. ` +
         'Use the format "provider/model" with characters limited to letters, digits, dots, hyphens, and underscores ' +
-        '(e.g. "anthropic/claude-sonnet-4-6" or "openai/gpt-5.5-fast"). ' +
+        '(e.g. "anthropic/claude-sonnet-4-6" or "openai/gpt-5.5"). ' +
         'Whitespace, #, =, and other special characters are not allowed.',
     )
   }

--- a/docs/solutions/integration-issues/gateway-mention-loop-model-config-2026-06-04.md
+++ b/docs/solutions/integration-issues/gateway-mention-loop-model-config-2026-06-04.md
@@ -1,0 +1,110 @@
+---
+title: Gateway mention loop empty/no reply — model resolution, small_model, and event-directory chain
+date: 2026-06-04
+category: docs/solutions/integration-issues
+module: apps/gateway
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - 'Discord @fro-bot mention creates a thread but Fro Bot posts no reply'
+  - 'workspace OpenCode log: ProviderHeaderTimeoutError ms:10000 stream error, retrying forever'
+  - 'cliproxy /v1/responses returns 502 "unknown provider for model <id>" for an unlisted model'
+  - 'gateway log ends: session created → prompt sent → "stream ended due to timeout signal"'
+  - 'OpenCode stored a complete assistant message (finish:stop, output tokens) but nothing reached Discord'
+root_cause: config_error
+resolution_type: config_change
+severity: high
+related_components:
+  - cliproxy
+tags:
+  - gateway
+  - opencode
+  - cliproxy
+  - mention-loop
+  - model-resolution
+  - small-model
+  - event-stream
+  - reasoning-model
+---
+
+# Gateway mention loop empty/no reply — model resolution, small_model, and event-directory chain
+
+## Problem
+
+After the gateway daemon reached the model successfully (post-#749 supervisor fix), an
+`@fro-bot` mention produced a thread but no reply. Diagnosis peeled back three independent
+layers: an invalid main model id, an invalid default `small_model`, and finally an upstream
+gateway event-subscription bug that drops the response even when the model answers correctly.
+
+## Symptoms
+
+- Mention thread created, but Fro Bot posts nothing (or "workspace not reachable" / "task timed out").
+- Workspace OpenCode: `ERROR service=llm ... ProviderHeaderTimeoutError ms:10000 stream error`, retrying forever.
+- A direct `POST cliproxy.fro.bot/v1/responses` for the configured model returns **502 "unknown provider for model <id>"**.
+- Gateway log: `run-core: session created → event stream subscribed → prompt sent → stream ended due to timeout signal` — no reply, no error.
+- The OpenCode session API (`GET /session/{id}/message`) shows a **complete** assistant message (`finish:"stop"`, non-zero output tokens, a `text` part with the answer) — proving the model worked.
+
+## What Didn't Work
+
+- Assuming the failure was the v0.53.1 supervisor (#749). It was fixed — runs reach `prompt sent`.
+- Assuming mitmproxy broke the streaming Responses API. Disproven: gpt-5.5 streaming was **byte-identical** direct vs through mitmproxy (same SSE frames, same answer).
+- Assuming the model itself returns empty. Disproven: the model produced the answer (stored in OpenCode; `finish:stop`).
+- Assuming the `gpt-5-nano` title-gen 502 was an egress block. Disproven: mitmproxy logged **zero** blocked hosts; the request reached cliproxy (`via: Caddy`) and got "unknown provider".
+- Reproducing the run with `POST /session/{id}/prompt` — that path returns the OpenCode **web-UI HTML** (SPA fallback). The real prompt route is `POST /session/{id}/message`.
+
+## Solution
+
+Three config-level fixes, applied to the deploy `.env`, the local `.env`, and the GitHub
+`gateway` environment secrets (so they survive redeploys):
+
+1. **Main model must be a real cliproxy `/v1/models` id.**
+   `WORKSPACE_OPENCODE_MODEL=openai/gpt-5.5-fast` → **`openai/gpt-5.5`**.
+   `gpt-5.5-fast` is not in the catalog (502); `gpt-5.5` returns 200. Validate first:
+   ```sh
+   OKEY=$(bun --env-file=.env -e 'process.stdout.write(JSON.parse(process.env.WORKSPACE_OPENCODE_AUTH).openai.key)')
+   curl -s https://cliproxy.fro.bot/v1/models -H "Authorization: Bearer $OKEY" | jq '.data[].id'
+   ```
+
+2. **Override OpenCode's default `small_model`** (used for title generation) to a real cliproxy model.
+   OpenCode's default small model is `gpt-5-nano`, which routes through the `openai`→cliproxy
+   baseURL overlay and 502s ("unknown provider"). Add to `WORKSPACE_OPENCODE_CONFIG`:
+   ```json
+   { "provider": { "...": "..." }, "small_model": "anthropic/claude-haiku-4-5-20251001" }
+   ```
+
+3. **The real mention-loop blocker is upstream** (`fro-bot/agent#766`): `run-core.ts` creates the
+   OpenCode session with **no directory** (it roots at the default cwd `/workspace/repos`) but
+   subscribes to `/event` **filtered to the repo subdir** — so the gateway receives none of the
+   session's events and times out. No infra-side config fixes this; tracked via smart note until a
+   patched tag ships.
+
+## Why This Works
+
+`readSecret`/provider routing sends any `openai/*` model id to the overlaid cliproxy baseURL.
+cliproxy only serves the ids in its `/v1/models` catalog (the proxied subscription models); an
+unlisted id (`gpt-5.5-fast`, `gpt-5-nano`) yields a 502 that OpenCode surfaces as an infinite
+`ProviderHeaderTimeoutError` retry (no usable assistant text → empty run). Picking ids that exist
+in the catalog makes both the main and small model calls succeed.
+
+The #766 directory mismatch is proven by an A/B capture of the same gpt-5.5 run: an **unfiltered**
+`/event` subscription received `message.part.delta` + `session.idle` + the reply text, while the
+**subdir-filtered** subscription (the gateway's exact pattern) received only heartbeats.
+
+## Prevention
+
+- **Validate every workspace/CI model id against `/v1/models` before setting it.** An unresolvable
+  id does not error cleanly — it 502s and OpenCode retries silently, producing an empty run.
+- **Always set an explicit `small_model`** in any OpenCode config that overlays the `openai`
+  provider to a custom proxy — otherwise the `gpt-5-nano` default is misrouted to the proxy and 502s.
+- **When a run "succeeds" but nothing posts, check the consumer's event subscription, not the model.**
+  Confirm the model's output via `GET /session/{id}/message` (route: `POST /session/{id}/message`
+  to send) before blaming the model/transport.
+- The diagnostic order that works: supervisor ready? → model in catalog? → egress allowed (mitmproxy
+  blocked list)? → did the model store output? → did the consumer receive the events?
+
+## Related Issues
+
+- `fro-bot/agent#766` — gateway run-core subscribes to an event stream filtered to a directory the session isn't rooted at (the real mention-loop blocker).
+- `fro-bot/agent#749` — workspace-agent OpenCode supervisor cold-boot timeout (fixed in v0.53.1; prerequisite for reaching the model).
+- `docs/solutions/integration-issues/gateway-mention-loop-supervisor-timeout-2026-06-03.md` — the prior layer (supervisor) of the same mention-loop arc.
+- `docs/solutions/integration-issues/gateway-caddy-announce-ingress-self-404-2026-06-04.md` — sibling gateway integration learning.


### PR DESCRIPTION
Documents the gateway mention-loop model/config diagnostic chain and corrects stale model-id examples that pointed operators at an invalid model.

**Compound doc** (`docs/solutions/integration-issues/`): the mention loop returned an empty thread for three independent reasons, peeled back in order:
1. `WORKSPACE_OPENCODE_MODEL` was `openai/gpt-5.5-fast` — not in cliproxy's `/v1/models` catalog, so it 502s and OpenCode retries silently into an empty run. Fixed to `openai/gpt-5.5`.
2. OpenCode's default `small_model` (`gpt-5-nano`) is misrouted through the openai→cliproxy overlay and 502s. Fixed with an explicit `small_model: anthropic/claude-haiku-4-5-20251001`.
3. The real remaining blocker is upstream `fro-bot/agent#766`: the gateway subscribes to the OpenCode event stream filtered to a directory the session isn't rooted at, so it receives none of the run's events and times out — even though the model produced the answer.

**Stale-ref fixes**: `apps/gateway/AGENTS.md` and `apps/gateway/src/deploy.ts` used `openai/gpt-5.5-fast` as the example model id, and AGENTS.md wrongly stated the value is "not a `/v1/models` catalog id" — the exact misconception behind the incident. Corrected to `openai/gpt-5.5` with a note that the id MUST be a real catalog id.
