### PR TITLE
fix(opencode): run infra MCP from local source

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -6,7 +6,7 @@
     // .env locally; CI/harness inherits the parent process env. No values in this file.
     "infra": {
       "type": "local",
-      "command": ["bunx", "@marcusrbrown/infra", "mcp"],
+      "command": ["bun", "run", "packages/cli/src/cli.ts", "mcp"],
       "enabled": true,
     },
   },

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -276,6 +276,30 @@ describe('repo conventions', () => {
     expect(offenders).toEqual([])
   })
 
+  it('opencode.jsonc mcp.infra.command uses local repo source (not bunx published package)', async () => {
+    const jsoncText = await Bun.file(resolve(REPO_ROOT, 'opencode.jsonc')).text()
+    const stripped = jsoncText
+      .split('\n')
+      .map(line => (/^\s*\/\//.test(line) ? '' : line))
+      .join('\n')
+      .replaceAll(/,(\s*[}\]])/g, '$1')
+    const opencode = JSON.parse(stripped) as {mcp?: {infra?: {command?: unknown}}}
+
+    const infraCommand = opencode.mcp?.infra?.command
+    expect(Array.isArray(infraCommand), 'mcp.infra.command must be an array').toBe(true)
+
+    const cmd = infraCommand as string[]
+    expect(
+      cmd,
+      'mcp.infra.command must be ["bun", "run", "packages/cli/src/cli.ts", "mcp"] — use local source, not bunx',
+    ).toEqual(['bun', 'run', 'packages/cli/src/cli.ts', 'mcp'])
+
+    // Explicit regression guard: bunx @marcusrbrown/infra resolves stale published
+    // package cache and exits before the MCP handshake, causing connection closed.
+    expect(cmd.join(' ')).not.toContain('bunx')
+    expect(cmd.join(' ')).not.toContain('@marcusrbrown/infra')
+  })
+
   it('gates every sensitive infra MCP tool in opencode.jsonc', async () => {
     // Parse opencode.jsonc tolerantly: it uses JSONC syntax (// line comments,
     // trailing commas). Strategy:


### PR DESCRIPTION
## Summary

- Run the project infra MCP server from checked-out repo source instead of the published package path.
- Add a convention test that pins the local-source command and rejects the stale `bunx @marcusrbrown/infra` path.

## Verification

- `bun test packages/cli/src/conventions.test.ts`
- `printf '\ | bun run packages/cli/src/cli.ts mcp`
- held-open MCP stdio smoke (`tail -f /dev/null | bun run packages/cli/src/cli.ts mcp`)
- `bun test --recursive`
- `bunx tsc --noEmit`
- `bun run lint`
