### PR TITLE
ci: tighten workflow token permissions to least-privilege

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       id-token: write
-      pull-requests: write
     steps:
       - id: get-app-token
         name: Get Workflow Access Token

--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -4,6 +4,9 @@ name: Renovate Changesets
 on:
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   renovate-changesets:
     name: Create Renovate Changeset

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -9,6 +9,9 @@ on:
     - cron: '02 18 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-repo-settings:
     name: Update Repo Settings


### PR DESCRIPTION
Tightens GitHub Actions token permissions to least-privilege, resolving the Scorecard Token-Permissions code-scanning alerts.

- **`release.yaml`**: the release job now requests only `id-token: write`. Every API and publish step uses a GitHub App token, and checkout sets `persist-credentials: false`, so the default `GITHUB_TOKEN` is unused — except for npm provenance, which signs via OIDC (`id-token: write`). Dropped the unused `contents: write` and `pull-requests: write` grants.
- **`renovate-changesets.yaml`** and **`update-repo-settings.yaml`**: added top-level `permissions: contents: read`, matching the rest of the workflows. Both already use an App token (or a reusable workflow with its own scopes) for any writes.

No functional change — release publishing, GHCR pushes, and Renovate changeset generation all keep the tokens they actually use.
