### PR TITLE
feat(gateway): post-deploy ingress probe + announce test hardening

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3575,6 +3575,68 @@ describe('main() — post-deploy HTTPS ingress probe', () => {
     )
     expect(warnAboutCert).toHaveLength(0)
   })
+
+  test('announce enabled + never-resolving fetch → bounded by probePerAttemptTimeoutMs, warning logged, deploy succeeds', async () => {
+    // A fetch that never resolves on its own must be bounded by the per-attempt AbortController:
+    // it fires after probePerAttemptTimeoutMs, the attempt is treated as a connection error, and
+    // the probe ends warning-only so the deploy still succeeds.
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.join(' '))
+      origWarn(...args)
+    }
+
+    // fetchFn that never resolves on its own — only rejects when its signal aborts.
+    const mockFetch = mock(async (url: string, init?: RequestInit) => {
+      if (url.includes('/v1/announce')) {
+        // Hang until the AbortController fires
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal
+          if (signal) {
+            if (signal.aborted) {
+              reject(new DOMException('The operation was aborted.', 'AbortError'))
+              return
+            }
+            signal.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'))
+            })
+          }
+          // No signal → hangs forever (should not happen with the fix)
+        })
+      }
+      // Discord registration
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    let threw = false
+    try {
+      await main({
+        env: makeEnv({GATEWAY_WEBHOOK_SECRET: 'hmac-secret', GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666'}),
+        args: [],
+        fetch: mockFetch,
+        sleep: async () => {},
+        spawn: spawnFn,
+        probeAttempts: 2,
+        probeIntervalMs: 0,
+        probePerAttemptTimeoutMs: 10,
+      })
+    } catch {
+      threw = true
+    } finally {
+      console.warn = origWarn
+    }
+
+    // Deploy must NOT throw — warning-only
+    expect(threw).toBe(false)
+    // A warning about cert issuing must be logged (all attempts timed out)
+    const warnAboutCert = warnMessages.filter(
+      m => m.includes('still be issuing') || m.includes('probe did not succeed'),
+    )
+    expect(warnAboutCert.length).toBeGreaterThan(0)
+  })
 })
 
 // ─── Item 2: checksum-delta isolation test ────────────────────────────────────

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3380,6 +3380,233 @@ describe('main() — compose-up args', () => {
   })
 })
 
