### PR TITLE
fix(cliproxy): write provisioning management key to a 0600 file instead of stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .env
 .env.*
 !.env.example
+.cliproxy-management-key
 .DS_Store
 *.swp
 *.swo

--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -1,4 +1,6 @@
-import {existsSync} from 'node:fs'
+import {existsSync, statSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 
@@ -6,6 +8,7 @@ import {
   performProvisioning,
   resolveProvisionIdentity,
   validateCliproxyDomain,
+  writeManagementKeyFile,
   writeRemoteEnvFile,
 } from './provision-droplet'
 
@@ -309,6 +312,63 @@ describe('provision-droplet', () => {
       await expect(writeRemoteEnvFile('1.2.3.4')).rejects.toThrow(/255/)
 
       spawnSpy.mockRestore()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // writeManagementKeyFile — writes key to 0600 file, never to stdout
+  // ---------------------------------------------------------------------------
+
+  describe('writeManagementKeyFile', () => {
+    let testDir: string
+    let keyFilePath: string
+
+    beforeEach(() => {
+      testDir = join(tmpdir(), `infra-test-${Date.now()}`)
+      keyFilePath = join(testDir, '.cliproxy-management-key')
+    })
+
+    afterEach(async () => {
+      // Clean up test file
+      try {
+        const {rmSync} = await import('node:fs')
+        rmSync(testDir, {recursive: true, force: true})
+      } catch {
+        // best-effort
+      }
+    })
+
+    it('writes the management key to the expected file path', async () => {
+      const key = 'test-management-key-value-abc123'
+      const result = await writeManagementKeyFile(testDir, key)
+
+      expect(existsSync(result)).toBe(true)
+      const contents = await Bun.file(result).text()
+      expect(contents).toBe(key)
+    })
+
+    it('creates the file with mode 0600 (owner read/write only)', async () => {
+      const key = 'test-management-key-value-abc123'
+      const result = await writeManagementKeyFile(testDir, key)
+
+      const stat = statSync(result)
+      // 0o600 = 384 decimal; mask with 0o777 to get permission bits only
+      expect(stat.mode & 0o777).toBe(0o600)
+    })
+
+    it('returns the path to the written file', async () => {
+      const key = 'test-management-key-value-abc123'
+      const result = await writeManagementKeyFile(testDir, key)
+
+      expect(result).toBe(keyFilePath)
+    })
+
+    it('does NOT include the raw key value in the returned path string', async () => {
+      const key = 'super-secret-management-key-xyz789'
+      const result = await writeManagementKeyFile(testDir, key)
+
+      // The returned path must not contain the key value
+      expect(result).not.toContain(key)
     })
   })
 })

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import {randomBytes} from 'node:crypto'
-import {resolve} from 'node:path'
+import {chmodSync, mkdirSync, writeFileSync} from 'node:fs'
+import {join, resolve} from 'node:path'
 
 import {
   dropletExists,
@@ -221,6 +222,24 @@ export async function performProvisioning(
 }
 
 // ---------------------------------------------------------------------------
+// Management key file helper (exported for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes the management key to `<repoRoot>/.cliproxy-management-key` with mode 0600.
+ * Returns the absolute path to the written file.
+ *
+ * The key value is NEVER printed to stdout — only the file path is surfaced to the operator.
+ */
+export async function writeManagementKeyFile(repoRoot: string, key: string): Promise<string> {
+  mkdirSync(repoRoot, {recursive: true})
+  const filePath = join(repoRoot, '.cliproxy-management-key')
+  writeFileSync(filePath, key, {mode: 0o600})
+  chmodSync(filePath, 0o600)
+  return filePath
+}
+
+// ---------------------------------------------------------------------------
 // Main orchestrator
 // ---------------------------------------------------------------------------
 
@@ -241,11 +260,14 @@ async function provision(): Promise<void> {
 
   const managementPassword = await performProvisioning(dropletIp, process.env.CLIPROXY_SSH_KEY)
 
+  const repoRoot = resolve(import.meta.dir, '../../..')
+  const keyFilePath = await writeManagementKeyFile(repoRoot, managementPassword)
+
   console.log('\n\u001B[1;32m✓\u001B[0m CLIProxy droplet provisioned\n')
   console.log(`Droplet IP: ${dropletIp}`)
-  console.log(`Management key: ${managementPassword}`)
+  console.log(`Management key written to: ${keyFilePath} (mode 0600)`)
   console.log(
-    '\n⚠️  Save this key — it cannot be recovered. Set it as CLIPROXY_MANAGEMENT_KEY in GitHub secrets and local .env',
+    '\n⚠️  Save this key now — it cannot be recovered. Copy it into CLIPROXY_MANAGEMENT_KEY (GitHub secret + local .env), then delete the file.',
   )
   console.log('\nCommit the updated .github/known_hosts before triggering a CI deploy.')
 }


### PR DESCRIPTION
Stops the CLIProxyAPI provisioning script from printing the generated management key to stdout, where it lands in terminal scrollback and any terminal logging.

The key is now written to a gitignored `.cliproxy-management-key` file (mode 0600), and provisioning prints only the path plus a reminder to copy it into `CLIPROXY_MANAGEMENT_KEY` and delete the file. The key-writing logic is extracted into a tested `writeManagementKeyFile` helper.

Resolves a CodeQL clear-text-logging finding.
