### PR TITLE
feat(gateway): build images in CI and pull on the droplet instead of building on-host

### DIFF
--- a/.github/workflows/deploy-gateway.yaml
+++ b/.github/workflows/deploy-gateway.yaml
@@ -59,7 +59,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      gateway_digest: ${{ steps.build-gateway.outputs.digest }}
+      workspace_digest: ${{ steps.build-workspace.outputs.digest }}
+    steps:
+      - name: Checkout infra
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Read upstream ref
+        id: upstream
+        run: echo "ref=$(jq -r .ref apps/gateway/upstream.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout fro-bot/agent
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: fro-bot/agent
+          ref: ${{ steps.upstream.outputs.ref }}
+          path: upstream-agent
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push gateway image
+        id: build-gateway
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: upstream-agent
+          file: upstream-agent/deploy/gateway.Dockerfile
+          push: true
+          tags: ghcr.io/marcusrbrown/infra-gateway:${{ steps.upstream.outputs.ref }}
+
+      - name: Build and push workspace image
+        id: build-workspace
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: upstream-agent
+          file: upstream-agent/deploy/workspace.Dockerfile
+          push: true
+          tags: ghcr.io/marcusrbrown/infra-workspace:${{ steps.upstream.outputs.ref }}
+
   deploy-gateway:
+    needs: build-images
     runs-on: ubuntu-latest
     environment: gateway
     steps:
@@ -142,3 +191,5 @@ jobs:
           GATEWAY_TRIGGER_ROLE_ID: ${{ secrets.GATEWAY_TRIGGER_ROLE_ID }}
           GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}
           GATEWAY_PRESENCE_CHANNEL_ID: ${{ secrets.GATEWAY_PRESENCE_CHANNEL_ID }}
