### PR TITLE
docs(solutions): off-droplet image build playbook

### DIFF
--- a/docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md
+++ b/docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md
@@ -1,0 +1,245 @@
+---
+title: Off-droplet Docker image build for a single-droplet deploy (CI build → GHCR push → droplet pull)
+date: 2026-06-04
+category: docs/solutions/best-practices
+module: apps/gateway
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - A single-droplet deploy currently runs `docker compose up --build` on the target host
+  - The host is too small (e.g. 1vCPU/2GB) to build a memory-heavy image while the old stack is still running
+  - You want reproducible, digest-pinned deploy artifacts built from a pinned source ref
+  - You need the running host to only pull prebuilt images, never build
+  - You need to verify the running image's identity (not just its tag) after a registry pull
+related_components:
+  - cliproxy
+  - umami
+tags:
+  - gateway
+  - ghcr
+  - docker
+  - off-droplet-build
+  - digest-pinning
+  - deploy
+  - reusable-workflow
+  - pull-not-build
+---
+
+# Off-droplet Docker image build for a single-droplet deploy (CI build → GHCR push → droplet pull)
+
+## Context
+
+A single-droplet deploy that builds its image on the target host has a latent resourcing
+bomb: `docker compose up --build` builds the new image *while the old stack is still running*,
+so peak memory is roughly old-stack + build. On a small droplet (the gateway runs on
+`s-1vcpu-2gb`) building a memory-heavy image (a Node/OpenCode workspace image) blows past
+available RAM and thrashes swap — a `fro-bot/agent` v0.54.1 cutover did exactly this and took
+the gateway down for ~50 minutes (see `docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md`).
+
+The durable fix is to move the build off the droplet entirely:
+
+```text
+CI runner (16 GB):  checkout pinned ref → build → push to GHCR → capture digest
+Droplet (2 GB):     pull digest-pinned image → up -d --no-build → verify running digest
+```
+
+This playbook captures the reusable mechanics so other single-droplet deploys
+(`apps/cliproxy`, `apps/umami`) can adopt the same model.
+
+## Guidance
+
+### 1. Build off-droplet; the droplet only pulls
+
+The CI runner builds and pushes; the droplet pulls and recreates without building.
+
+```bash
+docker compose --project-directory "$DEPLOY_DIR" pull
+docker compose --project-directory "$DEPLOY_DIR" up -d --no-build --wait --wait-timeout 120 --remove-orphans
+```
+
+`--no-build` is belt-and-suspenders: even an accidental future code path cannot trigger a
+host build.
+
+### 2. Materialize the image pins unconditionally
+
+Write the `image:` digest pins on **every** deploy. Do not gate them behind an optional
+feature flag (the gateway's announce/Caddy override is a conditional *layer* merged into the
+same file — the image pins are not). If the default path can omit the override, Compose can
+drift back toward `build:` semantics and the host builds again.
+
+```ts
+// buildComposeOverride(): image pins always present; announce/Caddy is a conditional layer
+return `services:
+  gateway:
+    image: ${GATEWAY_IMAGE_NAME}@${gatewayDigest}${announceGatewaySection}
+  workspace:
+    image: ${WORKSPACE_IMAGE_NAME}@${workspaceDigest}
+${caddySection}${volumesSection}`
+```
+
+### 3. Pin by digest, not tag — and validate the shape
+
+GHCR tags are mutable; digests are identity. Capture the pushed digest from
+`docker/build-push-action` (`outputs.digest`), pin `image: ...@sha256:<digest>`, and validate
+the shape before it reaches a compose file or a remote command:
+
+```ts
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
+if (!DIGEST_RE.test(gatewayDigest)) {
+  throw new Error('GATEWAY_IMAGE_DIGEST is not a valid sha256 digest')
+}
+```
+
+Validating up front (before any SSH) keeps a malformed digest from materializing a bad image
+reference or reaching an interpolated remote command.
+
+### 4. Compose `build:` + `image:` coexistence — PROVEN, not assumed
+
+The load-bearing assumption is that a service with BOTH an upstream `build:` and an override
+`image:` pin, run with `pull` + `up --no-build`, uses the pulled image and never host-builds.
+Prove it on the target's actual Compose version before relying on it. Disjoint-project proof
+(verified on Docker Compose v5.1.3):
+
+```bash
+# A Dockerfile that, IF built, writes an obvious marker the pulled image lacks:
+cat > Dockerfile <<'DF'
+FROM alpine:3.20
+RUN echo "BUILT-ON-HOST" > /marker
+CMD ["cat","/marker"]
+DF
+# Service has BOTH build: and image: (image is a plain alpine, NOT the built one):
+cat > compose.yaml <<'CY'
+services:
+  probe:
+    build: .
+    image: alpine:3.20
+    command: ["sh","-c","test -f /marker && echo USED-BUILD || echo USED-IMAGE"]
+CY
+docker compose -p semtest pull
+docker compose -p semtest up --no-build   # → "USED-IMAGE" (never built)
+```
+
+Results that must hold:
+- `pull` + `up --no-build` → **USED-IMAGE** (the pulled image runs; no build).
+- A missing/unpullable `image:` → the pull/up **errors** (it does NOT fall back to a host build).
+- Even a plain `up` (no `--build`) on a `build:`+`image:` service uses the image.
+
+If any of these don't hold on your Compose version, add an explicit guard before adopting.
+
+### 5. Verify the running image by digest — in two steps
+
+A **container** has no `.RepoDigests` field; the **image** does. Inspecting the container
+directly returns a template error and empty output, which silently fails verification.
+
+**Correct (two-step):**
+
+```bash
+IMAGE_SHA=$(docker inspect --format '{{.Image}}' "$(docker compose --project-directory "$DEPLOY_DIR" ps -q gateway)")
+docker inspect --format '{{json .RepoDigests}}' "$IMAGE_SHA"
+# → ["ghcr.io/marcusrbrown/infra-gateway@sha256:<digest>"]  — compare to the CI-pushed digest
+```
+
+**Anti-pattern (always fails):**
+
+```bash
+docker inspect --format '{{json .RepoDigests}}' "$(docker compose ps -q gateway)"
+# container has no .RepoDigests → template error → empty → verification always throws
+```
+
+Narrow the parsed JSON to `string[]` (reject `null`/object/non-string array) so a malformed
+inspect result surfaces an actionable mismatch error rather than a `TypeError`.
+
+### 6. Reusable-workflow permissions are capped by the caller
+
+A called reusable workflow's `GITHUB_TOKEN` permissions cannot exceed what the caller grants.
+Declaring `packages: write` on the build job inside the reusable workflow is necessary but
+**insufficient** — the caller job in the parent workflow must grant it too. Scope it to the
+single job, not workflow-wide and not on sibling deploy jobs.
+
+```yaml
+# Parent (.github/workflows/deploy.yaml) — caller job:
+deploy-gateway:
+  permissions:
+    contents: read
+    packages: write
+  uses: ./.github/workflows/deploy-gateway.yaml
+
+# Reusable (.github/workflows/deploy-gateway.yaml) — build job:
+build-images:
+  permissions:
+    contents: read
+    packages: write
+```
+
+Symptom when the caller grant is missing: the GHCR push 403s even though the build job's own
+`permissions:` block looks correct.
+
+### 7. Public GHCR packages — verify pullability anonymously
+
+Packages with no baked secrets can be public (the droplet then pulls with no auth). On first
+push the package may already be public (org/repo default) — verify rather than assume, via the
+anonymous registry token + manifest endpoint:
+
+```bash
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:marcusrbrown/infra-gateway:pull" | jq -r .token)
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://ghcr.io/v2/marcusrbrown/infra-gateway/manifests/<tag>"
+# 200 → public and pullable; 401/403 → private (flip to public or add a read-only pull token)
+```
+
+Before going public, audit the Dockerfiles/build context: no secret `ARG`/`ENV`, no `COPY` of
+a secrets directory. All runtime secrets should be bind-mounts into `/run/secrets/...`, never
+baked into a layer.
+
+### 8. Safe failure is deliberate
+
+The deploy job depends on the build job, so a failed build/push never touches the live stack:
+
+```yaml
+deploy-gateway:
+  needs: build-images
+```
+
+On the droplet, the `pull` runs before `up`, so an unavailable image errors before any
+recreate — the old stack stays live. Break-glass when CI/GHCR is unavailable: build + push the
+pinned ref from a workstation (ample RAM — the off-droplet build done by hand), then deploy
+locally with the digests supplied manually:
+
+```bash
+GATEWAY_IMAGE_DIGEST="sha256:..." \
+WORKSPACE_IMAGE_DIGEST="sha256:..." \
+bunx @marcusrbrown/infra gateway deploy --local
+```
+
+Never run `docker compose up --build` on the droplet — that reintroduces the swap-thrash.
+
+## Why This Matters
+
+- Eliminates swap-thrash outages on small droplets — the build moves to a 16 GB runner.
+- Deploys become reproducible and immutable: the droplet runs exactly the digest CI pushed.
+- Verification answers "are we really running the pushed image?" as a hard digest check, not a tag.
+- Safety is preserved: a failed build or unavailable image leaves the old stack running.
+- The build → push → deploy trust chain stays explicit, including across reusable workflows.
+
+## When to Apply
+
+Any single-droplet deploy where the host is too small to build safely, the image is built in
+CI, the runtime host should only pull, and you want rollback-safe, digest-verified deploys.
+Directly reusable for `apps/cliproxy` and `apps/umami`, which currently pull upstream registry
+images but build no custom image — if either grows a custom build, adopt this model rather than
+building on its droplet.
+
+## Examples
+
+The shipped implementation lives in `apps/gateway/src/deploy.ts`,
+`.github/workflows/deploy-gateway.yaml` (the `build-images` job + digest outputs), and
+`.github/workflows/deploy.yaml` (the `deploy-gateway` caller permission grant). `apps/gateway/AGENTS.md`
+documents the operator flow + the break-glass runbook.
+
+## Related
+
+- `docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md` — the outage that motivated this. Its "build off-droplet (GHCR) and pull" prevention option is what this playbook operationalizes; that option is now the implemented path.
+- `docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md` — added `--build` to defeat stale-image reuse for an **on-host** build. That guidance applies to host-built `build:` services; under this off-droplet model the droplet pulls a digest-pinned image and must not use `--build`.
+- `docs/solutions/best-practices/major-version-upstream-upgrade-playbook-2026-05-29.md` — complementary image-swap discipline: probe the pinned image, verify the real contract, keep cutover rollback-safe.

