### PR TITLE
chore(gateway): allow fro-bot agent v0.55 updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,9 +72,9 @@
       // the workspace-agent secret additions are why this gate exists.
       automerge: false,
       dependencyDashboardApproval: true,
-      // Allow v0.54.x patch/hotfix PRs; v0.55.0+ needs a deliberate source-contract pass
+      // Allow v0.55.x patch/hotfix PRs; v0.56.0+ needs a deliberate source-contract pass
       // (verify no new boot-required secrets) before the ceiling moves.
-      allowedVersions: '<0.55.0',
+      allowedVersions: '<0.56.0',
     },
   ],
   // Track the upstream daemon source pin (`ref`) in each apps/*/upstream.json so new


### PR DESCRIPTION
## Summary
- allows Renovate to keep `fro-bot/agent` v0.55.x gateway daemon updates after the v0.55.2 source-contract pass
- keeps the next minor line gated so v0.56.0+ still requires deliberate review before the ceiling moves

## Verification
- `npx --yes --package renovate@latest renovate-config-validator .github/renovate.json5`
