### PR TITLE
docs: add generating-project-docs skill + ARCHITECTURE.md and STRUCTURE.md

### DIFF
--- a/.agents/skills/generating-project-docs/SKILL.md
+++ b/.agents/skills/generating-project-docs/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: generating-project-docs
+description: Use when creating, refreshing, or updating this repo's agent-facing system docs — ARCHITECTURE.md and STRUCTURE.md, or scoped section updates within them
+argument-hint: "[architecture|structure|all|section-name]"
+---
+
+# Generating Project Documentation
+
+## Overview
+
+This is a Bun-workspace monorepo of personal infrastructure deploys (apps under `apps/`, shared libraries under `packages/`, a goke CLI, GitHub Actions deploy pipelines, an MCP bridge). Its surface — apps, CLI commands, deploy contracts, pinned upstream versions — changes constantly, so generated docs go stale fast.
+
+**Core principle:** Derive every fact from the live repository. Optimize for an AI agent that needs to orient and make a correct change. Preserve each document's evolved structure. Never regress to a generic template.
+
+If you cannot point at a file or command that justifies a sentence, do not write it.
+
+**Scope:** This skill owns `ARCHITECTURE.md` and `STRUCTURE.md` (root-level, agent-facing system docs). It does NOT own `README.md` — the `/generate-readme` OpenCode command (`.opencode/commands/generate-readme.md`) owns that. When this skill creates ARCHITECTURE.md / STRUCTURE.md, the deep structural content moves OUT of the README into them, and the README links to them.
+
+## When to Use
+
+- Creating `ARCHITECTURE.md` or `STRUCTURE.md` for the first time (neither exists yet)
+- Refreshing them after a new app, package, CLI command, or deploy contract lands
+- Fixing documentation drift (app/package counts, directory layout, CLI surface, codemap paths)
+- Updating a scoped section (e.g. only the `## Codemap` block or the "Where to Add New Code" checklist)
+
+## When NOT to Use
+
+- Updating `README.md` — use the `/generate-readme` command instead
+- Writing planning docs (`docs/brainstorms/`, `docs/plans/`, `docs/solutions/`) — those follow their own templates
+- Writing per-app operational docs (`apps/*/AGENTS.md`, `packages/*/AGENTS.md`) — those are nearest-context runbooks with their own shape; ARCHITECTURE/STRUCTURE link TO them, they are not regenerated here
+
+## Arguments
+
+```
+$ARGUMENTS
+```
+
+- **Empty or `architecture`** — Create/update `ARCHITECTURE.md` (default)
+- **`structure`** — Create/update `STRUCTURE.md`
+- **`all`** — Both docs
+- **`<section-name>`** — Update only that named section within the target doc (e.g. `codemap`, `invariants`, `where-to-add`)
+
+For scoped updates: read the current document, locate the section by heading, replace only that section's content. Preserve surrounding structure exactly.
+
+## Pre-Generation Inventory
+
+Before writing anything, gather these from the live repo. Count things; never estimate or carry over from a previous draft or from the README.
+
+| Source | What to extract |
+|--------|----------------|
+| `ls -d apps/*/` | exact app list (keeweb, cliproxy, gateway, umami, …) |
+| `ls -d packages/*/` | exact package list (cli, shared, …) |
+| `cat package.json` | workspaces globs, root scripts (`provision:*`, `deploy:*`, `test`, `lint`), version |
+| `cat apps/*/package.json packages/*/package.json` | per-workspace name, description, scripts |
+| `grep -nE "register[A-Z]" packages/cli/src/cli.ts` | exact CLI command-group registrations |
+| `ls packages/cli/src/commands/*/` | per-app subcommand files (status, deploy, …) |
+| `find . -name AGENTS.md -not -path '*/node_modules/*' -not -path './.slim/*'` | the real AGENTS.md hierarchy to cross-link |
+| `ls .github/workflows/*.yaml` | workflow + deploy-pipeline inventory |
+| `cat apps/*/upstream.json 2>/dev/null` | pinned upstream daemon refs (gateway) |
+| `git log --oneline -15` | recent change context |
+| Current target doc (if it exists) | existing structure, headings, voice |
+
+Use `find ... -exec` or `while IFS= read -r` for shell loops over file lists. Unquoted `for f in $VAR` does not word-split a multiline variable reliably.
+
+Counts and paths MUST come from live `ls`/`find`/`grep`. Exclude `.slim/clonedeps/` (vendored dependency source) from every inventory — it is not part of this repo's structure.
+
+## AI-Agent Optimization Rules (Non-Negotiable)
+
+These docs are read by coding agents that need to make a correct change fast. Optimize for retrieval and action, not prose.
+
+1. **Codemap by symbol/path, never by line number.** Reference `apps/gateway/src/deploy.ts` and the `main()` export, not "line 240". Line numbers rot on the next edit; agents symbol-search.
+2. **Invariants stated as enforceable rules.** Phrase as constraints an agent can self-check: "Only `apps/keeweb/deploy.sh` is Bash", "Never pass secret bytes via argv", "`apps/` is deployable units; `packages/` is reusable libraries — `packages/` never imports from `apps/`". Mirror the `(enforced)` anti-patterns already in root `AGENTS.md`.
+3. **Prescriptive "Where to Add New X".** Don't just list what exists — give the step-by-step pattern: "New app → create `apps/<name>/`, mirror `apps/cliproxy/` (compose + `src/deploy.ts` + `server/provision-droplet.ts`), add to `package.json` workspaces, add `provision:<name>`/`deploy:<name>` root scripts, add `apps/<name>/AGENTS.md`, add a `deploy-<name>.yaml` workflow."
+4. **Tables for codemap and key-file lookup** (agents parse `| role | path |` better than prose). Prose for data flow and rationale.
+5. **Cross-link to nearest-context AGENTS.md.** Each app/package has its own `AGENTS.md` runbook. ARCHITECTURE/STRUCTURE point at them for operational detail and do not duplicate it.
+6. **State the boundary upfront.** Each doc opens by saying what it covers and where to go for the rest: "This describes system shape and invariants. For deploy procedures see `apps/<name>/AGENTS.md`; for the CLI surface see `packages/cli/AGENTS.md`; for where things live see `STRUCTURE.md`."
+7. **Describe shape, not volatile specifics.** Don't hardcode port numbers, version refs, or exact CLI flags that live in source — name the source of truth instead (e.g. "the pinned daemon ref lives in `apps/gateway/upstream.json`").
+
+## Document Division of Labor
+
+Keep the two docs disjoint so they don't drift into each other.
+
+| `ARCHITECTURE.md` (why / how it fits) | `STRUCTURE.md` (where things live) |
+|---------------------------------------|------------------------------------|
+| System shape: apps vs packages vs CLI vs MCP bridge | Directory tree with inline purpose comments |
+| Codemap: role → path table | Per-directory purpose subsections |
+| Data flow: CLI → command module → SSH/deploy / MCP bridge → tool | Naming conventions (files, tests, commands) |
+| Invariants CI/review enforce | Key file locations (entry points, config, tests) |
+| Cross-cutting concerns (secrets, deploy gating, host-key pinning, paths-filter) | "Where to Add New Code" checklist |
+| "Where to add a new app / command" patterns (the *why*/integration) | Build-artifact + fixture/snapshot locations |
+
+## Section Order
+
+Read the target doc first (if it exists) and preserve its evolved structure. The lists below are the starting shape for first creation; confirm against the live file before regenerating. New top-level sections need explicit approval.
+
+### `ARCHITECTURE.md`
+
+Following matklad's "Bird's Eye" pattern, optimized for agents.
+
+1. `# Architecture` — H1 + 1–2 sentence orientation pointing at `STRUCTURE.md` and the AGENTS.md hierarchy, and the boundary statement (rule 6 above)
+2. `## Bird's Eye Overview` — two paragraphs: the monorepo's job (deploy + manage personal infra) and its shape (each `apps/<name>` is a self-contained DigitalOcean/Docker-Compose deploy unit; `packages/cli` is the unified operator surface; `packages/shared` holds cross-app helpers; the MCP bridge re-exposes read commands)
+3. `## Codemap` — role → path table (deploy scripts, provision scripts, CLI command groups, shared helpers, MCP bridge, conventions test) using symbols/paths, no line numbers
+4. `## Data Flow` — operator/agent → `packages/cli` command → goke action → SSH/Docker-Compose on droplet, and the MCP-bridge path (`ctx`-captured read commands only)
+5. `## Invariants` — numbered, enforceable; mirror root `AGENTS.md` anti-patterns (Bash-script rule, secrets-never-in-argv, `apps`↔`packages` import direction, SHA-pinned actions, `.yaml` workflows, no `as any`, paths-filter `predicate-quantifier: every`)
+6. `## Cross-Cutting Concerns` — secret materialization, GitHub Environment deploy gating, pinned host keys (`.github/known_hosts`), upstream pin + verify-at-tag (gateway), conventions test as executable enforcement
+7. `## Where to Add New Code` — integration-level patterns (new app, new CLI command group, new deploy workflow), each cross-linking STRUCTURE.md for the mechanical layout
+
+### `STRUCTURE.md`
+
+Audience: an agent that needs to know where to put a change.
+
+1. `# Structure` — H1 + cross-references to `ARCHITECTURE.md` and the AGENTS.md hierarchy
+2. `## Directory Layout` — ASCII tree of `apps/`, `packages/`, `.github/`, `docs/`, `.agents/`, `.opencode/` with inline purpose comments (exclude `.slim/`)
+3. `## Directory Purposes` — H3 per top-level dir (`apps/`, `packages/`, `.github/`, `docs/`, `.agents/skills/`, `.opencode/commands/`)
+4. `## Key File Locations` — categorized tables: Entry Points, Per-App Deploy/Provision, CLI Commands, Config, Tests, CI/Deploy
+5. `## Naming Conventions` — files, colocated `*.test.ts`, `__fixtures__/`/`__snapshots__/`, command modules (`<action>.ts` under `commands/<app>/` + barrel `index.ts`), host validators (`host.ts` per app)
+6. `## Where to Add New Code` — mechanical checklist (new app, new command, new shared helper, new test, new workflow, new docs page), deferring the *why* to ARCHITECTURE.md
+
+## Style Rules (Non-Negotiable)
+
+1. **Voice**: terse, declarative, fact-first. No marketing language ("robust", "powerful", "leverages", "seamless").
+2. **Present tense, current state only**: describe what the system IS. Never "previously X", "unchanged behavior", or session/process framing.
+3. **No session/process leakage**: never reference subagent names, plan paths, skill names, plan-unit/rule-ID taxonomy, or "how it was built". These docs describe the system, not the work that produced them. Grep gate before save: `grep -nE "\bUnit [0-9]+|\bR[0-9]+\b|ce:[a-z]" ARCHITECTURE.md STRUCTURE.md` returns nothing.
+4. **Paths in backticks**: every file, directory, command, env var.
+5. **Code blocks language-tagged**: `bash`, `json`, `text` for trees, `mermaid` only if a diagram earns its place.
+6. **No secrets, no machine-specifics**: no real secret values, no droplet IPs, no `/Users/...` local paths, no live hostnames beyond the public deploy domains already in the README.
+7. **Counts derived from live tooling**: never hardcode "4 apps" without having just run `ls -d apps/*/`.
+8. **Symbol references, not line numbers** (restating rule 1 of AI-Agent Optimization because it is the most common rot source).
+
+## Generation Flow
+
+1. **Inventory** — run every command in "Pre-Generation Inventory". Count; don't estimate.
+2. **Diff against current doc** — for each section, identify what changed (new app/package, new command group, renamed paths, count drift). First creation: extract the deep structural content from `README.md`'s `## Repository Structure` and the deploy/CI sections, reshaped per the section order above, then leave a lean pointer in the README (coordinate with `/generate-readme`).
+3. **Write minimal diff** — update only what changed; keep voice and untouched sections exact.
+4. **Verify** — run the quality checks below; re-read end-to-end before saving.
+
+## Quality Checks
+
+**Security (always):**
+- [ ] No secrets, tokens, droplet IPs, or local `/Users/...` paths
+- [ ] Only public deploy domains referenced (those already public in the README)
+
+**Accuracy (always):**
+- [ ] App/package counts and names match `ls -d apps/*/` and `ls -d packages/*/`
+- [ ] Every codemap path resolves to a real file on disk
+- [ ] CLI command groups match `grep register[A-Z] packages/cli/src/cli.ts`
+- [ ] Every cross-link (ARCHITECTURE ↔ STRUCTURE ↔ AGENTS.md ↔ README) resolves
+- [ ] No line-number references in any codemap entry
+
+**Style (always):**
+- [ ] Headings increase monotonically (H1 → H2 → H3)
+- [ ] All code blocks language-tagged; all paths in backticks
+- [ ] Taxonomy/process-leakage grep returns nothing (see Style rule 3)
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Carrying counts/paths from the README or a previous draft | Re-derive from `ls`/`find`/`grep` |
+| Line numbers in the codemap | Reference the symbol/path; agents symbol-search |
+| Duplicating deploy procedures from `apps/*/AGENTS.md` | Cross-link to the AGENTS.md; don't copy |
+| Regenerating the README here | README is owned by `/generate-readme`; this skill owns ARCHITECTURE/STRUCTURE |
+| Overlapping ARCHITECTURE and STRUCTURE content | Apply the division-of-labor table; shape/why vs where/layout |
+| Including `.slim/clonedeps/` in trees or counts | Exclude vendored dependency source from all inventory |
+| Marketing language or "previously X" framing | Delete it; state the present-tense fact |
+| Leaking plan/skill/subagent names | These docs describe the system, not how it was built |
+
+## Quick Reference
+
+```bash
+# Inventory (run before writing)
+ls -d apps/*/ packages/*/                              # apps + packages
+grep -nE "register[A-Z]" packages/cli/src/cli.ts       # CLI command groups
+find . -name AGENTS.md -not -path '*/node_modules/*' -not -path './.slim/*'   # AGENTS.md hierarchy
+ls .github/workflows/*.yaml                            # workflows / deploy pipeline
+cat apps/*/upstream.json 2>/dev/null                   # pinned upstream refs
+git log --oneline -15                                  # recent change context
+
+# Verify (run after writing)
+grep -nE "\bUnit [0-9]+|\bR[0-9]+\b|ce:[a-z]" ARCHITECTURE.md STRUCTURE.md   # must be empty
+git diff ARCHITECTURE.md STRUCTURE.md                  # review own diff
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architecture
+
+System shape and invariants for this monorepo. For where things live, see [`STRUCTURE.md`](STRUCTURE.md). For per-app operational detail (deploy procedures, runbooks, secret contracts) see each `apps/<name>/AGENTS.md` and `packages/cli/AGENTS.md`. For the CLI surface and command help, see `packages/cli/AGENTS.md`.
+
+## Bird's Eye Overview
+
+This is a Bun-workspace monorepo that deploys and manages personal infrastructure: KeeWeb (`box.heatvision.co`), a CLIProxyAPI Claude proxy (`cliproxy.fro.bot`), the Fro Bot Discord gateway (`gateway.fro.bot`), and Umami analytics (`metrics.fro.bot`). Each deployable lives under `apps/`; each is self-contained (its own Docker Compose stack or build, a TypeScript deploy script, and a droplet provisioning script). DigitalOcean droplets host the Docker apps; KeeWeb deploys to a Mail-in-a-Box server over SSH/rsync.
+
+`packages/cli` is the unified operator surface — a goke CLI (`@marcusrbrown/infra`) with one command group per app plus a unified `status` dashboard. `packages/shared` holds cross-app provisioning helpers. The same CLI exposes a read-only subset of its commands over an MCP bridge so coding agents can query deployment state. GitHub Actions runs the deploy pipeline (one gated workflow per app behind a per-app GitHub Environment) and automation (Fro Bot review, Renovate, releases via Changesets).
+
+## Codemap
+
+Role → path. Reference symbols and files; no line numbers (they rot).
+
+| Role | Path |
+| --- | --- |
+| CLI entry point (goke) | `packages/cli/src/cli.ts` (`registerKeewebCommands`, `registerCliproxyCommands`, `registerGatewayCommands`, `registerUmamiCommands`, `registerStatus`, `registerMcp`) |
+| Per-app CLI command groups | `packages/cli/src/commands/<app>/` (each `<action>.ts` + barrel `index.ts`) |
+| Unified status dashboard | `packages/cli/src/commands/status.ts` |
+| MCP bridge + allowlist | `packages/cli/src/commands/mcp.ts` (`MCP_ALLOWLIST`, `registerMcp`) |
+| MCP-capturable action context | `packages/cli/src/lib/action-ctx.ts` (`ActionCtx`) |
+| Executable conventions enforcement | `packages/cli/src/conventions.test.ts` |
+| App deploy scripts | `apps/<name>/src/deploy.ts` (`main`/`deploy`) — except keeweb |
+| KeeWeb build + deploy | `apps/keeweb/src/build.ts`, `apps/keeweb/deploy.sh` |
+| Droplet provisioning | `apps/<name>/server/provision-droplet.ts` (cliproxy, gateway, umami) |
+| Shared SSH/SCP/DO helpers | `packages/shared/server/droplet-helpers.ts` (`ssh`, `scp`, `waitForSsh`, `getSshFingerprint`, `pinHostKeys`, `materializeIdentityFile`) |
+| Gateway upstream daemon pin | `apps/gateway/upstream.json` |
+| Per-app host validators | `apps/<name>/src/host.ts` and `packages/cli/src/commands/<app>/host.ts` |
+| Deploy pipeline | `.github/workflows/deploy.yaml` (router) + `deploy-<app>.yaml` |
+| Pinned SSH host keys | `.github/known_hosts` |
+
+## Data Flow
+
+**Operator / agent → deploy or status:**
+
+```text
+operator (CLI) or agent (MCP)
+  → packages/cli/src/cli.ts (goke parse)
+  → packages/cli/src/commands/<app>/<action>.ts (goke action, receives ctx)
+  → packages/shared/server/droplet-helpers.ts (SSH/SCP) or app deploy.ts
+  → droplet: docker compose / rsync over SSH
+  → result captured via ctx (MCP) or printed (terminal)
+```
+
+**MCP bridge:** `registerMcp` exposes only the `MCP_ALLOWLIST` set — `gateway status`, `cliproxy status`, `keeweb status`, `umami status`, and unified `status`. All mutating commands (keys, config, deploy, backup, logs) are source-gated out of MCP. Allowlisted actions thread `ctx` (`packages/cli/src/lib/action-ctx.ts`) so captured output reaches the agent; global `console`/`process.stdout` bypass capture and must not be used in MCP-exposed bodies.
+
+**Deploy pipeline:** a push to `main` triggers `.github/workflows/deploy.yaml`, which runs `dorny/paths-filter` (`predicate-quantifier: every`) and routes to the matching `deploy-<app>.yaml`. Each app deploy waits at its per-app GitHub Environment approval gate before touching the droplet.
+
+## Invariants
+
+Enforceable rules. Many are gated by `packages/cli/src/conventions.test.ts`, ESLint, or review; mirror the `(enforced)` anti-patterns in the root `AGENTS.md`.
+
+1. **`apps/` are deployable units; `packages/` are reusable libraries.** `packages/` never imports from `apps/`.
+2. **Only `apps/keeweb/deploy.sh` is Bash.** Every other script is TypeScript run via `bun run`.
+3. **Never pass secret bytes via argv.** Secret material is piped through SSH stdin (`writeRemoteFile` pattern); `--body <value>` patterns are banned.
+4. **Host validation before SSH.** Every SSH-spawning command validates the host (`host.ts`, rejecting `-`-prefixed and invalid values) before constructing the SSH command.
+5. **GitHub Actions are SHA-pinned** with a `# vX.Y.Z` comment; workflow files use `.yaml` (not `.yml`).
+6. **No `as any` / `@ts-ignore` / `@ts-expect-error`** — fix the types. No TS files excluded from type checking.
+7. **Tracked files never contain secret values.** Secrets are injected at build/deploy time from environment or GitHub Environment secrets.
+8. **Deploy workflows use `dorny/paths-filter` with `predicate-quantifier: every`** so `!` negations work and docs/tests do not trigger deploys.
+9. **Never use `ssh-keyscan` in CI** — host keys are pinned in `.github/known_hosts`; provisioning scripts may use it locally via `pinHostKeys`.
+10. **MCP exposes read commands only** (`MCP_ALLOWLIST`); mutating commands are source-gated out.
+
+## Cross-Cutting Concerns
+
+- **Secret materialization.** Deploy scripts write secrets to droplet files over SSH stdin (never argv), and CI loads GitHub Environment secrets into the deploy step. Local runs load the repo-root `.env` (Bun loads `.env` from CWD only — run via root `provision:<app>` / `deploy:<app>` wrappers).
+- **Deploy gating.** Each app has a GitHub Environment (`keeweb`, `cliproxy`, `gateway`, `umami`) with a required reviewer and a main-only branch policy. Merging a deploy-triggering change holds at the approval gate.
+- **Host-key pinning.** `.github/known_hosts` pins both domain (unhashed) and IP (hashed) entries; CI connects with strict host-key checking against only that file.
+- **Upstream pinning + verify-at-tag.** The gateway daemon source is pinned in `apps/gateway/upstream.json`; bumping it requires diffing the daemon's required-secret contract against the compose wiring at the new tag before deploy. This is independent of the Fro Bot review Action SHA pinned in `.github/workflows/fro-bot.yaml` (see `docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md`).
+- **Executable conventions.** `packages/cli/src/conventions.test.ts` enforces several invariants above (SHA-pinned actions, `.yaml` extension, no stray Bash scripts, no `ssh-keyscan` in workflows, no `bundledDependencies`) as part of the test suite.
+- **Releases.** Changesets version `@marcusrbrown/infra`; only `packages/cli/src/` user-facing changes warrant a changeset.
+
+## Where to Add New Code
+
+Integration-level patterns; for the mechanical file layout see [`STRUCTURE.md`](STRUCTURE.md).
+
+- **New deployable app** → create `apps/<name>/` mirroring the closest existing app (`apps/cliproxy/` for a Docker-Compose droplet app): Compose config, `src/deploy.ts`, `server/provision-droplet.ts` (using `packages/shared/server/droplet-helpers.ts`), `src/host.ts`. Add it to `package.json` `workspaces`, add `provision:<name>` / `deploy:<name>` root scripts, add a CLI command group under `packages/cli/src/commands/<name>/`, add a gated `deploy-<name>.yaml` workflow wired into `deploy.yaml`'s paths-filter, create the `<name>` GitHub Environment, and add `apps/<name>/AGENTS.md`.
+- **New CLI command group** → add `register<Name>Commands` and a `commands/<name>/` directory with per-action files and a barrel `index.ts`; register it in `packages/cli/src/cli.ts`. Expose a command over MCP only by adding it to `MCP_ALLOWLIST`, and only if it is read-only.
+- **New shared provisioning helper** → add it to `packages/shared/server/droplet-helpers.ts` with a colocated test; consume it from each `provision-droplet.ts`.
+- **New deploy workflow** → copy an existing `deploy-<app>.yaml`, keep the per-app Environment gate and `paths-filter` negations, and wire it into `deploy.yaml`.