--- a/docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md
+++ b/docs/solutions/workflow-issues/gateway-deploy-resourcing-thrash-2026-06-04.md
@@ -109,7 +109,7 @@ verify the running image's build timestamp + code signature, never the git check
 
 - **The next `fro-bot/agent` CI bump WILL re-thrash** — same `--build`-with-old-stack-running path. Fix before the next daemon bump, via one of:
   - **Resize the droplet to ≥4 GB** — simplest; the build gets headroom alongside the running stack. Standing cost increase.
-  - **Build off-droplet (GHCR) and pull** — no recurring cost; the droplet only pulls a prebuilt image. Larger change (CI build/push + registry auth).
+  - **Build off-droplet (GHCR) and pull** — no recurring cost; the droplet only pulls a prebuilt image. Larger change (CI build/push + registry auth). **This is the implemented path** — see the playbook `docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md`. The droplet now pulls digest-pinned GHCR images and never builds.
   - **Stop the old stack before building in `deploy.ts`** — no cost; accepts a planned downtime window per deploy (no safe-failure fallback during the build).
 - **Always run a manual recovery rebuild detached** (`setsid`/`nohup` to a logfile) so an SSH drop or local fork-pressure can't abort it half-done.
 - **Never SSH-hammer a thrashing droplet** — it can't run `docker ps`, and UFW rate-limits new connections. Use external probes (public endpoint, GitHub run API, `doctl`) which add zero droplet load.