+// ─── Item 1: post-deploy HTTPS ingress probe (announce enabled) ───────────────
+
+describe('main() — post-deploy HTTPS ingress probe', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('announce disabled → probe fetch never called', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const fetchCalls: string[] = []
+
+    const mockFetch = mock(async (url: string) => {
+      fetchCalls.push(url)
+      // Discord registration response
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    const env = makeEnv()
+    delete (env as Record<string, string>).GATEWAY_WEBHOOK_SECRET
+    delete (env as Record<string, string>).GATEWAY_PRESENCE_CHANNEL_ID
+
+    await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    // No probe URL should have been called
+    const probeCalls = fetchCalls.filter(u => u.includes('/v1/announce'))
+    expect(probeCalls).toHaveLength(0)
+  })
+
+  test('announce enabled + HTTP 400 → healthy (no warning logged, deploy succeeds)', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.join(' '))
+      origWarn(...args)
+    }
+
+    const mockFetch = mock(async (url: string) => {
+      if (url.includes('/v1/announce')) {
+        // 400 = HMAC-gated endpoint, TLS terminated + Caddy routed → healthy
+        return new Response('Bad Request', {status: 400})
+      }
+      // Discord registration
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    try {
+      await main({
+        env: makeEnv({GATEWAY_WEBHOOK_SECRET: 'hmac-secret', GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666'}),
+        args: [],
+        fetch: mockFetch,
+        sleep: async () => {},
+        spawn: spawnFn,
+        probeAttempts: 3,
+        probeIntervalMs: 0,
+      })
+    } finally {
+      console.warn = origWarn
+    }
+
+    // Deploy must succeed (no throw)
+    // No warning about cert issuing should appear (400 = healthy)
+    // Filter specifically for the probe failure warning (not "init-certs.sh" which also contains "cert")
+    const warnAboutCert = warnMessages.filter(
+      m => m.includes('still be issuing') || m.includes('probe did not succeed'),
+    )
+    expect(warnAboutCert).toHaveLength(0)
+  })
+
+  test('announce enabled + connection error on all attempts → warning logged, deploy still succeeds', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.join(' '))
+      origWarn(...args)
+    }
+
+    const mockFetch = mock(async (url: string) => {
+      if (url.includes('/v1/announce')) {
+        throw new TypeError('fetch failed: connection refused')
+      }
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    let threw = false
+    try {
+      await main({
+        env: makeEnv({GATEWAY_WEBHOOK_SECRET: 'hmac-secret', GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666'}),
+        args: [],
+        fetch: mockFetch,
+        sleep: async () => {},
+        spawn: spawnFn,
+        probeAttempts: 3,
+        probeIntervalMs: 0,
+      })
+    } catch {
+      threw = true
+    } finally {
+      console.warn = origWarn
+    }
+
+    // Deploy must NOT throw — warning-only
+    expect(threw).toBe(false)
+    // A warning about cert issuing must be logged (the probe failure warning)
+    const warnAboutCert = warnMessages.filter(
+      m => m.includes('still be issuing') || m.includes('probe did not succeed'),
+    )
+    expect(warnAboutCert.length).toBeGreaterThan(0)
+  })
+
+  test('announce enabled + probe runs against https://<GATEWAY_HOST>/v1/announce', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const probedUrls: string[] = []
+
+    const mockFetch = mock(async (url: string) => {
+      if (url.includes('/v1/announce')) {
+        probedUrls.push(url)
+        return new Response('Bad Request', {status: 400})
+      }
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    await main({
+      env: makeEnv({GATEWAY_WEBHOOK_SECRET: 'hmac-secret', GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666'}),
+      args: [],
+      fetch: mockFetch,
+      sleep: async () => {},
+      spawn: spawnFn,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+    })
+
+    expect(probedUrls).toHaveLength(1)
+    expect(probedUrls[0]).toBe('https://gateway.fro.bot/v1/announce')
+  })
+
+  test('announce enabled + 2xx response → healthy (deploy succeeds, no warning)', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn} = makeSpawnMock()
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.join(' '))
+      origWarn(...args)
+    }
+
+    const mockFetch = mock(async (url: string) => {
+      if (url.includes('/v1/announce')) {
+        return new Response('OK', {status: 200})
+      }
+      return new Response(JSON.stringify([{name: 'ping'}]), {status: 200})
+    }) as unknown as typeof fetch
+
+    try {
+      await main({
+        env: makeEnv({GATEWAY_WEBHOOK_SECRET: 'hmac-secret', GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666'}),
+        args: [],
+        fetch: mockFetch,
+        sleep: async () => {},
+        spawn: spawnFn,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+      })
+    } finally {
+      console.warn = origWarn
+    }
+
+    // Filter specifically for the probe failure warning (not "init-certs.sh" which also contains "cert")
+    const warnAboutCert = warnMessages.filter(
+      m => m.includes('still be issuing') || m.includes('probe did not succeed'),
+    )
+    expect(warnAboutCert).toHaveLength(0)
+  })
+})
+
+// ─── Item 2: checksum-delta isolation test ────────────────────────────────────
+
+describe('computeSecretsChecksum — override+Caddyfile contribution isolates from secret-only checksum', () => {
+  test('same announce secrets: checksum WITH override+Caddyfile bytes differs from checksum of JUST secret files', async () => {
+    const {buildSecretFileList, buildComposeOverride, buildCaddyfile, computeSecretsChecksum} = await import('./deploy')
+
+    const announceEnv = makeEnv({
+      GATEWAY_WEBHOOK_SECRET: 'hmac-secret-value',
+      GATEWAY_PRESENCE_CHANNEL_ID: '111222333444555666',
+    })
+
+    // Checksum of just the secret files (same announce secrets present)
+    const secretsOnly = buildSecretFileList(announceEnv)
+    const checksumSecretsOnly = computeSecretsChecksum(secretsOnly)
+
+    // Checksum with override + Caddyfile bytes folded in (same secrets, same env)
+    const overrideContent = buildComposeOverride()
+    const caddyfileContent = buildCaddyfile(announceEnv.GATEWAY_HOST ?? 'gateway.fro.bot')
+    const checksumInput = [
+      ...secretsOnly,
+      {name: 'compose.override.yaml', content: overrideContent, required: false},
+      {name: 'Caddyfile', content: caddyfileContent, required: false},
+    ]
+    const checksumWithOverride = computeSecretsChecksum(checksumInput)
+
+    // The override/Caddyfile contribution alone must flip the checksum
+    expect(checksumWithOverride).not.toBe(checksumSecretsOnly)
+  })
+})
+
 // ─── docker compose config merge integration test ─────────────────────────────
 
 describe('docker compose config merge — override appends mounts, does not replace', () => {
@@ -3387,9 +3614,15 @@ describe('docker compose config merge — override appends mounts, does not repl
     const {buildComposeOverride} = await import('./deploy')
 
     // Check docker is available
-    const dockerCheck = Bun.spawnSync(['docker', '--version'], {stdout: 'pipe', stderr: 'pipe'})
-    if (dockerCheck.exitCode !== 0) {
-      console.warn('docker not available — skipping compose merge integration test')
+    const dockerAvailable = Boolean(Bun.which('docker'))
+    if (!dockerAvailable) {
+      if (process.env.CI) {
+        throw new Error(
+          'docker is not available in CI — the compose merge proof must not silently vanish. ' +
+            'Ensure docker is installed in the CI environment.',
+        )
+      }
+      console.warn('docker not available (non-CI) — skipping compose merge integration test')
       return
     }
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -67,6 +67,8 @@ export interface MainOpts {
   probeAttempts?: number
   /** Interval between probe attempts in ms when announce is enabled (default: 3_000). */
   probeIntervalMs?: number
+  /** Per-attempt timeout in ms for the HTTPS ingress probe (default: 5_000). */
+  probePerAttemptTimeoutMs?: number
 }
 
 export interface DeployArgs {
@@ -949,6 +951,7 @@ export async function main(opts: MainOpts = {}): Promise<void> {
   const intervalMs = opts.intervalMs ?? 3000
   const probeAttempts = opts.probeAttempts ?? 5
   const probeIntervalMs = opts.probeIntervalMs ?? 3_000
+  const probePerAttemptTimeoutMs = opts.probePerAttemptTimeoutMs ?? 5_000
 
   const {dryRun: isDryRun, forceRecreate} = parseDeployArgs(args)
 
@@ -1248,14 +1251,24 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     // Phase 9b: Post-deploy HTTPS ingress probe — warning-only, only when announce is enabled.
     // The endpoint is HMAC-gated: an unsigned POST returns HTTP 400, which proves TLS terminated
     // and Caddy routed correctly. Any 2xx or 4xx is treated as healthy. Connection/TLS errors
-    // mean the cert is still issuing (ACME can take 30-60s+); we warn and let the deploy succeed.
+    // (including per-attempt AbortController timeout) mean the cert is still issuing
+    // (ACME can take 30-60s+); we warn and let the deploy succeed.
+    // Each attempt is bounded by probePerAttemptTimeoutMs via AbortController (mirrors pollRegistration).
     if (announceEnabled) {
       const probeUrl = `https://${host}/v1/announce`
       console.warn(`\u001B[1;34m==>\u001B[0m Probing HTTPS ingress: ${probeUrl}`)
       let probeOk = false
       for (let attempt = 1; attempt <= probeAttempts; attempt++) {
+        const ac = new AbortController()
+        const timer = setTimeout(() => ac.abort(), probePerAttemptTimeoutMs)
         try {
-          const response = await fetchFn(probeUrl)
+          const response = await fetchFn(probeUrl, {
+            method: 'POST',
+            body: '{}',
+            headers: {'Content-Type': 'application/json'},
+            signal: ac.signal,
+          })
+          clearTimeout(timer)
           const status = response.status
           // Any HTTP response (2xx or 4xx) proves TLS terminated + Caddy routed → healthy.
           // 400 is the expected response for an unsigned POST to the HMAC-gated endpoint.
@@ -1264,7 +1277,8 @@ export async function main(opts: MainOpts = {}): Promise<void> {
             break
           }
         } catch {
-          // Connection/TLS error — cert may still be issuing; retry
+          clearTimeout(timer)
+          // Connection/TLS error or AbortError from per-attempt timeout — cert may still be issuing; retry
         }
         if (attempt < probeAttempts) {
           await sleepFn(probeIntervalMs)

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -63,6 +63,10 @@ export interface MainOpts {
   spawn?: SpawnFn
   maxAttempts?: number
   intervalMs?: number
+  /** Number of HTTPS ingress probe attempts when announce is enabled (default: 5). */
+  probeAttempts?: number
+  /** Interval between probe attempts in ms when announce is enabled (default: 3_000). */
+  probeIntervalMs?: number
 }
 
 export interface DeployArgs {
@@ -943,6 +947,8 @@ export async function main(opts: MainOpts = {}): Promise<void> {
   const spawnFn = opts.spawn ?? defaultSpawn
   const maxAttempts = opts.maxAttempts ?? 10
   const intervalMs = opts.intervalMs ?? 3000
+  const probeAttempts = opts.probeAttempts ?? 5
+  const probeIntervalMs = opts.probeIntervalMs ?? 3_000
 
   const {dryRun: isDryRun, forceRecreate} = parseDeployArgs(args)
 
@@ -1238,6 +1244,41 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       maxAttempts,
       intervalMs,
     })
+
+    // Phase 9b: Post-deploy HTTPS ingress probe — warning-only, only when announce is enabled.
+    // The endpoint is HMAC-gated: an unsigned POST returns HTTP 400, which proves TLS terminated
+    // and Caddy routed correctly. Any 2xx or 4xx is treated as healthy. Connection/TLS errors
+    // mean the cert is still issuing (ACME can take 30-60s+); we warn and let the deploy succeed.
+    if (announceEnabled) {
+      const probeUrl = `https://${host}/v1/announce`
+      console.warn(`\u001B[1;34m==>\u001B[0m Probing HTTPS ingress: ${probeUrl}`)
+      let probeOk = false
+      for (let attempt = 1; attempt <= probeAttempts; attempt++) {
+        try {
+          const response = await fetchFn(probeUrl)
+          const status = response.status
+          // Any HTTP response (2xx or 4xx) proves TLS terminated + Caddy routed → healthy.
+          // 400 is the expected response for an unsigned POST to the HMAC-gated endpoint.
+          if (status >= 200 && status < 500) {
+            probeOk = true
+            break
+          }
+        } catch {
+          // Connection/TLS error — cert may still be issuing; retry
+        }
+        if (attempt < probeAttempts) {
+          await sleepFn(probeIntervalMs)
+        }
+      }
+      if (probeOk) {
+        console.warn(`\u001B[1;32m✓\u001B[0m HTTPS ingress probe succeeded: ${probeUrl}`)
+      } else {
+        console.warn(
+          `\u001B[1;33m[warn]\u001B[0m HTTPS ingress probe did not succeed — cert may still be issuing. ` +
+            `Verify with: curl -sI ${probeUrl}`,
+        )
+      }
+    }
 
     // Phase 10: Persist checksum AFTER compose + registration succeed
     // If either phase 8 or 9 threw, we never reach here — prior checksum stays in place


### PR DESCRIPTION
Hardens the opt-in announce/presence ingress shipped in #409. Closes #410.

- **Post-deploy HTTPS ingress probe (when announce enabled).** After `docker compose up`, probe `https://<gateway-host>/v1/announce`. Any HTTP response (the HMAC-gated endpoint returns 400 to an unsigned request) proves TLS terminated and Caddy routed → healthy. Connection/TLS errors retry a few times, then log a warning and let the deploy **succeed** — first-enable ACME issuance can take 30-60s+, so a hard failure would flag a healthy deploy. Warning-only, mirroring the umami deploy's public-probe pattern; `fetch`/`sleep` are injected for tests. No probe runs when announce is disabled.
- **Checksum-delta isolation test.** Proves the override + Caddyfile bytes alone flip the secrets checksum (so toggling announce forces `--force-recreate`), independent of the secret files.
- **Merge-test CI guard.** The live `docker compose config` merge proof now fails in CI when Docker is unavailable instead of passing vacuously.

No changeset — `apps/gateway/` deploy infra, not the published CLI package. 1147 tests pass, type-check and lint clean.