--- a/README.md
+++ b/README.md
@@ -358,46 +358,7 @@ Host keys for `box.heatvision.co`, `cliproxy.fro.bot`, and `gateway.fro.bot` are
 
 ## Repository Structure
 
-```text
-├── apps/
-│   ├── keeweb/                  KeeWeb deploy package
-│   │   ├── src/build.ts         Build script (download + SHA-256 verify + config injection)
-│   │   ├── config/              Config templates (nginx, app config)
-│   │   ├── server/              Deploy user provisioning script
-│   │   └── deploy.sh            SSH/rsync deploy script
-│   └── cliproxy/                CLIProxyAPI deployment package
-│       ├── config/              docker-compose.yaml, Caddyfile, config.yaml template
-│       ├── server/              Droplet provisioning script
-│       └── src/deploy.ts        Deploy script
-│   └── gateway/                 Fro Bot gateway deployment package
-│       ├── server/              Droplet provisioning script
-│       ├── src/deploy.ts        Deploy script (secrets materialization, compose up, registration poll)
-│       └── upstream.json        Pinned fro-bot/agent ref
-├── packages/cli/                @marcusrbrown/infra CLI
-│   └── src/
-│       ├── cli.ts               Entry point (goke framework)
-│       ├── cli.test.ts          CLI snapshot + discovery tests
-│       └── commands/            Command modules (subdirectory per app)
-│           ├── keeweb/          status, deploy, open + barrel
-│           ├── cliproxy/        status, deploy, config, keys, login, open, setup + barrel
-│           ├── gateway/         status, deploy, logs, backup, restore + barrel
-│           ├── status.ts        Unified cross-app status dashboard
-│           └── mcp.ts           MCP bridge (stdio server)
-├── .agents/
-│   └── skills/                  Agent skill context packets (goke)
-├── .github/
-│   ├── copilot-instructions.md  Copilot coding agent instructions
-│   ├── known_hosts              Pinned SSH host keys
-│   ├── renovate.json5           Renovate configuration
-│   ├── settings.yml             Repository settings definition
-│   └── workflows/               CI/CD and automation workflows
-├── docs/
-│   ├── brainstorms/             Requirements and brainstorms
-│   ├── plans/                   Implementation plans
-│   └── solutions/               Compound learning docs
-└── .opencode/
-    └── commands/                OpenCode slash commands
-```
+For the directory layout and where to put new code, see [`STRUCTURE.md`](STRUCTURE.md). For system shape, data flow, and invariants, see [`ARCHITECTURE.md`](ARCHITECTURE.md).
 
 ## Testing
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,114 @@
+# Structure
+
+Where things live and where to put new code. For system shape, data flow, and invariants, see [`ARCHITECTURE.md`](ARCHITECTURE.md). For per-app operational detail, see each `apps/<name>/AGENTS.md` and `packages/cli/AGENTS.md`.
+
+## Directory Layout
+
+```text
+├── apps/                       Deployable units (one self-contained deploy each)
+│   ├── keeweb/                 KeeWeb static-site deploy (SSH/rsync to Mail-in-a-Box)
+│   ├── cliproxy/               CLIProxyAPI Claude proxy (DigitalOcean + Docker Compose)
+│   ├── gateway/                Fro Bot Discord gateway (DigitalOcean + Docker Compose)
+│   └── umami/                  Umami analytics (DigitalOcean + Docker Compose)
+├── packages/                   Reusable libraries (never import from apps/)
+│   ├── cli/                    @marcusrbrown/infra goke CLI + MCP bridge
+│   └── shared/                 Cross-app SSH/SCP/DigitalOcean provisioning helpers
+├── docs/                       Brainstorms → plans → solutions (compound learning)
+├── .agents/skills/             Agent skill context packets (load before working in a domain)
+├── .github/                    Workflows, pinned host keys, Renovate, Copilot, repo settings
+└── .opencode/commands/         OpenCode slash commands (e.g. generate-readme)
+```
+
+## Directory Purposes
+
+### `apps/`
+
+One subdirectory per deployable. Each app owns its Compose/build config, a TypeScript deploy script (`src/deploy.ts`; KeeWeb uses `src/build.ts` + `deploy.sh`), a droplet provisioning script (`server/provision-droplet.ts`, except keeweb), a deploy-side host validator (`src/host.ts` where the deploy spawns SSH), and an `AGENTS.md` runbook. Apps never share code by importing each other — shared logic lives in `packages/shared`.
+
+### `packages/`
+
+Reusable libraries. `packages/cli` is the operator surface (goke command groups, unified status, MCP bridge). `packages/shared` is the provisioning helper library consumed by every app's provision script. `packages/` never imports from `apps/`.
+
+### `.github/`
+
+CI/CD and automation: `workflows/*.yaml` (deploy router + per-app deploys, CI, release, Fro Bot, Renovate, Scorecard, settings sync), `known_hosts` (pinned SSH host keys), `renovate.json5`, `settings.yml`, `copilot-instructions.md`.
+
+### `docs/`
+
+Compound-learning chain: `brainstorms/` (requirements), `plans/` (implementation plans), `solutions/` (documented fixes/best-practices with YAML frontmatter). Plan-taxonomy lives here and only here — never in shipped source or public docs.
+
+### `.agents/skills/`
+
+Per-domain agent context packets (`<name>/SKILL.md`). Load the relevant skill before working in that domain.
+
+### `.opencode/commands/`
+
+OpenCode slash commands (Markdown). `generate-readme.md` owns `README.md` generation; this is distinct from the `generating-project-docs` skill that owns `ARCHITECTURE.md`/`STRUCTURE.md`.
+
+## Key File Locations
+
+**Entry Points**
+
+| File                        | Role                                                     |
+| --------------------------- | -------------------------------------------------------- |
+| `packages/cli/src/cli.ts`   | goke CLI entry; registers all command groups             |
+| `apps/<name>/src/deploy.ts` | App deploy script (`main`/`deploy`)                      |
+| `apps/keeweb/src/build.ts`  | KeeWeb build (download + SHA-256 verify + config inject) |
+| `apps/keeweb/deploy.sh`     | Only Bash script in the repo (SSH/rsync deploy)          |
+
+**Per-App Deploy / Provision**
+
+| File                                      | Role                                                              |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `apps/<name>/server/provision-droplet.ts` | DigitalOcean droplet provisioning (cliproxy, gateway, umami)      |
+| `apps/<name>/src/host.ts`                 | Deploy-side host validator (rejects `-`-prefixed / invalid hosts) |
+| `apps/gateway/upstream.json`              | Pinned `fro-bot/agent` daemon ref                                 |
+
+**CLI Commands**
+
+| File                                          | Role                                           |
+| --------------------------------------------- | ---------------------------------------------- |
+| `packages/cli/src/commands/<app>/<action>.ts` | Per-app subcommand (status, deploy, …)         |
+| `packages/cli/src/commands/<app>/index.ts`    | Command-group barrel (`register<App>Commands`) |
+| `packages/cli/src/commands/status.ts`         | Unified cross-app status dashboard             |
+| `packages/cli/src/commands/mcp.ts`            | MCP stdio bridge + `MCP_ALLOWLIST`             |
+| `packages/cli/src/lib/action-ctx.ts`          | `ActionCtx` — MCP-capturable action context    |
+| `packages/shared/server/droplet-helpers.ts`   | Shared SSH/SCP/DigitalOcean helpers            |
+
+**Config**
+
+| File                     | Role                                                                  |
+| ------------------------ | --------------------------------------------------------------------- |
+| `package.json`           | Workspaces, root `provision:*` / `deploy:*` / `test` / `lint` scripts |
+| `eslint.config.ts`       | ESLint via `@bfra.me/eslint-config`                                   |
+| `tsconfig.json`          | TypeScript via `@bfra.me/tsconfig`                                    |
+| `.github/renovate.json5` | Renovate config (incl. `apps/*/upstream.json` custom manager)         |
+
+**Tests / CI**
+
+| File                                   | Role                                                       |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `**/*.test.ts`                         | Colocated tests (mock at boundaries: `fetch`, `Bun.spawn`) |
+| `packages/cli/src/conventions.test.ts` | Executable convention enforcement                          |
+| `.github/workflows/deploy.yaml`        | Deploy router (paths-filter → per-app deploy)              |
+| `.github/workflows/deploy-<app>.yaml`  | Gated per-app deploy                                       |
+
+## Naming Conventions
+
+- **Scripts**: TypeScript run via `bun run`. Only `apps/keeweb/deploy.sh` is Bash.
+- **Tests**: colocated `*.test.ts` beside source. Fixtures in `__fixtures__/`, snapshots in `__snapshots__/`. Use `NO_COLOR=1` for deterministic subprocess snapshots.
+- **CLI command modules**: `packages/cli/src/commands/<app>/<action>.ts` (e.g. `status.ts`, `deploy.ts`) + a barrel `index.ts` exporting `register<App>Commands`.
+- **Host validators**: `host.ts` (deploy-side under `apps/<name>/src/`, CLI-side under `packages/cli/src/commands/<app>/`).
+- **Workflows**: `.yaml` extension (not `.yml`); deploy workflows `deploy-<app>.yaml`.
+- **Bun script guards**: scripts exporting functions for tests gate top-level execution with `if (import.meta.main)`.
+
+## Where to Add New Code
+
+Mechanical layout; for the integration rationale see [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+- **New app** → `apps/<name>/` mirroring `apps/cliproxy/`: Compose config, `src/deploy.ts`, `server/provision-droplet.ts`, `src/host.ts`, `AGENTS.md`. Add to `package.json` `workspaces` + `provision:<name>`/`deploy:<name>` scripts; run `bun install` to refresh `bun.lock`.
+- **New CLI command** → `packages/cli/src/commands/<app>/<action>.ts` + colocated test; export it from the group's `index.ts` barrel.
+- **New shared helper** → `packages/shared/server/droplet-helpers.ts` + colocated test.
+- **New test** → colocate `*.test.ts` beside the source; fixtures/snapshots in `__fixtures__/`/`__snapshots__/`.
+- **New workflow** → `.github/workflows/<name>.yaml`, SHA-pinned actions with `# vX.Y.Z`; for a deploy, copy a `deploy-<app>.yaml` and wire it into `deploy.yaml`'s paths-filter.
+- **New docs page** → `docs/<brainstorms|plans|solutions>/`; solutions carry YAML frontmatter.


### PR DESCRIPTION
Adds a project-specific `generating-project-docs` skill under `.agents/skills/` and the two docs it generates: `ARCHITECTURE.md` (system shape, codemap, invariants, data flow, cross-cutting concerns) and `STRUCTURE.md` (directory layout, key file locations, naming, where-to-add-new-code).

The skill is optimized for AI agents: codemap by symbol/path never line numbers, invariants stated as enforceable rules, prescriptive "where to add new X" patterns, and cross-links to the per-app `AGENTS.md` runbooks. It owns ARCHITECTURE/STRUCTURE only — the README stays owned by the `generate-readme` command, so the README's old structure tree is trimmed to a pointer at the two new docs.

Both docs are derived entirely from live repo inventory (apps/packages from `ls`, CLI groups from `cli.ts`, the real AGENTS.md hierarchy). Cross-links resolve and the conventions test stays green.