+          GATEWAY_IMAGE_DIGEST: ${{ needs.build-images.outputs.gateway_digest }}
+          WORKSPACE_IMAGE_DIGEST: ${{ needs.build-images.outputs.workspace_digest }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -89,6 +89,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       needs.detect-changes.outputs.gateway == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy-gateway.yaml
     secrets:
       GATEWAY_SSH_KEY: ${{ secrets.GATEWAY_SSH_KEY }}

--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -184,7 +184,7 @@ The deploy depends on CI and GHCR availability. If CI or GHCR is unavailable dur
 
 **Never run `docker compose up --build` on the droplet.** The `compose.override.yaml` image pins make GHCR the source of truth regardless, but building on the 1vCPU/2GB droplet exhausts RAM and thrashes swap — this is the failure mode the off-droplet build flow exists to prevent. The on-droplet build fallback is intentionally removed; the workstation build above is the correct emergency path.
 
-The deploy now depends on CI + GHCR availability + pull working. This is a deliberate trade: the on-droplet build is the hazard being removed, so keeping it as a fallback would keep the hazard.
+The deploy depends on CI + GHCR availability + pull working. This is a deliberate trade: the on-droplet build is the hazard being removed, so keeping it as a fallback would keep the hazard.
 
 ### GitHub App (`/fro-bot add-project`)
 
@@ -224,11 +224,11 @@ The override is a working-tree file re-materialized on every deploy when the inp
 - **Auth:** the daemon verifies the HMAC signature, enforces a replay cache, and applies a rate limiter. Caddy adds TLS termination.
 - **No IP allowlist:** GitHub Actions egress ranges are too dynamic to pin reliably. HMAC + TLS is the full auth boundary.
 - **Secret materialization:** `GATEWAY_WEBHOOK_SECRET` is written to the droplet via SSH stdin only — never via argv.
-- **Path isolation:** Caddy uses a named `@announce` matcher (`path /v1/announce`) with a default `respond 404`. The catch-all does not shadow ACME challenge paths (Caddy uses TLS-ALPN-01 on `:443` by default, which does not touch HTTP path routing).
+- **Path isolation:** Caddy uses a `handle /v1/announce { ... }` block with a catch-all `handle { respond 404 }`. The catch-all does not shadow ACME challenge paths (Caddy uses TLS-ALPN-01 on `:443` by default, which does not touch HTTP path routing).
 
 ### Rollback / disabling
 
-Remove both `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` from the `gateway` GitHub Environment and redeploy. The deploy's `git clean -xfd` removes the `compose.override.yaml` (a working-tree file); `--remove-orphans` retires the now-undeclared Caddy container; the checksum flip (override bytes gone) triggers `--force-recreate`. After the deploy, verify with `docker compose config` on the droplet — the Caddy service must not appear.
+Remove both `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` from the `gateway` GitHub Environment and redeploy. The `compose.override.yaml` is always rewritten on deploy — when announce is disabled, the override carries only the image digest pins (no Caddy/announce sections). `git clean -xfd` removes the `Caddyfile` (a working-tree file written only when announce is enabled); `--remove-orphans` retires the now-undeclared Caddy container; the checksum flip (override bytes changed, Caddyfile gone) triggers `--force-recreate`. After the deploy, verify with `docker compose config` on the droplet — the Caddy service must not appear.
 
 ### Caddy volume guardrail
 

--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -43,8 +43,8 @@ The `deploy-gateway` job declares `needs: build-images`. A build or push failure
 9. **Registration poll** — `GET /applications/{app_id}/guilds/{guild_id}/commands` on the Discord API. Polls Discord registration with ~90s default budget (10 attempts × (3s interval + 6s per-attempt timeout); defaults from `apps/gateway/src/deploy.ts:344-368`). 429 honors `Retry-After` and doesn't count against the attempt budget (each 429 retry adds up to 60s; pathological all-429 ceiling ~11 min). 401/403/404 abort immediately with token-sanitized errors. 5xx retries.
 10. **Running image digest verification** — for each of `gateway` and `workspace`, the deploy reads the running container's `RepoDigests` and asserts they match the CI-pushed digest. This confirms the droplet is running the GHCR artifact, not a stale or locally-built image. Throws if the digest does not match — deploy fails loudly. Manual verification:
     ```bash
-    docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory /opt/gateway/deploy ps -q gateway)
-    docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory /opt/gateway/deploy ps -q workspace)
+    docker inspect --format '{{json .RepoDigests}}' "$(docker inspect --format '{{.Image}}' "$(docker compose --project-directory /opt/gateway/deploy ps -q gateway)")"
+    docker inspect --format '{{json .RepoDigests}}' "$(docker inspect --format '{{.Image}}' "$(docker compose --project-directory /opt/gateway/deploy ps -q workspace)")"
     ```
 11. **Checksum write** — `/opt/gateway/.secrets-checksum` is written only after compose + registration + digest verification all succeed. If any step fails mid-rotation, the old checksum persists and the next deploy force-recreates again.
 

--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -15,14 +15,38 @@ The deploy script materializes secrets as files on the droplet (never via argv),
 
 ## DEPLOY FLOW
 
+The deploy runs in two stages: a CI `build-images` job builds and pushes the `gateway` and `workspace` Docker images to GHCR, then the `deploy-gateway` job SSHes to the droplet to pull those images and bring up the stack. The droplet never builds images — it only pulls prebuilt artifacts.
+
+### CI: build-images job
+
+Runs on `ubuntu-latest` with `packages: write` permission (job-scoped only; the deploy job is package-read-only). Steps:
+
+1. Reads the pinned `ref` from `apps/gateway/upstream.json`.
+2. Checks out `fro-bot/agent` at that ref.
+3. Logs in to `ghcr.io` with `GITHUB_TOKEN`.
+4. Builds `deploy/gateway.Dockerfile` (context: upstream root) and pushes to `ghcr.io/marcusrbrown/infra-gateway:<ref>`. Captures the pushed digest from `build-push-action` outputs.
+5. Builds `deploy/workspace.Dockerfile` (context: upstream root) and pushes to `ghcr.io/marcusrbrown/infra-workspace:<ref>`. Captures the pushed digest.
+6. Exposes both digests as job outputs (`gateway_digest`, `workspace_digest`).
+
+The `deploy-gateway` job declares `needs: build-images`. A build or push failure blocks the deploy entirely — the old stack stays live.
+
+### Droplet: deploy-gateway job
+
 1. **Validate host** — `validateGatewayHost` rejects `-`-prefixed values and characters outside the allowed alphabet. SSH treats `-`-prefixed hostnames as flags (including `-oProxyCommand=`); this check is mandatory before any SSH invocation.
-2. **Checksum computation** — SHA-256 of all secret values is computed locally. The result is compared against `/opt/gateway/.secrets-checksum` on the droplet. If the checksums differ, `--force-recreate` is added to `docker compose up` so containers pick up the new secret files. If they match, containers are still restarted by `docker compose up -d --wait` but without `--force-recreate` (faster). In both cases the deploy continues — there is no early exit. The checksum file lives outside the deploy clone so `git clean -xfd` on subsequent deploys doesn't wipe it.
-3. **Source materialization** — SSH to the droplet; clone or fetch `fro-bot/agent` at the pinned ref from `upstream.json`, then `git reset --hard && git clean -xfd` to the pinned SHA.
+2. **Checksum computation** — SHA-256 of all secret values (including the `compose.override.yaml` content) is computed locally. The result is compared against `/opt/gateway/.secrets-checksum` on the droplet. If the checksums differ, `--force-recreate` is added to `docker compose up` so containers pick up the new secret files. If they match, containers are still restarted by `docker compose up -d --wait` but without `--force-recreate` (faster). In both cases the deploy continues — there is no early exit. The checksum file lives outside the deploy clone so `git clean -xfd` on subsequent deploys doesn't wipe it.
+3. **Source materialization** — SSH to the droplet; clone or fetch `fro-bot/agent` at the pinned ref from `upstream.json`, then `git reset --hard && git clean -xfd` to the pinned SHA. The upstream checkout is still needed for `compose.yaml`, `init-certs.sh`, and the Dockerfiles compose references — but the droplet does not build from them.
 4. **Secret files** — 11 required files written atomically under `/opt/gateway/deploy/secrets/` (`discord-token`, `discord-application-id`, `discord-guild-id`, `aws-access-key-id`, `aws-secret-access-key`, `s3-bucket`, `s3-region`, `github-app-id`, `github-app-private-key`, `workspace-opencode-token`, `workspace-opencode-auth`) plus optional-shaped files (`s3-endpoint`, `aws-session-token`, `discord-privileged-intents`, `workspace-opencode-url`, and `gateway-trigger-role-id` — written as 0-byte placeholders when unset, though `GATEWAY_TRIGGER_ROLE_ID` is enforced non-empty via `REQUIRED_ENV_VARS`, so the mention-loop authz gate fails closed rather than opening to all guild members). The `/opt/gateway/deploy/.env` carries `OBJECT_STORE_HOSTS` (computed from `S3_BUCKET`/`S3_REGION`/`S3_ENDPOINT`), `WORKSPACE_OPENCODE_MODEL`, `WORKSPACE_OPENCODE_CONFIG` — the latter is JSON-validated (via `JSON.parse`, not the shell-metachar guard) and `$`→`$$`-escaped so docker-compose `${VAR}` interpolation passes the JSON through intact — and `WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot,models.dev` (v0.52.1+ requirement; consumed by `deploy/mitmproxy/allowlist.py` to allow the sandboxed workspace to reach the cliproxy OpenCode proxy and the OpenCode model catalog through mitmproxy; fail-closed if unset). Secret bytes enter via SSH stdin only — never via argv. Filenames on disk are kebab-case; the compose contract maps each to `/run/secrets/<snake_case>` and exposes via `${NAME}_FILE` env vars. The GitHub App credentials come from the `GH_APP_ID` / `GH_APP_PRIVATE_KEY` environment secrets (GitHub reserves the `GITHUB_` prefix for secret names) and materialize to the upstream-fixed `github-app-id` / `github-app-private-key` files. See `docs/runbooks/discord-token-lifecycle.md` for the full mapping table.
-5. **CA bootstrap** — `init-certs.sh` runs on the droplet (idempotent; skips if the CA already exists in the `mitmproxy-certs` named volume).
-6. **Compose up** — `docker compose up -d --wait --wait-timeout 120`. mitmproxy starts first, then the gateway daemon.
-7. **Registration poll** — `GET /applications/{app_id}/guilds/{guild_id}/commands` on the Discord API. Polls Discord registration with ~90s default budget (10 attempts × (3s interval + 6s per-attempt timeout); defaults from `apps/gateway/src/deploy.ts:344-368`). 429 honors `Retry-After` and doesn't count against the attempt budget (each 429 retry adds up to 60s; pathological all-429 ceiling ~11 min). 401/403/404 abort immediately with token-sanitized errors. 5xx retries.
-8. **Checksum write** — `/opt/gateway/.secrets-checksum` is written only after compose + registration both succeed. If either fails mid-rotation, the old checksum persists and the next deploy force-recreates again.
+5. **Compose override** — `compose.override.yaml` is written on every deploy. It pins `gateway.image` to `ghcr.io/marcusrbrown/infra-gateway@<digest>` and `workspace.image` to `ghcr.io/marcusrbrown/infra-workspace@<digest>` using the exact digests from the `build-images` job. Docker Compose deep-merges the override; the upstream `build:` stanzas remain present but are inert without `--build`. When announce is enabled, the override also adds the Caddy service and announce secret wiring (see [Announce/presence webhook](#announcepresence-webhook)).
+6. **CA bootstrap** — `init-certs.sh` runs on the droplet (idempotent; skips if the CA already exists in the `mitmproxy-certs` named volume).
+7. **Pull images** — `docker compose --project-directory /opt/gateway/deploy pull` fetches the pinned GHCR images by digest. A missing or unpullable image errors here and does not fall back to an on-droplet build.
+8. **Compose up** — `docker compose --project-directory /opt/gateway/deploy up -d --no-build --wait --wait-timeout 120 --remove-orphans` (plus `--force-recreate` when the checksum changed or `--force-recreate` was passed). `mitmproxy` starts first, then the gateway daemon. `--no-build` is explicit — the droplet never builds images.
+9. **Registration poll** — `GET /applications/{app_id}/guilds/{guild_id}/commands` on the Discord API. Polls Discord registration with ~90s default budget (10 attempts × (3s interval + 6s per-attempt timeout); defaults from `apps/gateway/src/deploy.ts:344-368`). 429 honors `Retry-After` and doesn't count against the attempt budget (each 429 retry adds up to 60s; pathological all-429 ceiling ~11 min). 401/403/404 abort immediately with token-sanitized errors. 5xx retries.
+10. **Running image digest verification** — for each of `gateway` and `workspace`, the deploy reads the running container's `RepoDigests` and asserts they match the CI-pushed digest. This confirms the droplet is running the GHCR artifact, not a stale or locally-built image. Throws if the digest does not match — deploy fails loudly. Manual verification:
+    ```bash
+    docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory /opt/gateway/deploy ps -q gateway)
+    docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory /opt/gateway/deploy ps -q workspace)
+    ```
+11. **Checksum write** — `/opt/gateway/.secrets-checksum` is written only after compose + registration + digest verification all succeed. If any step fails mid-rotation, the old checksum persists and the next deploy force-recreates again.
 
 ## DAY-2 OPERATIONS
 
@@ -100,8 +124,67 @@ After provisioning: commit the updated `.github/known_hosts`.
 | `DISCORD_PRIVILEGED_INTENTS` | — | Opt-in privileged intents (e.g. `MessageContent`); materializes to `discord-privileged-intents`, empty = baseline intents |
 | `GATEWAY_WEBHOOK_SECRET` | opt-in† | HMAC signing key for the announce webhook — strong random value; materialized via SSH stdin, never argv. Set together with `GATEWAY_PRESENCE_CHANNEL_ID` to enable the announce endpoint; leave both unset to keep the gateway outbound-only. Setting exactly one fails the deploy before any SSH. |
 | `GATEWAY_PRESENCE_CHANNEL_ID` | opt-in† | Discord channel ID where the daemon posts presence embeds as the Fro Bot user. Set together with `GATEWAY_WEBHOOK_SECRET`. |
+| `GATEWAY_IMAGE_DIGEST` | CI-injected | `sha256:<digest>` of the `ghcr.io/marcusrbrown/infra-gateway` image pushed by the `build-images` job. Threaded from `needs.build-images.outputs.gateway_digest`. Required for the deploy to pin and verify the running image. For a local/break-glass deploy, supply manually (see [Break-glass runbook](#break-glass-runbook)). |
+| `WORKSPACE_IMAGE_DIGEST` | CI-injected | `sha256:<digest>` of the `ghcr.io/marcusrbrown/infra-workspace` image pushed by the `build-images` job. Threaded from `needs.build-images.outputs.workspace_digest`. Required for the deploy to pin and verify the running image. For a local/break-glass deploy, supply manually. |
 
 †Both-or-neither: set both to enable the announce/presence webhook; set neither to disable. Setting exactly one is an error — the deploy fails fast with a message naming the missing input, before any SSH connection is made.
+
+## GHCR IMAGES
+
+The `gateway` and `workspace` images are published to:
+
+- `ghcr.io/marcusrbrown/infra-gateway` — built from `fro-bot/agent` `deploy/gateway.Dockerfile`
+- `ghcr.io/marcusrbrown/infra-workspace` — built from `fro-bot/agent` `deploy/workspace.Dockerfile`
+
+Both packages are **public**. The upstream Dockerfiles were audited before first publish: all secrets are runtime bind-mounts into `/run/secrets/...` — no `ARG`/`ENV`/`COPY` of secret material is baked into the image layers. The source (`fro-bot/agent`) is itself public. Public visibility means the droplet pulls with no authentication required.
+
+Tags (`:<ref>`) are pushed for human readability. The deploy pins and verifies by **digest** (`@sha256:<digest>`), not by tag — GHCR tags are mutable, so tag-based verification would be circular. Digest pull is immutable and makes the running-image check a true identity assertion.
+
+The `build-images` CI job holds `packages: write` permission (job-scoped only). The `deploy-gateway` job is package-read-only.
+
+## BREAK-GLASS RUNBOOK
+
+The deploy depends on CI and GHCR availability. If CI or GHCR is unavailable during an incident and the droplet needs a redeploy:
+
+1. **Build and push from a workstation** (which has ample RAM — this is the off-droplet build done by hand):
+   ```bash
+   # Check out fro-bot/agent at the pinned ref
+   REF=$(jq -r .ref apps/gateway/upstream.json)
+   git clone --depth 1 --branch "$REF" https://github.com/fro-bot/agent.git /tmp/fro-bot-agent
+
+   # Log in to GHCR
+   echo "$GITHUB_TOKEN" | docker login ghcr.io -u <your-github-username> --password-stdin
+
+   # Build and push gateway image; capture the digest
+   GATEWAY_DIGEST=$(docker buildx build \
+     --platform linux/amd64 \
+     --file /tmp/fro-bot-agent/deploy/gateway.Dockerfile \
+     --push \
+     --iidfile /tmp/gateway-iid.txt \
+     --metadata-file /tmp/gateway-meta.json \
+     /tmp/fro-bot-agent \
+     && jq -r '."containerimage.digest"' /tmp/gateway-meta.json)
+
+   # Build and push workspace image; capture the digest
+   WORKSPACE_DIGEST=$(docker buildx build \
+     --platform linux/amd64 \
+     --file /tmp/fro-bot-agent/deploy/workspace.Dockerfile \
+     --push \
+     --metadata-file /tmp/workspace-meta.json \
+     /tmp/fro-bot-agent \
+     && jq -r '."containerimage.digest"' /tmp/workspace-meta.json)
+   ```
+
+2. **Run the local deploy** with the digests you just captured:
+   ```bash
+   GATEWAY_IMAGE_DIGEST="$GATEWAY_DIGEST" \
+   WORKSPACE_IMAGE_DIGEST="$WORKSPACE_DIGEST" \
+   bunx @marcusrbrown/infra gateway deploy --local
+   ```
+
+**Never run `docker compose up --build` on the droplet.** The `compose.override.yaml` image pins make GHCR the source of truth regardless, but building on the 1vCPU/2GB droplet exhausts RAM and thrashes swap — this is the failure mode the off-droplet build flow exists to prevent. The on-droplet build fallback is intentionally removed; the workstation build above is the correct emergency path.
+
+The deploy now depends on CI + GHCR availability + pull working. This is a deliberate trade: the on-droplet build is the hazard being removed, so keeping it as a fallback would keep the hazard.
 
 ### GitHub App (`/fro-bot add-project`)
 
@@ -213,6 +296,7 @@ For the full operator-facing rotation and emergency revocation procedure (includ
 - **Never pass secret bytes via argv** — `writeRemoteFile` pipes bytes through SSH stdin only. `--body <value>` patterns are banned.
 - **Never skip `validateGatewayHost`** — it rejects `-`-prefixed values and characters outside the allowed alphabet. SSH treats `-`-prefixed hostnames as flags (including `-oProxyCommand=`).
 - **Never restart the gateway in-place to rotate the CA** — workspaces lose trust in the egress proxy. Restore from backup instead.
+- **Never run `docker compose up --build` on the droplet** — building the `gateway` or `workspace` images on the 1vCPU/2GB droplet exhausts RAM and thrashes swap while the live stack is running. The deploy uses `docker compose pull` + `up -d --no-build`; the `compose.override.yaml` image pins make GHCR the source of truth. For emergency rebuilds, build from a workstation and push to GHCR (see [Break-glass runbook](#break-glass-runbook)).
 - **Never validate `WORKSPACE_OPENCODE_CONFIG` with the shell-metachar guard** — it is JSON (`"`, `$`, `\` are required) and `SHELL_METACHAR_RE` would reject every valid config. Validate it with `JSON.parse` + newline/size checks; `SHELL_METACHAR_RE` is only for simple values like `WORKSPACE_OPENCODE_MODEL`.
 - **Never bind-mount config files outside `/opt/gateway/deploy/secrets/`** — `init-certs.sh` and `docker-compose.yaml` are upstream's; this repo materializes secrets only.
 - **Never run `pollRegistration` with an unbounded per-attempt timeout** — each fetch is wrapped in an `AbortController` with `perAttemptTimeoutMs` (defaults to `max(6000, intervalMs * 2)`).

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -4,6 +4,11 @@ import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, mock, test} from 'bun:test'
 
+// ─── Test digest fixtures ─────────────────────────────────────────────────────
+
+const GATEWAY_DIGEST = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const WORKSPACE_DIGEST = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function makeStream(content: string): ReadableStream<Uint8Array> {
@@ -58,6 +63,8 @@ function makeEnv(overrides: Record<string, string> = {}): Record<string, string>
     WORKSPACE_OPENCODE_MODEL: 'anthropic/claude-sonnet-4-6',
     WORKSPACE_OPENCODE_CONFIG: '{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}',
     GATEWAY_TRIGGER_ROLE_ID: '123456789012345678',
+    GATEWAY_IMAGE_DIGEST: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    WORKSPACE_IMAGE_DIGEST: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     PATH: '/usr/bin:/bin',
     HOME: '/root',
     ...overrides,
@@ -73,13 +80,28 @@ function writeUpstreamJson(content: object): string {
   return path
 }
 
-/** Build a spawn mock that records calls and returns success by default. */
+/**
+ * Build a spawn mock that records calls and returns success by default.
+ * docker inspect commands return a JSON array containing the expected digest
+ * so assertRunningImageDigest passes in tests that don't override the handler.
+ */
 function makeSpawnMock(handler?: (cmd: string[]) => SpawnResult | undefined): {spawnFn: SpawnFn; calls: string[][]} {
   const calls: string[][] = []
   const spawnFn: SpawnFn = (cmd, _opts) => {
     calls.push(cmd)
     const custom = handler?.(cmd)
-    return custom ?? makeSpawnResult()
+    if (custom !== undefined) return custom
+    // Return valid RepoDigests JSON for docker inspect so assertRunningImageDigest passes
+    const cmdStr = cmd.join(' ')
+    if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+      // Return both digests so either gateway or workspace check passes
+      const digests = [
+        `ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`,
+        `ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`,
+      ]
+      return makeSpawnResult({stdout: JSON.stringify(digests)})
+    }
+    return makeSpawnResult()
   }
   return {spawnFn, calls}
 }
@@ -593,9 +615,19 @@ describe('main', () => {
   })
 
   test('edge case (secrets unchanged): checksum matches → no --force-recreate', async () => {
-    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+    const {main, buildSecretFileList, computeSecretsChecksum, buildComposeOverride} = await import('./deploy')
     const env = makeEnv()
-    const expectedChecksum = computeSecretsChecksum(buildSecretFileList(env))
+    const secrets = buildSecretFileList(env)
+    // Override is always included in checksum now
+    const overrideContent = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    const expectedChecksum = computeSecretsChecksum([
+      ...secrets,
+      {name: 'compose.override.yaml', content: overrideContent, required: false},
+    ])
 
     const {spawnFn, calls} = makeSpawnMock(cmd => {
       const cmdStr = cmd.join(' ')
@@ -608,10 +640,10 @@ describe('main', () => {
 
     await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
 
-    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCall).toBeDefined()
-    expect(composeCall?.join(' ')).not.toContain('--force-recreate')
-    expect(composeCall?.join(' ')).toContain('--build')
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall).toBeDefined()
+    expect(upCall?.join(' ')).not.toContain('--force-recreate')
+    expect(upCall?.join(' ')).not.toContain('--build')
   })
 
   test('edge case (secrets changed): checksum differs → --force-recreate added', async () => {
@@ -628,16 +660,25 @@ describe('main', () => {
 
     await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
 
-    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCall).toBeDefined()
-    expect(composeCall?.join(' ')).toContain('--force-recreate')
-    expect(composeCall?.join(' ')).toContain('--build')
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall).toBeDefined()
+    expect(upCall?.join(' ')).toContain('--force-recreate')
+    expect(upCall?.join(' ')).not.toContain('--build')
   })
 
-  test('rebuilds the image from pinned source on every deploy regardless of --force-recreate', async () => {
-    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+  test('pulls prebuilt GHCR image on every deploy regardless of --force-recreate', async () => {
+    const {main, buildSecretFileList, computeSecretsChecksum, buildComposeOverride} = await import('./deploy')
     const env = makeEnv()
-    const expectedChecksum = computeSecretsChecksum(buildSecretFileList(env))
+    const secrets = buildSecretFileList(env)
+    const overrideContent = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    const expectedChecksum = computeSecretsChecksum([
+      ...secrets,
+      {name: 'compose.override.yaml', content: overrideContent, required: false},
+    ])
 
     // Secrets unchanged path — no --force-recreate
     const {spawnFn: spawnFnA, calls: callsA} = makeSpawnMock(cmd => {
@@ -650,12 +691,12 @@ describe('main', () => {
     const mockFetchA = makeDiscordFetch([{name: 'ping'}])
     await main({env, args: [], fetch: mockFetchA, sleep: async () => {}, spawn: spawnFnA})
 
-    const composeCallA = callsA.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCallA).toBeDefined()
-    expect(composeCallA?.join(' ')).toContain('--build')
-    expect(composeCallA?.join(' ')).not.toContain('--force-recreate')
+    const upCallA = callsA.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCallA).toBeDefined()
+    expect(upCallA?.join(' ')).toContain('--no-build')
+    expect(upCallA?.join(' ')).not.toContain('--force-recreate')
 
-    // Secrets changed path — --force-recreate present alongside --build
+    // Secrets changed path — --force-recreate present alongside --no-build
     const {spawnFn: spawnFnB, calls: callsB} = makeSpawnMock(cmd => {
       const cmdStr = cmd.join(' ')
       if (cmdStr.includes('.secrets-checksum') && cmdStr.includes('cat')) {
@@ -666,16 +707,25 @@ describe('main', () => {
     const mockFetchB = makeDiscordFetch([{name: 'ping'}])
     await main({env: makeEnv(), args: [], fetch: mockFetchB, sleep: async () => {}, spawn: spawnFnB})
 
-    const composeCallB = callsB.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCallB).toBeDefined()
-    expect(composeCallB?.join(' ')).toContain('--build')
-    expect(composeCallB?.join(' ')).toContain('--force-recreate')
+    const upCallB = callsB.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCallB).toBeDefined()
+    expect(upCallB?.join(' ')).toContain('--no-build')
+    expect(upCallB?.join(' ')).toContain('--force-recreate')
   })
 
   test('readRemoteChecksum: SSH exits 0 with checksum → returns checksum string', async () => {
-    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+    const {main, buildSecretFileList, computeSecretsChecksum, buildComposeOverride} = await import('./deploy')
     const env = makeEnv()
-    const expectedChecksum = computeSecretsChecksum(buildSecretFileList(env))
+    const secrets = buildSecretFileList(env)
+    const overrideContent = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    const expectedChecksum = computeSecretsChecksum([
+      ...secrets,
+      {name: 'compose.override.yaml', content: overrideContent, required: false},
+    ])
 
     const mockFetch = makeDiscordFetch([{name: 'ping'}])
 
@@ -688,8 +738,8 @@ describe('main', () => {
       return undefined
     })
     await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
-    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCall?.join(' ')).not.toContain('--force-recreate')
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall?.join(' ')).not.toContain('--force-recreate')
   })
 
   test('readRemoteChecksum: SSH exits 0 with empty stdout (first deploy) → returns empty string, no force-recreate suppressed', async () => {
@@ -707,9 +757,9 @@ describe('main', () => {
 
     await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
 
-    // Empty prior checksum != current checksum → --force-recreate
-    const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))
-    expect(composeCall?.join(' ')).toContain('--force-recreate')
+    // Empty prior checksum != current checksum → --force-recreate on the up command
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall?.join(' ')).toContain('--force-recreate')
   })
 
   test('readRemoteChecksum: SSH exits non-zero → throws with exit code and stderr', async () => {
@@ -2950,51 +3000,57 @@ describe('buildSecretFileList — normalizePemPrivateKey wiring', () => {
 
 // ─── buildComposeOverride ─────────────────────────────────────────────────────
 
+const OVERRIDE_OPTS_ANNOUNCE = {
+  gatewayDigest: GATEWAY_DIGEST,
+  workspaceDigest: WORKSPACE_DIGEST,
+  announceEnabled: true,
+}
+
 describe('buildComposeOverride', () => {
   test('includes caddy service with 80:80 and 443:443 port bindings', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('80:80')
     expect(yaml).toContain('443:443')
   })
 
   test('caddy service joins gateway-net network', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('gateway-net')
   })
 
   test('caddy service has named caddy_data and caddy_config volumes', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('caddy_data')
     expect(yaml).toContain('caddy_config')
   })
 
   test('caddy service depends_on gateway', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('depends_on')
     expect(yaml).toContain('gateway')
   })
 
   test('caddy service mounts Caddyfile read-only', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('Caddyfile')
     expect(yaml).toContain(':ro')
   })
 
   test('gateway service gets GATEWAY_WEBHOOK_SECRET_FILE env entry', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('GATEWAY_WEBHOOK_SECRET_FILE')
     expect(yaml).toContain('/run/secrets/gateway_webhook_secret')
   })
 
   test('gateway service gets GATEWAY_PRESENCE_CHANNEL_ID_FILE env entry', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('GATEWAY_PRESENCE_CHANNEL_ID_FILE')
     expect(yaml).toContain('/run/secrets/gateway_presence_channel_id')
   })
@@ -3002,26 +3058,26 @@ describe('buildComposeOverride', () => {
   test('gateway service gets two announce bind-mount volumes with correct source paths', async () => {
     const {buildComposeOverride, ANNOUNCE_WEBHOOK_SECRET_FILE, ANNOUNCE_PRESENCE_CHANNEL_FILE} =
       await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain(`./secrets/${ANNOUNCE_WEBHOOK_SECRET_FILE}`)
     expect(yaml).toContain(`./secrets/${ANNOUNCE_PRESENCE_CHANNEL_FILE}`)
   })
 
   test('gateway service bind-mounts target /run/secrets/gateway_webhook_secret', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('/run/secrets/gateway_webhook_secret')
   })
 
   test('gateway service bind-mounts target /run/secrets/gateway_presence_channel_id', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('/run/secrets/gateway_presence_channel_id')
   })
 
   test('top-level volumes block declares caddy_data and caddy_config', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     // Top-level volumes section must exist
     expect(yaml).toMatch(/^volumes:/m)
     expect(yaml).toContain('caddy_data')
@@ -3030,14 +3086,14 @@ describe('buildComposeOverride', () => {
 
   test('caddy image is pinned to the same digest as cliproxy (caddy:2.11.3-alpine@sha256:...)', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     // Must use a pinned digest (sha256:)
     expect(yaml).toMatch(/caddy:[\d.]+-alpine@sha256:[0-9a-f]{64}/)
   })
 
   test('caddy service has restart: unless-stopped', async () => {
     const {buildComposeOverride} = await import('./deploy')
-    const yaml = buildComposeOverride()
+    const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     expect(yaml).toContain('unless-stopped')
   })
 })
@@ -3135,7 +3191,7 @@ describe('main() — announce override + Caddyfile materialization', () => {
     }
   })
 
-  test('announce disabled → writeRemoteFile NOT called for compose.override.yaml', async () => {
+  test('announce disabled → compose.override.yaml IS written (carries image pins)', async () => {
     const {main} = await import('./deploy')
     const stdinCaptures: Record<string, string> = {}
     const {spawnFn} = makeSpawnMock(cmd => {
@@ -3165,9 +3221,13 @@ describe('main() — announce override + Caddyfile materialization', () => {
       fetch: makeDiscordFetch([{name: 'ping'}]),
     })
 
-    // compose.override.yaml must NOT have been written
+    // compose.override.yaml MUST be written (carries image digest pins)
     const overridePath = '/opt/gateway/deploy/compose.override.yaml'
-    expect(stdinCaptures[overridePath]).toBeUndefined()
+    expect(stdinCaptures[overridePath]).toBeDefined()
+    expect(stdinCaptures[overridePath]).toContain('ghcr.io/marcusrbrown/infra-gateway@')
+    expect(stdinCaptures[overridePath]).toContain('ghcr.io/marcusrbrown/infra-workspace@')
+    // Caddy/announce wiring must NOT be present when announce is disabled
+    expect(stdinCaptures[overridePath]).not.toContain('GATEWAY_WEBHOOK_SECRET_FILE')
   })
 
   test('announce disabled → writeRemoteFile NOT called for Caddyfile', async () => {
@@ -3289,7 +3349,15 @@ describe('computeSecretsChecksum — override + Caddyfile folded in', () => {
     const announceSecrets = buildSecretFileList(announceEnv)
 
     // Fold override + Caddyfile into the announce checksum input
-    const overrideEntry = {name: 'compose.override.yaml', content: buildComposeOverride(), required: false}
+    const overrideEntry = {
+      name: 'compose.override.yaml',
+      content: buildComposeOverride({
+        gatewayDigest: GATEWAY_DIGEST,
+        workspaceDigest: WORKSPACE_DIGEST,
+        announceEnabled: true,
+      }),
+      required: false,
+    }
     const caddyfileEntry = {
       name: 'Caddyfile',
       content: buildCaddyfile(announceEnv.GATEWAY_HOST ?? 'gateway.fro.bot'),
@@ -3352,7 +3420,7 @@ describe('main() — compose-up args', () => {
     expect(cmdStr).toContain('--remove-orphans')
   })
 
-  test('compose-up command always includes --build', async () => {
+  test('compose-up command always includes --no-build (pulls prebuilt image, never builds on droplet)', async () => {
     const {main} = await import('./deploy')
     const composeCmds: string[][] = []
     const {spawnFn} = makeSpawnMock(cmd => {
@@ -3376,7 +3444,8 @@ describe('main() — compose-up args', () => {
     expect(composeCmds.length).toBeGreaterThan(0)
     const composeCmd = composeCmds[0]!
     const cmdStr = composeCmd.join(' ')
-    expect(cmdStr).toContain('--build')
+    expect(cmdStr).toContain('--no-build')
+    expect(cmdStr).not.toContain('--build')
   })
 })
 
@@ -3655,7 +3724,11 @@ describe('computeSecretsChecksum — override+Caddyfile contribution isolates fr
     const checksumSecretsOnly = computeSecretsChecksum(secretsOnly)
 
     // Checksum with override + Caddyfile bytes folded in (same secrets, same env)
-    const overrideContent = buildComposeOverride()
+    const overrideContent = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: true,
+    })
     const caddyfileContent = buildCaddyfile(announceEnv.GATEWAY_HOST ?? 'gateway.fro.bot')
     const checksumInput = [
       ...secretsOnly,
@@ -3709,7 +3782,7 @@ networks:
     driver: bridge
 `
 
-    const overrideYaml = buildComposeOverride()
+    const overrideYaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
 
     // Write to a temp directory
     const {mkdtempSync: mkdtemp, writeFileSync: writeFile, rmSync: rm} = await import('node:fs')
@@ -3749,5 +3822,302 @@ networks:
     } finally {
       rm(testDir, {recursive: true, force: true})
     }
+  })
+})
+
+// ─── Off-droplet image build: override, pull-then-up, digest verification ─────
+
+describe('buildComposeOverride — image pins always materialized', () => {
+  test('announce-disabled: override contains image pins for gateway and workspace', async () => {
+    const {buildComposeOverride} = await import('./deploy')
+    const result = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    expect(result).toContain(`ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`)
+    expect(result).toContain(`ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`)
+  })
+
+  test('announce-disabled: override does NOT contain Caddy service or announce wiring', async () => {
+    const {buildComposeOverride} = await import('./deploy')
+    const result = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    expect(result).not.toContain('caddy:')
+    expect(result).not.toContain('GATEWAY_WEBHOOK_SECRET_FILE')
+    expect(result).not.toContain('GATEWAY_PRESENCE_CHANNEL_ID_FILE')
+  })
+
+  test('announce-enabled: override contains BOTH image pins AND Caddy/announce wiring', async () => {
+    const {buildComposeOverride} = await import('./deploy')
+    const result = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: true,
+    })
+    // Image pins present
+    expect(result).toContain(`ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`)
+    expect(result).toContain(`ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`)
+    // Caddy/announce wiring present
+    expect(result).toContain('caddy:')
+    expect(result).toContain('GATEWAY_WEBHOOK_SECRET_FILE')
+    expect(result).toContain('GATEWAY_PRESENCE_CHANNEL_ID_FILE')
+  })
+
+  test('image pins use exact @sha256: digest format, not a tag', async () => {
+    const {buildComposeOverride} = await import('./deploy')
+    const result = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    // Must use @sha256: digest notation
+    expect(result).toMatch(/ghcr\.io\/marcusrbrown\/infra-gateway@sha256:[0-9a-f]{64}/)
+    expect(result).toMatch(/ghcr\.io\/marcusrbrown\/infra-workspace@sha256:[0-9a-f]{64}/)
+  })
+
+  test('announce-enabled: announce volumes use new mount targets (volume-merge semantics preserved)', async () => {
+    const {buildComposeOverride} = await import('./deploy')
+    const result = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: true,
+    })
+    expect(result).toContain('/run/secrets/gateway_webhook_secret')
+    expect(result).toContain('/run/secrets/gateway_presence_channel_id')
+  })
+})
+
+describe('main() — compose command sequence: pull-then-up-without-build', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('compose command sequence includes a pull step before up', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const composeCalls = calls.filter(cmd => cmd.some(s => s.includes('docker compose')))
+    const pullCall = composeCalls.find(cmd => cmd.some(s => s.includes(' pull') || s.endsWith('pull')))
+    const upCall = composeCalls.find(cmd => cmd.some(s => s.includes(' up ')))
+
+    expect(pullCall).toBeDefined()
+    expect(upCall).toBeDefined()
+
+    // pull must come before up
+    const pullIdx = pullCall ? calls.indexOf(pullCall) : -1
+    const upIdx = upCall ? calls.indexOf(upCall) : -1
+    expect(pullIdx).toBeLessThan(upIdx)
+  })
+
+  test('compose up command does NOT contain --build', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall).toBeDefined()
+    expect(upCall?.join(' ')).not.toContain('--build')
+  })
+
+  test('compose up command contains --no-build', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall).toBeDefined()
+    expect(upCall?.join(' ')).toContain('--no-build')
+  })
+
+  test('compose up command retains --wait, --wait-timeout 120, --remove-orphans', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall).toBeDefined()
+    const upStr = upCall?.join(' ') ?? ''
+    expect(upStr).toContain('--wait')
+    expect(upStr).toContain('--wait-timeout')
+    expect(upStr).toContain('120')
+    expect(upStr).toContain('--remove-orphans')
+  })
+
+  test('--force-recreate absent when checksum unchanged and forceRecreate not set', async () => {
+    const {main, buildSecretFileList, computeSecretsChecksum} = await import('./deploy')
+    const env = makeEnv()
+    // Compute what the checksum will be with the override always included
+    const secrets = buildSecretFileList(env)
+    const {buildComposeOverride} = await import('./deploy')
+    const overrideContent = buildComposeOverride({
+      gatewayDigest: GATEWAY_DIGEST,
+      workspaceDigest: WORKSPACE_DIGEST,
+      announceEnabled: false,
+    })
+    const checksumInput = [...secrets, {name: 'compose.override.yaml', content: overrideContent, required: false}]
+    const expectedChecksum = computeSecretsChecksum(checksumInput)
+
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes('cat')) {
+        return makeSpawnResult({stdout: expectedChecksum})
+      }
+      return undefined
+    })
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env, args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall?.join(' ')).not.toContain('--force-recreate')
+  })
+
+  test('--force-recreate present when checksum changed', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('.secrets-checksum') && cmdStr.includes('cat')) {
+        return makeSpawnResult({stdout: 'old-checksum-that-differs'})
+      }
+      return undefined
+    })
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall?.join(' ')).toContain('--force-recreate')
+  })
+
+  test('--force-recreate present when --force-recreate arg passed', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: ['--force-recreate'], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    const upCall = calls.find(cmd => cmd.some(s => s.includes('docker compose') && s.includes(' up ')))
+    expect(upCall?.join(' ')).toContain('--force-recreate')
+  })
+
+  test('missing GATEWAY_IMAGE_DIGEST → throws before any SSH, no build fallback', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const env = makeEnv()
+    delete (env as Record<string, string>).GATEWAY_IMAGE_DIGEST
+
+    await expect(main({env, args: [], spawn: spawnFn})).rejects.toThrow(/GATEWAY_IMAGE_DIGEST/)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('missing WORKSPACE_IMAGE_DIGEST → throws before any SSH, no build fallback', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+    const env = makeEnv()
+    delete (env as Record<string, string>).WORKSPACE_IMAGE_DIGEST
+
+    await expect(main({env, args: [], spawn: spawnFn})).rejects.toThrow(/WORKSPACE_IMAGE_DIGEST/)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('override is always written (announce-disabled path) and contains image pins', async () => {
+    const {main} = await import('./deploy')
+    const overrideWrites: string[] = []
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('compose.override.yaml')) {
+        const result = makeSpawnResult({captureStdin: true})
+        if (result.stdin) {
+          const origWrite = result.stdin.write.bind(result.stdin)
+          result.stdin.write = (data: Uint8Array) => {
+            overrideWrites.push(new TextDecoder().decode(data))
+            origWrite(data)
+          }
+        }
+        return result
+      }
+      return undefined
+    })
+    const mockFetch = makeDiscordFetch([{name: 'ping'}])
+
+    await main({env: makeEnv(), args: [], fetch: mockFetch, sleep: async () => {}, spawn: spawnFn})
+
+    expect(overrideWrites.length).toBeGreaterThan(0)
+    const overrideContent = overrideWrites.join('')
+    expect(overrideContent).toContain(`ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`)
+    expect(overrideContent).toContain(`ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`)
+  })
+})
+
+describe('assertRunningImageDigest — pure digest verification helper', () => {
+  test('passes when actual RepoDigests contains the expected digest', async () => {
+    const {assertRunningImageDigest} = await import('./deploy')
+    const repoDigests = [
+      `ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`,
+      'ghcr.io/marcusrbrown/infra-gateway:v0.44.0',
+    ]
+    expect(() => assertRunningImageDigest(repoDigests, GATEWAY_DIGEST, 'gateway')).not.toThrow()
+  })
+
+  test('throws when actual RepoDigests does not contain the expected digest', async () => {
+    const {assertRunningImageDigest} = await import('./deploy')
+    const wrongDigest = 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+    const repoDigests = [`ghcr.io/marcusrbrown/infra-gateway@${wrongDigest}`]
+    expect(() => assertRunningImageDigest(repoDigests, GATEWAY_DIGEST, 'gateway')).toThrow(/gateway/)
+  })
+
+  test('throws when RepoDigests is empty', async () => {
+    const {assertRunningImageDigest} = await import('./deploy')
+    expect(() => assertRunningImageDigest([], GATEWAY_DIGEST, 'gateway')).toThrow(/gateway/)
+  })
+
+  test('error message includes the expected digest for actionability', async () => {
+    const {assertRunningImageDigest} = await import('./deploy')
+    const wrongDigest = 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+    const repoDigests = [`ghcr.io/marcusrbrown/infra-gateway@${wrongDigest}`]
+    let errorMessage = ''
+    try {
+      assertRunningImageDigest(repoDigests, GATEWAY_DIGEST, 'gateway')
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+    expect(errorMessage).toContain(GATEWAY_DIGEST)
+  })
+
+  test('passes for workspace service with correct digest', async () => {
+    const {assertRunningImageDigest} = await import('./deploy')
+    const repoDigests = [`ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`]
+    expect(() => assertRunningImageDigest(repoDigests, WORKSPACE_DIGEST, 'workspace')).not.toThrow()
   })
 })

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -82,8 +82,12 @@ function writeUpstreamJson(content: object): string {
 
 /**
  * Build a spawn mock that records calls and returns success by default.
- * docker inspect commands return a JSON array containing the expected digest
- * so assertRunningImageDigest passes in tests that don't override the handler.
+ * docker inspect commands return appropriate values so assertRunningImageDigest
+ * passes in tests that don't override the handler.
+ *
+ * Two-step image inspect (P1 fix):
+ *   1. `docker inspect --format '{{.Image}}' <container>` → returns a fake image SHA
+ *   2. `docker inspect --format '{{json .RepoDigests}}' <imageSHA>` → returns valid RepoDigests JSON
  */
 function makeSpawnMock(handler?: (cmd: string[]) => SpawnResult | undefined): {spawnFn: SpawnFn; calls: string[][]} {
   const calls: string[][] = []
@@ -91,10 +95,13 @@ function makeSpawnMock(handler?: (cmd: string[]) => SpawnResult | undefined): {s
     calls.push(cmd)
     const custom = handler?.(cmd)
     if (custom !== undefined) return custom
-    // Return valid RepoDigests JSON for docker inspect so assertRunningImageDigest passes
     const cmdStr = cmd.join(' ')
+    // Step 1: resolve container → image SHA
+    if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+      return makeSpawnResult({stdout: 'sha256:mockimagesha0000000000000000000000000000000000000000000000000000'})
+    }
+    // Step 2: inspect image RepoDigests — return both digests so either service check passes
     if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
-      // Return both digests so either gateway or workspace check passes
       const digests = [
         `ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`,
         `ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`,
@@ -4119,5 +4126,416 @@ describe('assertRunningImageDigest — pure digest verification helper', () => {
     const {assertRunningImageDigest} = await import('./deploy')
     const repoDigests = [`ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`]
     expect(() => assertRunningImageDigest(repoDigests, WORKSPACE_DIGEST, 'workspace')).not.toThrow()
+  })
+})
+
+// ─── P1: image-inspect command targets IMAGE, not container ──────────────────
+
+describe('Phase 9c — running image digest verification (P1)', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('inspect command resolves container image ID first, then inspects image RepoDigests', async () => {
+    // P1: the old code ran `docker inspect --format '{{json .RepoDigests}}' <container-id>`
+    // which errors on containers (no .RepoDigests field). The fix must:
+    //   1. Run `docker inspect --format '{{.Image}}' <container-id>` to get the image SHA
+    //   2. Run `docker inspect --format '{{json .RepoDigests}}' <image-sha>` on the IMAGE
+    const {main} = await import('./deploy')
+    const inspectCalls: string[] = []
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect')) {
+        inspectCalls.push(cmdStr)
+        // First inspect: resolve container → image ID
+        if (cmdStr.includes('{{.Image}}')) {
+          return makeSpawnResult({stdout: 'sha256:deadbeef1234'})
+        }
+        // Second inspect: image RepoDigests
+        if (cmdStr.includes('RepoDigests') && cmdStr.includes('sha256:deadbeef1234')) {
+          const digests = [
+            `ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`,
+            `ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`,
+          ]
+          return makeSpawnResult({stdout: JSON.stringify(digests)})
+        }
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    // Must have at least one inspect call that resolves the container's image ID
+    const imageResolutionCall = inspectCalls.find(c => c.includes('{{.Image}}'))
+    expect(imageResolutionCall).toBeDefined()
+
+    // Must have at least one inspect call that inspects RepoDigests on the image SHA
+    const repoDigestsCall = inspectCalls.find(c => c.includes('RepoDigests') && c.includes('sha256:deadbeef1234'))
+    expect(repoDigestsCall).toBeDefined()
+  })
+
+  test('RepoDigests inspect uses the image SHA returned by the {{.Image}} step, not a subshell', async () => {
+    // The old broken form embedded `$(docker compose ps -q svc)` directly in the RepoDigests inspect.
+    // The fix: Step 1 resolves the image SHA via `{{.Image}}`; Step 2 passes that SHA to RepoDigests.
+    // This test verifies Step 2's command contains the image SHA from Step 1's stdout.
+    const {main} = await import('./deploy')
+    const inspectCalls: string[] = []
+    const IMAGE_SHA = 'sha256:verifiableimagesha00000000000000000000000000000000000000000000'
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect')) {
+        inspectCalls.push(cmdStr)
+        if (cmdStr.includes('{{.Image}}')) {
+          // Return a known image SHA
+          return makeSpawnResult({stdout: IMAGE_SHA})
+        }
+        if (cmdStr.includes('RepoDigests')) {
+          const digests = [
+            `ghcr.io/marcusrbrown/infra-gateway@${GATEWAY_DIGEST}`,
+            `ghcr.io/marcusrbrown/infra-workspace@${WORKSPACE_DIGEST}`,
+          ]
+          return makeSpawnResult({stdout: JSON.stringify(digests)})
+        }
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    // The RepoDigests inspect must contain the image SHA from Step 1
+    const repoDigestsCalls = inspectCalls.filter(c => c.includes('RepoDigests'))
+    expect(repoDigestsCalls.length).toBeGreaterThan(0)
+    for (const call of repoDigestsCalls) {
+      expect(call).toContain(IMAGE_SHA)
+    }
+  })
+
+  test('deploy fails when image RepoDigests do not contain the expected digest', async () => {
+    // Regression guard: assertRunningImageDigest must still throw when digest mismatches
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+        return makeSpawnResult({stdout: 'sha256:imagesha999'})
+      }
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+        // Return a WRONG digest
+        return makeSpawnResult({
+          stdout: JSON.stringify([`ghcr.io/marcusrbrown/infra-gateway@sha256:${'f'.repeat(64)}`]),
+        })
+      }
+      return undefined
+    })
+
+    await expect(
+      main({
+        env: makeEnv(),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/digest does not match/)
+  })
+})
+
+// ─── P2: digest format validation ────────────────────────────────────────────
+
+describe('Phase 3c — digest format validation (P2)', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('malformed GATEWAY_IMAGE_DIGEST (partial hex) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({GATEWAY_IMAGE_DIGEST: 'sha256:abc123'}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/GATEWAY_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('malformed GATEWAY_IMAGE_DIGEST (tag-only, no sha256:) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({GATEWAY_IMAGE_DIGEST: 'v1.2.3'}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/GATEWAY_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('malformed GATEWAY_IMAGE_DIGEST (sha256: prefix but wrong length) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({GATEWAY_IMAGE_DIGEST: `sha256:${'a'.repeat(63)}`}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/GATEWAY_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('malformed GATEWAY_IMAGE_DIGEST (shell metacharacters) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({GATEWAY_IMAGE_DIGEST: `sha256:$(evil)${'a'.repeat(55)}`}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/GATEWAY_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('malformed WORKSPACE_IMAGE_DIGEST (partial hex) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({WORKSPACE_IMAGE_DIGEST: 'sha256:abc123'}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/WORKSPACE_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('malformed WORKSPACE_IMAGE_DIGEST (tag-only) → throws before any spawn', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await expect(
+      main({
+        env: makeEnv({WORKSPACE_IMAGE_DIGEST: 'latest'}),
+        args: [],
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/WORKSPACE_IMAGE_DIGEST/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('valid sha256 digests (64 hex chars) → passes validation, proceeds to SSH', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    // Valid digests — should NOT throw from validation; will reach SSH phase
+    await main({
+      env: makeEnv({
+        GATEWAY_IMAGE_DIGEST: `sha256:${'a'.repeat(64)}`,
+        WORKSPACE_IMAGE_DIGEST: `sha256:${'b'.repeat(64)}`,
+      }),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    // Reached SSH phase (calls > 0)
+    expect(calls.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── P2: JSON narrowing for docker inspect output ────────────────────────────
+
+describe('Phase 9c — JSON narrowing for docker inspect RepoDigests output', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('docker inspect returning null → treated as empty → assertRunningImageDigest throws mismatch (not TypeError)', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+        return makeSpawnResult({stdout: 'sha256:imagesha999'})
+      }
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+        return makeSpawnResult({stdout: 'null'})
+      }
+      return undefined
+    })
+
+    let caughtError: Error | undefined
+    try {
+      await main({
+        env: makeEnv(),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      })
+    } catch (error) {
+      caughtError = error instanceof Error ? error : new Error(String(error))
+    }
+
+    expect(caughtError).toBeDefined()
+    // Must be the actionable mismatch error, not a TypeError from unsafe cast
+    expect(caughtError?.message).toMatch(/digest does not match/)
+    expect(caughtError?.message).not.toMatch(/TypeError/)
+    expect(caughtError?.message).not.toMatch(/Cannot read/)
+  })
+
+  test('docker inspect returning a plain string → treated as empty → assertRunningImageDigest throws mismatch', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+        return makeSpawnResult({stdout: 'sha256:imagesha999'})
+      }
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+        return makeSpawnResult({stdout: '"just-a-string"'})
+      }
+      return undefined
+    })
+
+    await expect(
+      main({
+        env: makeEnv(),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/digest does not match/)
+  })
+
+  test('docker inspect returning an object {} → treated as empty → assertRunningImageDigest throws mismatch', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+        return makeSpawnResult({stdout: 'sha256:imagesha999'})
+      }
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+        return makeSpawnResult({stdout: '{}'})
+      }
+      return undefined
+    })
+
+    await expect(
+      main({
+        env: makeEnv(),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/digest does not match/)
+  })
+
+  test('docker inspect returning array of non-strings [123] → treated as empty → assertRunningImageDigest throws mismatch', async () => {
+    const {main} = await import('./deploy')
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('{{.Image}}')) {
+        return makeSpawnResult({stdout: 'sha256:imagesha999'})
+      }
+      if (cmdStr.includes('docker inspect') && cmdStr.includes('RepoDigests')) {
+        return makeSpawnResult({stdout: '[123, 456]'})
+      }
+      return undefined
+    })
+
+    await expect(
+      main({
+        env: makeEnv(),
+        args: [],
+        fetch: makeDiscordFetch([{name: 'ping'}]),
+        sleep: async () => {},
+        spawn: spawnFn,
+      }),
+    ).rejects.toThrow(/digest does not match/)
   })
 })

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -550,22 +550,45 @@ export function computeSecretsChecksum(secrets: SecretFile[]): string {
 // Renovate tracks the digest in those files; keep in sync when Renovate bumps them.
 const CADDY_IMAGE = 'caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794'
 
+export interface ComposeOverrideOpts {
+  /** Digest of the gateway image pushed to GHCR (e.g. "sha256:abc..."). */
+  gatewayDigest: string
+  /** Digest of the workspace image pushed to GHCR (e.g. "sha256:def..."). */
+  workspaceDigest: string
+  /** When true, adds the Caddy reverse proxy and announce secret wiring. */
+  announceEnabled: boolean
+}
+
+const GATEWAY_IMAGE_NAME = 'ghcr.io/marcusrbrown/infra-gateway'
+const WORKSPACE_IMAGE_NAME = 'ghcr.io/marcusrbrown/infra-workspace'
+
 /**
- * Builds the compose.override.yaml content that adds a path-scoped Caddy reverse proxy
- * publishing :80/:443 on gateway-net, plus the daemon's announce secret wiring.
+ * Builds the compose.override.yaml content.
  *
- * This file is materialized on the droplet only when announceEnabled. When disabled,
- * git clean -xfd removes any prior copy automatically.
+ * Always emits `image:` digest pins for the `gateway` and `workspace` services so
+ * the droplet pulls the prebuilt GHCR artifacts and never builds from source.
+ * Docker Compose deep-merges the override; the upstream `build:` stanzas remain
+ * present but are inert without `--build`.
+ *
+ * When announceEnabled, also adds a path-scoped Caddy reverse proxy publishing
+ * :80/:443 on gateway-net, plus the daemon's announce secret wiring.
  *
  * Docker Compose merges the gateway service's `volumes:` list by mount-target key —
  * new targets APPEND, same-target REPLACES. The two announce bind mounts added here
  * use new targets (/run/secrets/gateway_webhook_secret and
  * /run/secrets/gateway_presence_channel_id), so upstream's other secret mounts are
  * preserved unchanged.
+ *
+ * When announceEnabled is false, git clean -xfd removes any prior Caddyfile
+ * automatically. The override file itself is always written (image pins are required
+ * on every deploy). --remove-orphans retires the Caddy container when announce is
+ * toggled off.
  */
-export function buildComposeOverride(): string {
-  return `services:
-  gateway:
+export function buildComposeOverride(opts: ComposeOverrideOpts): string {
+  const {gatewayDigest, workspaceDigest, announceEnabled} = opts
+
+  const announceSection = announceEnabled
+    ? `
     environment:
       GATEWAY_WEBHOOK_SECRET_FILE: /run/secrets/gateway_webhook_secret
       GATEWAY_PRESENCE_CHANNEL_ID_FILE: /run/secrets/gateway_presence_channel_id
@@ -581,8 +604,11 @@ export function buildComposeOverride(): string {
         target: /run/secrets/gateway_presence_channel_id
         read_only: true
         bind:
-          create_host_path: false
-  caddy:
+          create_host_path: false`
+    : ''
+
+  const caddySection = announceEnabled
+    ? `  caddy:
     image: ${CADDY_IMAGE}
     restart: unless-stopped
     ports:
@@ -596,10 +622,22 @@ export function buildComposeOverride(): string {
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:
       - gateway
-volumes:
+`
+    : ''
+
+  const volumesSection = announceEnabled
+    ? `volumes:
   caddy_data:
   caddy_config:
 `
+    : ''
+
+  return `services:
+  gateway:
+    image: ${GATEWAY_IMAGE_NAME}@${gatewayDigest}${announceSection}
+  workspace:
+    image: ${WORKSPACE_IMAGE_NAME}@${workspaceDigest}
+${caddySection}${volumesSection}`
 }
 
 /**
@@ -661,6 +699,35 @@ export function redactSecretsFromError(error: unknown, secrets: SecretFile[]): E
     }
   }
   return new Error(sanitized)
+}
+
+/**
+ * Asserts that the running container's RepoDigests include the expected digest.
+ *
+ * Pure helper — no SSH, no side effects. Throws with an actionable message when
+ * the running image does not match the CI-pushed digest. Used after `docker compose up`
+ * to confirm the droplet is running the prebuilt GHCR artifact, not a stale or
+ * locally-built image.
+ *
+ * @param actualRepoDigests - Array of RepoDigest strings from `docker inspect --format '{{json .RepoDigests}}'`
+ * @param expectedDigest - The sha256 digest that must appear in at least one entry (e.g. "sha256:abc...")
+ * @param serviceName - Human-readable service name for error messages (e.g. "gateway", "workspace")
+ */
+export function assertRunningImageDigest(
+  actualRepoDigests: string[],
+  expectedDigest: string,
+  serviceName: string,
+): void {
+  const matched = actualRepoDigests.some(d => d.includes(expectedDigest))
+  if (!matched) {
+    throw new Error(
+      `Running ${serviceName} image digest does not match the expected CI-pushed digest.\n` +
+        `  Expected: ${expectedDigest}\n` +
+        `  Actual RepoDigests: ${actualRepoDigests.length > 0 ? actualRepoDigests.join(', ') : '(empty)'}\n` +
+        `The droplet may be running a stale or locally-built image. ` +
+        `Re-run the deploy to pull the correct GHCR artifact.`,
+    )
+  }
 }
 
 /**
@@ -987,7 +1054,28 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     config: env.WORKSPACE_OPENCODE_CONFIG ?? '',
   })
 
-  // Phase 3c: Validate announce both-or-neither gate before any SSH.
+  // Phase 3c: Validate image digests before any SSH.
+  // GATEWAY_IMAGE_DIGEST and WORKSPACE_IMAGE_DIGEST are required on every deploy —
+  // they are supplied by the CI build-images job and used to pin the pulled images.
+  // Failing fast here prevents a silent fall-through to on-droplet building.
+  const gatewayDigest = env.GATEWAY_IMAGE_DIGEST?.trim()
+  const workspaceDigest = env.WORKSPACE_IMAGE_DIGEST?.trim()
+  if (!gatewayDigest) {
+    throw new Error(
+      'GATEWAY_IMAGE_DIGEST is required but not set. ' +
+        'This value is supplied by the CI build-images job. ' +
+        'For a local deploy, build and push the image to GHCR first, then set GATEWAY_IMAGE_DIGEST.',
+    )
+  }
+  if (!workspaceDigest) {
+    throw new Error(
+      'WORKSPACE_IMAGE_DIGEST is required but not set. ' +
+        'This value is supplied by the CI build-images job. ' +
+        'For a local deploy, build and push the image to GHCR first, then set WORKSPACE_IMAGE_DIGEST.',
+    )
+  }
+
+  // Phase 3d: Validate announce both-or-neither gate before any SSH.
   // Exactly one of the announce inputs being set is an invalid configuration —
   // fail fast with a clear message naming the missing input.
   const announceState = getAnnounceState(env)
@@ -1007,17 +1095,22 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     console.warn(`  1. Ensure droplet workspace at ${REMOTE_DIR} (clone ${repo}@${ref} or fetch+reset)`)
     console.warn(`  2. Compute OBJECT_STORE_HOSTS: ${objectStoreHosts}`)
     console.warn(`  3. Materialize ${buildSecretFileList(env).length} secret files under ${SECRETS_DIR}`)
+    console.warn(
+      `  3b. Write compose.override.yaml with image pins (gateway@${gatewayDigest}, workspace@${workspaceDigest})${announceEnabled ? ' + Caddy/announce wiring' : ''}`,
+    )
     if (announceEnabled) {
-      console.warn(`  3b. Announce enabled — materialize compose.override.yaml + Caddyfile under ${DEPLOY_DIR}`)
+      console.warn(`  3c. Announce enabled — materialize Caddyfile under ${DEPLOY_DIR}`)
     }
     console.warn(`  4. Write .env to ${ENV_PATH}`)
     console.warn(`  5. Run init-certs.sh (idempotent)`)
+    console.warn(`  6. docker compose pull (pull prebuilt GHCR images)`)
     console.warn(
-      `  6. docker compose up -d --build --wait --wait-timeout 120 --remove-orphans${forceRecreate ? ' --force-recreate' : ''}`,
+      `  7. docker compose up -d --no-build --wait --wait-timeout 120 --remove-orphans${forceRecreate ? ' --force-recreate' : ''}`,
     )
     console.warn(
-      `  7. Poll Discord slash command registration (app=${env.DISCORD_APPLICATION_ID} guild=${env.DISCORD_GUILD_ID})`,
+      `  8. Poll Discord slash command registration (app=${env.DISCORD_APPLICATION_ID} guild=${env.DISCORD_GUILD_ID})`,
     )
+    console.warn(`  9. Verify running image digests match CI-pushed digests`)
     console.warn('\u001B[1;33m[dry-run]\u001B[0m No remote side effects performed.')
     return
   }
@@ -1131,25 +1224,31 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       )
     }
 
-    // Phase 5b: Materialize compose.override.yaml + Caddyfile when announce is enabled.
-    // These are working-tree files; git clean -xfd (phase 4) already removed any prior copy,
-    // so they are only present when announceEnabled. writeRemoteFile overwrites idempotently.
+    // Phase 5b: Materialize compose.override.yaml (always) + Caddyfile (announce-only).
+    // The override is written on EVERY deploy because it carries the image digest pins
+    // for gateway and workspace — without it, compose would use build: semantics.
+    // git clean -xfd (phase 4) removed any prior copy; writeRemoteFile overwrites idempotently.
     const announceEnabled = announceState === 'enabled'
-    const overrideContent = announceEnabled ? buildComposeOverride() : ''
+    const overrideContent = buildComposeOverride({
+      gatewayDigest,
+      workspaceDigest,
+      announceEnabled,
+    })
     const caddyfileContent = announceEnabled ? buildCaddyfile(validated.GATEWAY_HOST) : ''
 
+    await writeRemoteFile(
+      'Writing compose.override.yaml',
+      host,
+      `${DEPLOY_DIR}/compose.override.yaml`,
+      overrideContent,
+      deployEnv,
+      spawnFn,
+      secrets,
+      keyPath,
+      controlPath,
+    )
+
     if (announceEnabled) {
-      await writeRemoteFile(
-        'Writing compose.override.yaml',
-        host,
-        `${DEPLOY_DIR}/compose.override.yaml`,
-        overrideContent,
-        deployEnv,
-        spawnFn,
-        secrets,
-        keyPath,
-        controlPath,
-      )
       await writeRemoteFile(
         'Writing Caddyfile',
         host,
@@ -1164,11 +1263,14 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     }
 
     // Compute current checksum and read prior checksum to detect rotation.
-    // Fold override + Caddyfile bytes into the checksum so toggling announce on/off
-    // forces --force-recreate (Caddy is created/destroyed on the toggling deploy).
-    const checksumInput: SecretFile[] = [...secrets]
+    // The override is always included (image pins change when digests change, which
+    // should force recreate). Caddyfile is included only when announce is enabled,
+    // so toggling announce on/off forces --force-recreate (Caddy is created/destroyed).
+    const checksumInput: SecretFile[] = [
+      ...secrets,
+      {name: 'compose.override.yaml', content: overrideContent, required: false},
+    ]
     if (announceEnabled) {
-      checksumInput.push({name: 'compose.override.yaml', content: overrideContent, required: false})
       checksumInput.push({name: 'Caddyfile', content: caddyfileContent, required: false})
     }
     const currentChecksum = computeSecretsChecksum(checksumInput)
@@ -1201,10 +1303,22 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       spawnFn,
     )
 
-    // Phase 8: docker compose up
+    // Phase 8: Pull prebuilt GHCR images, then bring up the stack without building.
+    // The compose.override.yaml written in phase 5b pins gateway and workspace to the
+    // CI-pushed digests. docker compose pull fetches those exact images; docker compose up
+    // with --no-build uses the pulled images and never triggers an on-droplet build.
+    // A missing/unpullable image errors here (does not fall back to building).
+    //
     // --remove-orphans: required to retire the Caddy container when announce is toggled off.
-    // When disabled, the override is absent (git clean removed it), so Caddy is no longer a
-    // declared service. Without --remove-orphans, the container lingers on :443.
+    // When announce is disabled, Caddy is not declared in the override, so without
+    // --remove-orphans the container lingers on :443.
+    await runCommand(
+      'Pulling prebuilt images from GHCR',
+      sshCommand(host, `docker compose --project-directory ${DEPLOY_DIR} pull`, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
     const composeArgs = [
       'docker',
       'compose',
@@ -1212,7 +1326,7 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       DEPLOY_DIR,
       'up',
       '-d',
-      '--build',
+      '--no-build',
       '--wait',
       '--wait-timeout',
       '120',
@@ -1294,8 +1408,36 @@ export async function main(opts: MainOpts = {}): Promise<void> {
       }
     }
 
-    // Phase 10: Persist checksum AFTER compose + registration succeed
-    // If either phase 8 or 9 threw, we never reach here — prior checksum stays in place
+    // Phase 9c: Verify running image digests match the CI-pushed GHCR digests.
+    // This confirms the droplet is running the prebuilt artifact, not a stale or
+    // locally-built image. Throws if the digest does not match — deploy fails loudly.
+    for (const [service, expectedDigest] of [
+      ['gateway', gatewayDigest],
+      ['workspace', workspaceDigest],
+    ] as const) {
+      const {stdout: repoDigestsJson} = await runCommand(
+        `Verifying running image digest: ${service}`,
+        sshCommand(
+          host,
+          `docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory ${DEPLOY_DIR} ps -q ${service})`,
+          keyPath,
+          controlPath,
+        ),
+        deployEnv,
+        spawnFn,
+      )
+      let repoDigests: string[]
+      try {
+        repoDigests = JSON.parse(repoDigestsJson.trim()) as string[]
+      } catch {
+        repoDigests = []
+      }
+      assertRunningImageDigest(repoDigests, expectedDigest, service)
+      console.warn(`\u001B[1;32m✓\u001B[0m ${service} image digest verified`)
+    }
+
+    // Phase 10: Persist checksum AFTER compose + registration + digest verification succeed
+    // If any of phase 8, 9, or 9c threw, we never reach here — prior checksum stays in place
     // so the next deploy correctly detects secrets as changed and forces recreate.
     await writeRemoteFile(
       'Persisting secrets checksum',

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -1058,6 +1058,9 @@ export async function main(opts: MainOpts = {}): Promise<void> {
   // GATEWAY_IMAGE_DIGEST and WORKSPACE_IMAGE_DIGEST are required on every deploy —
   // they are supplied by the CI build-images job and used to pin the pulled images.
   // Failing fast here prevents a silent fall-through to on-droplet building.
+  // Both digests are validated against /^sha256:[0-9a-f]{64}$/ to guard the
+  // compose override `image:@<digest>` and the Phase 9c verification.
+  const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
   const gatewayDigest = env.GATEWAY_IMAGE_DIGEST?.trim()
   const workspaceDigest = env.WORKSPACE_IMAGE_DIGEST?.trim()
   if (!gatewayDigest) {
@@ -1067,11 +1070,25 @@ export async function main(opts: MainOpts = {}): Promise<void> {
         'For a local deploy, build and push the image to GHCR first, then set GATEWAY_IMAGE_DIGEST.',
     )
   }
+  if (!DIGEST_RE.test(gatewayDigest)) {
+    throw new Error(
+      `GATEWAY_IMAGE_DIGEST has an invalid format: "${gatewayDigest}". ` +
+        'Expected sha256:<64 hex chars> (e.g. sha256:abc...def). ' +
+        'This value is supplied by the CI build-images job outputs.digest.',
+    )
+  }
   if (!workspaceDigest) {
     throw new Error(
       'WORKSPACE_IMAGE_DIGEST is required but not set. ' +
         'This value is supplied by the CI build-images job. ' +
         'For a local deploy, build and push the image to GHCR first, then set WORKSPACE_IMAGE_DIGEST.',
+    )
+  }
+  if (!DIGEST_RE.test(workspaceDigest)) {
+    throw new Error(
+      `WORKSPACE_IMAGE_DIGEST has an invalid format: "${workspaceDigest}". ` +
+        'Expected sha256:<64 hex chars> (e.g. sha256:abc...def). ' +
+        'This value is supplied by the CI build-images job outputs.digest.',
     )
   }
 
@@ -1411,24 +1428,44 @@ export async function main(opts: MainOpts = {}): Promise<void> {
     // Phase 9c: Verify running image digests match the CI-pushed GHCR digests.
     // This confirms the droplet is running the prebuilt artifact, not a stale or
     // locally-built image. Throws if the digest does not match — deploy fails loudly.
+    //
+    // Two-step inspect: containers have no .RepoDigests field — inspecting a container
+    // directly returns a template error and empty stdout. Instead:
+    //   1. Resolve the container's image SHA via `docker inspect --format '{{.Image}}' <container>`
+    //   2. Inspect the IMAGE's RepoDigests via `docker inspect --format '{{json .RepoDigests}}' <imageSHA>`
     for (const [service, expectedDigest] of [
       ['gateway', gatewayDigest],
       ['workspace', workspaceDigest],
     ] as const) {
-      const {stdout: repoDigestsJson} = await runCommand(
-        `Verifying running image digest: ${service}`,
+      // Step 1: resolve container → image SHA
+      const {stdout: imageSha} = await runCommand(
+        `Resolving running image SHA: ${service}`,
         sshCommand(
           host,
-          `docker inspect --format '{{json .RepoDigests}}' $(docker compose --project-directory ${DEPLOY_DIR} ps -q ${service})`,
+          `docker inspect --format '{{.Image}}' $(docker compose --project-directory ${DEPLOY_DIR} ps -q ${service})`,
           keyPath,
           controlPath,
         ),
         deployEnv,
         spawnFn,
       )
+      // Step 2: inspect the IMAGE's RepoDigests
+      const {stdout: repoDigestsJson} = await runCommand(
+        `Verifying running image digest: ${service}`,
+        sshCommand(host, `docker inspect --format '{{json .RepoDigests}}' ${imageSha.trim()}`, keyPath, controlPath),
+        deployEnv,
+        spawnFn,
+      )
+      // Narrow the parsed JSON: must be string[] — anything else is treated as empty
+      // so assertRunningImageDigest throws its actionable mismatch error (not a TypeError).
       let repoDigests: string[]
       try {
-        repoDigests = JSON.parse(repoDigestsJson.trim()) as string[]
+        const parsed: unknown = JSON.parse(repoDigestsJson.trim())
+        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+          repoDigests = parsed
+        } else {
+          repoDigests = []
+        }
       } catch {
         repoDigests = []
       }

--- a/docs/plans/2026-06-04-001-feat-gateway-offdroplet-image-build-plan.md
+++ b/docs/plans/2026-06-04-001-feat-gateway-offdroplet-image-build-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Off-droplet gateway image build (CI → GHCR → droplet pull)'
 type: feat
-status: active
+status: completed
 date: 2026-06-04
 origin: docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md
 ---
@@ -94,7 +94,7 @@ and a fresh upstream ref (cold build cache) makes it worse. See origin:
 
 ## Implementation Units
 
-- [ ] **Unit 1: CI build-and-push job (GHCR)**
+- [x] **Unit 1: CI build-and-push job (GHCR)**
 
 **Goal:** Build `gateway` + `workspace` images from the pinned upstream ref in CI and push to GHCR, before any droplet deploy.
 
@@ -122,7 +122,7 @@ and a fresh upstream ref (cold build cache) makes it worse. See origin:
 **Verification:**
 - A gateway deploy dispatch builds both images and pushes `:<ref>` tags to GHCR; the `deploy` job only starts after `build-images` succeeds.
 
-- [ ] **Unit 2: Droplet deploy pulls instead of builds**
+- [x] **Unit 2: Droplet deploy pulls instead of builds**
 
 **Goal:** Change `deploy.ts` so the droplet pulls the GHCR images and recreates, never building.
 
@@ -157,7 +157,7 @@ and a fresh upstream ref (cold build cache) makes it worse. See origin:
 **Verification:**
 - A deploy pulls both images, recreates, all services healthy, and the running gateway/workspace images are the GHCR `:<ref>` artifacts (verified by image ref, not git source).
 
-- [ ] **Unit 3: Docs + AGENTS.md for the new flow**
+- [x] **Unit 3: Docs + AGENTS.md for the new flow**
 
 **Goal:** Document the build→push→pull deploy flow, GHCR packages, local/emergency deploy path, and running-image verification.
 

--- a/docs/plans/2026-06-04-001-feat-gateway-offdroplet-image-build-plan.md
+++ b/docs/plans/2026-06-04-001-feat-gateway-offdroplet-image-build-plan.md
@@ -1,0 +1,218 @@
+---
+title: 'feat: Off-droplet gateway image build (CI → GHCR → droplet pull)'
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md
+---
+
+# feat: Off-droplet gateway image build (CI → GHCR → droplet pull)
+
+## Overview
+
+Move the gateway + workspace Docker image builds off the production droplet. Today
+`apps/gateway/src/deploy.ts` runs `docker compose up -d --build` on the droplet, which rebuilds
+the memory-heavy `gateway` and `workspace` images **while the old stack is still running** — on the
+`s-1vcpu-2gb` box this exhausts RAM and thrashes swap (a v0.54.1 cutover caused a ~50 min outage).
+
+This plan builds both images in GitHub Actions, pushes them to GHCR, and changes the droplet deploy
+to `docker compose pull` + recreate (no `--build`). The prod box never builds again; it only pulls a
+prebuilt artifact. This eliminates the root cause with no recurring infrastructure cost.
+
+## Problem Frame
+
+The gateway deploy is the only deploy in the repo that **builds images on the target host**
+(`apps/cliproxy` and `apps/umami` pull prebuilt registry images). The two gateway services that build
+from source — `gateway` and `workspace` — are exactly the memory-heavy ones, and the build runs
+concurrently with the live stack. On a 2 GB droplet the combined footprint exceeds available RAM,
+and a fresh upstream ref (cold build cache) makes it worse. See origin:
+`docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md`.
+
+## Requirements Trace
+
+- R1. The gateway droplet must never build images during deploy — it only pulls prebuilt images.
+- R2. CI must build `gateway` + `workspace` images from the pinned `apps/gateway/upstream.json` ref and push them to GHCR before the droplet deploy runs.
+- R3. The deploy must preserve the **safe-failure property**: if the new image is unavailable/bad, the old stack stays live (no teardown-before-ready).
+- R4. The deploy must preserve the **secrets-checksum recreate gate** and all existing secret-materialization safety (stdin-only, `0600`, no argv).
+- R5. Post-deploy verification must confirm the **running image digest** matches the CI-pushed GHCR digest (not a tag, not the git source ref — tag comparison is circular against a mutable label).
+- R6. No new recurring **compute** cost (GHCR storage/retention for a small image set is negligible; no droplet build CPU).
+
+## Scope Boundaries
+
+- Not resizing the droplet (this plan removes the need to).
+- Not changing `mitmproxy` or `caddy` — they already use pullable upstream `image:` refs.
+- Not changing the upstream `fro-bot/agent` Dockerfiles or compose `build:` definitions (we build *with* them in CI, unchanged).
+- Not migrating `cliproxy`/`umami` deploys (they already pull).
+- Not enforcing GHCR tag immutability at the registry level (we pin + verify by **digest** instead, which is stronger than tag immutability).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/gateway/src/deploy.ts:1208-1223` — compose command builder: `docker compose --project-directory /opt/gateway/deploy up -d --build --wait --wait-timeout 120 --remove-orphans` (+ `--force-recreate` when `forceRecreate || checksumChanged`). **This is where `--build` is removed and a `pull` step is added.**
+- `apps/gateway/src/deploy.ts:553-603` — `buildComposeOverride()` already injects an `image:`-based `caddy` service into `compose.override.yaml`. **Same mechanism adds `image:` to `gateway` + `workspace`.**
+- `apps/gateway/src/deploy.ts:1076-1109` — upstream checkout on droplet (`git clone/fetch/reset` at the pinned ref). Still needed for `compose.yaml` + `init-certs.sh` + Dockerfiles, but the droplet no longer *builds* from it.
+- `apps/gateway/src/deploy.ts:178-211` — `resolveUpstreamPin()` reads `apps/gateway/upstream.json` (`repo`, `ref`). CI build job reads the same file for the ref.
+- Upstream `fro-bot/agent` `deploy/compose.yaml`: `gateway` → `build: {context: .., dockerfile: deploy/gateway.Dockerfile}`; `workspace` → `build: {context: .., dockerfile: deploy/workspace.Dockerfile}`; both build from repo root `..`. `mitmproxy`/`caddy` are pullable `image:`.
+- `.github/workflows/deploy-gateway.yaml:66-144` — reusable deploy job: runner checks out infra, `bun install`, validates secrets, copies known_hosts, runs `bun run --cwd apps/gateway deploy` (script SSHes). **New build-and-push job goes here, before deploy.**
+- `.github/workflows/deploy.yaml:87-115` — parent passes the gateway secret set into the reusable workflow.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md` — `--build` was *added* because `up` on a `build:` service won't rebuild on source change. Off-droplet build must guarantee the **pulled image actually reflects the pinned ref**, and verification must check the running image, not the source tree.
+- `docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md` (origin) — explicitly recommends "build off-droplet (GHCR) and pull" as the no-recurring-cost fix; preserve "old stack stays live until the new artifact is ready."
+- `docs/solutions/workflow-issues/gateway-first-deploy-cascade-2026-05-20.md` — `readRemoteChecksum()` must fail on SSH errors (not act like first-deploy); secret bytes via stdin + `0600`, never argv. The checksum/sentinel gate must remain authoritative after the artifact source changes.
+- `docs/solutions/workflow-issues/gateway-v0500-undeployable-upstream-2026-06-02.md` — a valid image tag is not proof of a valid boot contract; keep pre-cutover/post-deploy verification against the actual running container.
+
+## Key Technical Decisions
+
+- **Build location:** GitHub Actions runner (16 GB RAM, no swap pressure) builds both images via the upstream Dockerfiles using `docker/build-push-action`. Workspace build was ~200s in a prior preflight; runner has ample headroom.
+- **Compose override, always materialized:** `buildComposeOverride()` adds `image: ghcr.io/marcusrbrown/infra-gateway@<digest>` and `image: ghcr.io/marcusrbrown/infra-workspace@<digest>` to the respective services. **Critical fix from review:** the override file must be written on **every** deploy, not only when announce is enabled (today it is announce-gated) — otherwise the default announce-disabled path has no `image:` pin and silently falls back to `build:` semantics. Compose deep-merges; the upstream `build:` stays present but is **inert without `--build`**. Deploy does `docker compose pull` then `docker compose up -d --wait` (no `--build`).
+- **Digest-pinned images, not tags:** CI captures the **pushed digest** of each image and threads it into the override as `image: ...@sha256:<digest>`. Tags (`:<ref>`) are still pushed for human readability, but the deploy pulls + verifies by **digest** — GHCR tags are mutable, so tag-based pull/verify would be non-deterministic and the verify would be circular (comparing a tag to itself). Digest pull is immutable and makes verification a true identity check (R5).
+- **GHCR package visibility — PUBLIC, gated on a secret-safety check:** the built images should contain **no secrets** (all secrets are runtime bind-mounts into `/run/secrets/...`, never baked), and the source is public `fro-bot/agent`, so public packages let the droplet pull with **no auth** (simplest, boring). But "no secrets in image" is an assumption, not a fact — so public visibility is **conditional** on an explicit pre-publish secret-safety audit (Unit 1): inspect the upstream Dockerfiles for `ARG`/`ENV`/`COPY` of secret material and confirm the build context carries none. *Alternative (privacy-max / if the audit is inconclusive):* keep packages private and `docker login ghcr.io` on the droplet with a read-only token materialized like other secrets (stdin, `0600`, no argv). Decision: **public after the audit passes**; fall back to private+token if it doesn't. Marcus confirms at work time.
+- **CI permission scoping:** `packages: write` is granted **only to the `build-images` job**, never workflow-wide; the `deploy` job stays package-read-only. Least privilege.
+- **Sequencing:** the `build-images` job runs first; the `deploy` job declares `needs: build-images`. If the build/push fails, the deploy never runs and the old stack stays live (R3).
+- **Verification by digest:** post-deploy, compare the running container's `RepoDigests` to the CI-pushed digest, not a tag or the git checkout (R5).
+
+## Resolve Before Implementation
+
+- **PROVE the compose `build:`+`image:` semantics empirically before writing Unit 2.** The entire plan rests on: a service that has BOTH an upstream `build:` and an override `image:@digest`, run with `docker compose pull` then `up -d` (no `--build`), pulls and runs the GHCR image and **cannot** trigger a host-side build — including the failure case where the image is missing/unpullable (must error, never fall back to building). Verify against the **droplet's actual Compose version** in a disjoint compose project (same preflight discipline used for daemon upgrades). If Compose can fall back to a host build for a `build:`-bearing service, the no-build guarantee is not real and Unit 2 must add an explicit guard (e.g. `--pull always` semantics, or strip `build:` in the override) before proceeding. This is the load-bearing assumption flagged by every technical reviewer.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *How does `image:` coexist with upstream `build:`?* — Expected: Compose merges both; without `--build`, `up` uses the local (pulled) image and ignores `build:`. **Must be proven by the Resolve-Before-Implementation preflight above, not assumed.**
+- *Does the droplet still need the upstream checkout?* — Yes, for `compose.yaml`, `init-certs.sh`, and the Dockerfiles compose references — but it no longer builds from them.
+- *First-deploy / image-missing?* — CI always builds+pushes before the deploy job (`needs: build-images`), so the digest exists when CI deploys. Local `bun run --cwd apps/gateway deploy --local` pulls the CI-built image; if the ref was never built by CI it fails clearly.
+- *Emergency path regression (honest tradeoff):* this change **removes the on-droplet local-build fallback** — today's exact incident was recovered by an on-droplet rebuild, which will no longer be possible. The deploy now depends on CI + GHCR availability + pull working. This is a deliberate trade: the on-droplet build is precisely what causes the outage this plan fixes, so keeping it as a fallback would keep the hazard. **Mitigation (Unit 3 runbook):** document the break-glass path — build+push the pinned ref from a workstation to GHCR, then `deploy --local` (pull). A workstation has ample RAM; this is the off-droplet build done by hand. Operators must never `docker compose up --build` on the droplet (it reintroduces the thrash); the override `image:` pins make the GHCR image the source of truth regardless.
+
+### Deferred to Implementation
+
+- Exact GHCR image name suffixes (`infra-gateway`/`infra-workspace` vs other) and `docker/build-push-action` cache config — finalize against the upstream Dockerfile build contexts at implementation time.
+- Whether to compare RepoDigests vs image-ID in verification — pick the most reliable signal once testing the real pulled image.
+
+## Implementation Units
+
+- [ ] **Unit 1: CI build-and-push job (GHCR)**
+
+**Goal:** Build `gateway` + `workspace` images from the pinned upstream ref in CI and push to GHCR, before any droplet deploy.
+
+**Requirements:** R2, R3, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `.github/workflows/deploy-gateway.yaml` (add a `build-images` job; `deploy` job gains `needs: build-images`; add `permissions: packages: write`)
+- Modify: `.github/workflows/deploy.yaml` (ensure the parent grants `packages: write` to the reusable gateway job if required)
+
+**Approach:**
+- New `build-images` job on `ubuntu-latest` with **job-scoped** `permissions: { contents: read, packages: write }` (never workflow-wide): read `ref` from `apps/gateway/upstream.json`; `actions/checkout` infra, then check out `fro-bot/agent` at that ref; `docker/login-action` to `ghcr.io` with `GITHUB_TOKEN`; two `docker/build-push-action` steps (gateway: `deploy/gateway.Dockerfile`, workspace: `deploy/workspace.Dockerfile`, both `context: <upstream-root>`), tagged `:<ref>` for readability and pushed to `ghcr.io/marcusrbrown/infra-gateway` + `infra-workspace`.
+- **Capture each pushed digest** (`build-push-action` exposes `outputs.digest`) and pass both digests to the `deploy` job as job outputs — the deploy pins + verifies by digest, not tag.
+- `deploy` job declares `needs: build-images` and keeps default read-only package perms; a failed build blocks the deploy (preserves R3).
+- **Pre-publish secret-safety audit** (gates the public-visibility decision): inspect the upstream `deploy/gateway.Dockerfile` + `deploy/workspace.Dockerfile` + build context for `ARG`/`ENV`/`COPY` of secret material. If clean, packages go public (no droplet auth). If not, fall back to private + a read-only GHCR pull token.
+- SHA-pin all new actions with `# vX.Y.Z` comments (repo convention).
+
+**Patterns to follow:**
+- Existing reusable-job + secret-passthrough shape in `.github/workflows/deploy-gateway.yaml`; SHA-pinning convention across `.github/workflows/`.
+
+**Test scenarios:**
+- Test expectation: none — CI workflow change, validated by the conventions test (SHA-pin + `.yaml` + action-comment) and a real dispatch. No unit-testable logic.
+
+**Verification:**
+- A gateway deploy dispatch builds both images and pushes `:<ref>` tags to GHCR; the `deploy` job only starts after `build-images` succeeds.
+
+- [ ] **Unit 2: Droplet deploy pulls instead of builds**
+
+**Goal:** Change `deploy.ts` so the droplet pulls the GHCR images and recreates, never building.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** Unit 1 (images must exist in GHCR)
+
+**Files:**
+- Modify: `apps/gateway/src/deploy.ts` (override `image:` refs for `gateway`/`workspace`; remove `--build`; add `docker compose pull`; update running-image verification)
+- Test: `apps/gateway/src/deploy.test.ts`
+
+**Approach:**
+- **Always materialize the override** with `image:` digest pins for `gateway` + `workspace` (the digests come from the deploy job's env, sourced from `build-images` outputs). Decouple this from announce gating — today `buildComposeOverride()` only writes when announce is enabled; the image pins must write unconditionally (announce/Caddy stays a conditional layer within the same file).
+- Replace the `up -d --build ...` invocation: first `docker compose --project-directory <dir> pull`, then `docker compose --project-directory <dir> up -d --wait --wait-timeout 120 --remove-orphans` (keep conditional `--force-recreate` on `forceRecreate || checksumChanged`). Apply whatever guard the Resolve-Before-Implementation preflight proved necessary so a missing image errors rather than host-builds.
+- Keep upstream checkout (compose/init-certs/Dockerfiles) and the checksum gate unchanged (R4).
+- Update post-deploy verification to read the running container's `RepoDigests` and assert it matches the CI-pushed digest (R5) — not a tag.
+- Public path → no droplet auth; private path → guarded `docker login ghcr.io` via stdin (no argv), token materialized like other secrets.
+
+**Execution note:** Test-first — add failing tests for the new override `image:` entries and the `pull`-then-`up`-without-`--build` command shape before changing the builder.
+
+**Patterns to follow:**
+- The existing `caddy` `image:` injection in `buildComposeOverride()`; the existing compose-arg-building tests in `deploy.test.ts`.
+
+**Test scenarios:**
+- Happy path: the override is materialized on the default (announce-disabled) path and contains `image:` digest pins for both `gateway` and `workspace`.
+- Happy path: the compose command sequence includes a `pull` invocation and an `up -d --wait` invocation that does **not** contain `--build`.
+- Edge case: `--force-recreate` still appended when `forceRecreate` is true or the checksum changed; absent otherwise.
+- Edge case: override image pins use the exact digests supplied by the build job (not tags).
+- Error path: verification fails (throws) when the running container's `RepoDigests` does not match the CI-pushed digest.
+- Error path (from preflight): a missing/unpullable image errors out and does **not** trigger a host-side build.
+
+**Verification:**
+- A deploy pulls both images, recreates, all services healthy, and the running gateway/workspace images are the GHCR `:<ref>` artifacts (verified by image ref, not git source).
+
+- [ ] **Unit 3: Docs + AGENTS.md for the new flow**
+
+**Goal:** Document the build→push→pull deploy flow, GHCR packages, local/emergency deploy path, and running-image verification.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `apps/gateway/AGENTS.md` (deploy flow now: CI builds+pushes → droplet pulls; GHCR package names + visibility; local-deploy/emergency path; image verification)
+- Modify: root `AGENTS.md` if it documents the gateway deploy mechanism
+- Modify: `README.md` only if it describes the gateway deploy build step
+
+**Approach:**
+- Replace any "droplet builds images" wording with the CI-build → GHCR-push → droplet-pull flow.
+- Document the **break-glass runbook**: build+push the pinned ref from a workstation to GHCR, then `deploy --local` (pull). Explicitly warn operators never to `docker compose up --build` on the droplet (reintroduces the swap-thrash). State the new dependency on CI/GHCR availability honestly.
+- Document the digest-based running-image verification command.
+- Note the GHCR package visibility decision (public after secret-safety audit, else private+token) and the pull-auth secret if private.
+
+**Patterns to follow:**
+- Existing `apps/gateway/AGENTS.md` deploy-flow + anti-pattern structure.
+
+**Test scenarios:**
+- Test expectation: none — documentation only.
+
+**Verification:**
+- AGENTS.md describes the off-droplet flow accurately; no stale "on-droplet build" references remain (grep clean).
+
+## System-Wide Impact
+
+- **Interaction graph:** CI `build-images` → GHCR → droplet `pull`. The `deploy.ts` checkout + secret-materialization + checksum + Discord-registration flow are otherwise unchanged.
+- **Error propagation:** Build/push failure → `deploy` job blocked (old stack untouched). Pull failure on the droplet → `up` does not recreate from a missing image; old stack stays up; deploy errors clearly.
+- **State lifecycle risks:** The secrets-checksum sentinel must remain authoritative; recreate still gated on checksum change + `--force-recreate`. The manual emergency rebuild changes from "build on droplet" to "pull a CI-built tag."
+- **API surface parity:** `cliproxy`/`umami` already pull prebuilt images; this brings gateway in line. No CLI flag changes (the `--force-recreate`/dry-run surfaces are preserved).
+- **Unchanged invariants:** secret materialization (stdin/`0600`/no-argv), `validateGatewayHost`, host-key pinning, `init-certs.sh` CA bootstrap, `--wait`/`--wait-timeout 120`, Discord registration polling — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Compose host-builds a `build:` service despite the `image:` pin (the outage comes back via the back door) | Resolve-Before-Implementation preflight PROVES the no-build semantics on the droplet's Compose version; Unit 2 adds a guard if needed; test asserts a missing image errors instead of building. |
+| Mutable tag pull/verify is non-deterministic | Pin + pull + verify by **digest**, not tag; tags are readability-only. |
+| Secret accidentally baked into a public image | Pre-publish secret-safety audit of Dockerfiles/build context gates the public decision; fall back to private + read-only token if inconclusive. |
+| GHCR/CI unavailable during an incident (no on-droplet build fallback) | Documented break-glass: workstation build+push → `deploy --local` pull. Honest tradeoff — the on-droplet build is the hazard being removed. |
+| Two images (gateway/workspace) drift or one push fails | Both built+pushed in the same `build-images` job; `deploy` gated on `needs: build-images`; both digests threaded together or the deploy doesn't run. |
+| `packages: write` over-broad | Scoped to the `build-images` job only; deploy job stays package-read-only. |
+
+## Documentation / Operational Notes
+
+- One-time: set the GHCR packages public (if public path) after first publish, or seed a read-only GHCR token secret (if private path).
+- The next `fro-bot/agent` bump exercises the new path end-to-end; verify the running image is the GHCR artifact, not a droplet build.
+- No changeset — this changes `apps/gateway/` deploy infra + CI, not `packages/cli/src` (the published package).
+
+## Sources & References
+
+- **Origin document:** `docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md`
+- Related code: `apps/gateway/src/deploy.ts` (`buildComposeOverride`, compose-arg builder, `resolveUpstreamPin`), `.github/workflows/deploy-gateway.yaml`, `.github/workflows/deploy.yaml`
+- Related learnings: `gateway-deploy-stale-image-2026-05-31.md`, `gateway-first-deploy-cascade-2026-05-20.md`, `gateway-v0500-undeployable-upstream-2026-06-02.md`
+- Upstream: `fro-bot/agent` `deploy/compose.yaml`, `deploy/gateway.Dockerfile`, `deploy/workspace.Dockerfile`


### PR DESCRIPTION
Move the gateway + workspace Docker image builds off the production droplet.

The gateway deploy was the only one in the repo that built images on the target host. On the `s-1vcpu-2gb` droplet, `docker compose up --build` rebuilds the memory-heavy workspace image while the old stack is still running — the combined footprint exceeds 2 GB, the box swap-thrashes, and a recent v0.54.1 cutover took the gateway down for ~50 minutes.

Now the build happens in CI and the droplet only pulls:

- A new `build-images` CI job builds both images from the pinned `fro-bot/agent` ref, pushes them to GHCR (`infra-gateway`, `infra-workspace`), and captures each pushed digest. `packages: write` is scoped to that job only.
- The deploy job depends on `build-images`, so a failed build blocks the deploy and the live stack stays up.
- On the droplet, the compose override pins both services to `ghcr.io/...@sha256:<digest>`, the deploy runs `docker compose pull` then `up -d --no-build` (never builds), and verifies the running image's digest matches the CI-pushed digest.

GHCR packages are public — the upstream Dockerfiles bake no secrets (all secrets are runtime bind-mounts), so the droplet pulls without auth.

I proved the load-bearing behavior on the droplet's Docker Compose v5.1.3 before building: an image-pinned `build:` service with `pull` + `--no-build` uses the pulled image and never host-builds, and a missing image errors instead of falling back to a build. The digest-verification command is also validated live.

`apps/gateway/AGENTS.md` documents the new flow, the public-GHCR rationale, digest verification, and a break-glass workstation build+push runbook for when CI/GHCR is unavailable.

No changeset — this is gateway deploy infrastructure, not the published CLI.
