### PR TITLE
ci: add security policy and CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,39 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '30 5 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: /language:${{ matrix.language }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please use GitHub's private vulnerability reporting to disclose security issues in this repo. You can open a report from the **Security** tab → **"Report a vulnerability"**. This is the preferred channel because it keeps the disclosure private until a fix is shipped.
+
+Do not open a public issue for security vulnerabilities.
+
+## Scope
+
+In scope:
+
+- The `@marcusrbrown/infra` CLI package (published to npm)
+- The deploy and provisioning automation in this repository
+
+Out of scope:
+
+- The upstream services this repo deploys — **KeeWeb**, **CLIProxyAPI**, **Umami**, and the **fro-bot** daemon. Report vulnerabilities in those projects to their respective upstream maintainers.
+
+## What to Include
+
+A useful report covers:
+
+- **Affected component and version** — which package, script, or workflow; which version or commit
+- **Reproduction steps** — enough detail to reproduce the issue
+- **Impact** — what an attacker could achieve and under what conditions
+
+## Response Expectations
+
+I'm a single maintainer. I'll do my best to acknowledge reports within a few days and work toward a fix as quickly as the severity warrants. There is no formal SLA and no bug bounty program.
+
+## Supported Versions
+
+Only the latest released version of `@marcusrbrown/infra` receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+| Older   | No        |


### PR DESCRIPTION
Adds two security-posture improvements that resolve open Scorecard findings.

- **`SECURITY.md`** — a vulnerability disclosure policy directing reporters to GitHub's private vulnerability reporting, with in-scope (the `@marcusrbrown/infra` CLI and deploy automation) vs out-of-scope (upstream deployed services) guidance and a supported-versions note. Resolves the Security-Policy finding.
- **`.github/workflows/codeql.yaml`** — CodeQL static analysis for JavaScript/TypeScript (`build-mode: none`, no build step needed), running on push to `main`, pull requests, and a weekly schedule. Least-privilege permissions, SHA-pinned actions. Resolves the SAST finding.