--- a/docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md
+++ b/docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md
@@ -61,7 +61,7 @@ The deploy's job is to make the running daemon match the pinned source. With a `
 
 ## Prevention
 
-- **For any `build:`-from-source Compose service, the deploy must `docker compose up --build`.** Without it, source changes (including pin bumps) never reach the running container. Mechanically enforced by a test asserting `--build` is present in the compose command on every path:
+- **For an ON-HOST `build:`-from-source Compose deploy, the deploy must `docker compose up --build`.** Without it, source changes (including pin bumps) never reach the running container. (Scope: this applies when the host builds the image. The gateway deploy later moved the build off the droplet — CI builds and pushes to GHCR, the droplet pulls a digest-pinned image and runs `up -d --no-build`. Under that model the droplet must NOT use `--build`; freshness comes from the pinned digest, not a host rebuild. See `docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md`.) When the host does build, enforce `--build` with a test asserting it is present in the compose command on every path:
 
   ```ts
   const composeCall = calls.find(cmd => cmd.some(s => s.includes('docker compose')))


### PR DESCRIPTION
Capture the off-droplet image build approach as a reusable best-practice playbook, now that it's shipped and verified live on the gateway.

The playbook documents the durable mechanics for building Docker images in CI and pulling digest-pinned images on a small droplet instead of building on-host:

- Why build off-droplet (small droplets swap-thrash when building alongside the live stack)
- The Compose `build:` + `image:` coexistence behavior, with the empirical proof technique
- Always-materializing the image pins (not gating them behind a feature flag)
- Digest-pinning instead of mutable tags, with shape validation
- Two-step running-image verification (a container has no `.RepoDigests`; the image does)
- The reusable-workflow caller-permission cap (the caller must grant `packages: write`)
- Anonymous GHCR public-pull verification
- Safe-failure preservation and the break-glass workstation path

It also cross-references the resourcing-thrash incident doc (this operationalizes its "build off-droplet and pull" prevention option) and adds an on-host-only caveat to the stale-image `--build` guidance so the two don't read as contradictory.

Directly reusable for the cliproxy and umami deploys. Docs only — no changeset.
