### PR TITLE
docs: add status badges to the root and per-package READMEs

### DIFF
--- a/.agents/skills/generating-project-docs/SKILL.md
+++ b/.agents/skills/generating-project-docs/SKILL.md
@@ -151,6 +151,13 @@ Audience: a developer/operator landing on one package. Seed from the package's `
 - `packages/cli/README.md` is the **npm-published** readme: H1 `@marcusrbrown/infra`, install (`bun add -g` / `bunx`), then the FULL current command surface grouped by app (status/deploy/… for keeweb, cliproxy, gateway, umami) + unified `status` + the MCP bridge. Derive the command list from `packages/cli/src/cli.ts` registrations and `commands/<app>/`.
 - `packages/shared/README.md`: H1 + one-line purpose (cross-app SSH/SCP/DigitalOcean provisioning helpers), a short consumer note (imported by each `apps/*/server/provision-droplet.ts`), and the exported helper surface from `packages/shared/server/droplet-helpers.ts`. Mark it a private workspace library (not published).
 
+**Badges (per-package):** badge eligibility is constrained by reality — only `@marcusrbrown/infra` (`packages/cli`) is published; every app and `packages/shared` is `private: true`, so npm/version badges are invalid for them.
+- **`apps/<name>/README.md`**: one GitHub-native deploy-status badge for that app's deploy workflow, directly under the H1:
+  `[![Deploy <App>](https://github.com/marcusrbrown/infra/actions/workflows/deploy-<name>.yaml/badge.svg)](https://github.com/marcusrbrown/infra/actions/workflows/deploy-<name>.yaml)` — renders the last completed deploy's conclusion (correct even though the workflow is environment-gated).
+- **`packages/cli/README.md`**: npm version + npm downloads (it is the npm package page): `https://img.shields.io/npm/v/@marcusrbrown/infra?style=flat-square` and `https://img.shields.io/npm/dm/@marcusrbrown/infra?style=flat-square`.
+- **`packages/shared/README.md`**: no badges — it is an internal library and badges would be noise.
+- Never place an npm badge on a private package. Verify any new badge endpoint resolves (`curl -sI`) before adding it.
+
 Match `.opencode/commands/generate-readme.md` formatting rules for all of the above.
 
 ## Style Rules (Non-Negotiable)

--- a/.opencode/commands/generate-readme.md
+++ b/.opencode/commands/generate-readme.md
@@ -42,9 +42,21 @@ $ARGUMENTS
 !`git log --oneline -15`
 </recent-changes>
 
-<scorecard-badge>
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/marcusrbrown/infra/badge)](https://scorecard.dev/viewer/?uri=github.com/marcusrbrown/infra)
-</scorecard-badge>
+<badges>
+The root README header carries a single centered badge row, in this order. Use `style=flat-square` for shields.io badges; GitHub-native workflow badges (`actions/workflows/<file>/badge.svg`) carry no style param.
+
+```html
+<p align="center">
+  <a href="https://www.npmjs.com/package/@marcusrbrown/infra"><img src="https://img.shields.io/npm/v/@marcusrbrown/infra?style=flat-square" alt="npm version"></a>
+  <a href="https://github.com/marcusrbrown/infra/actions/workflows/ci.yaml"><img src="https://github.com/marcusrbrown/infra/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/marcusrbrown/infra/actions/workflows/codeql.yaml"><img src="https://github.com/marcusrbrown/infra/actions/workflows/codeql.yaml/badge.svg" alt="CodeQL"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/marcusrbrown/infra"><img src="https://api.scorecard.dev/projects/github.com/marcusrbrown/infra/badge?style=flat-square" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/marcusrbrown/infra/blob/main/LICENSE"><img src="https://img.shields.io/github/license/marcusrbrown/infra?style=flat-square" alt="License"></a>
+</p>
+```
+
+Badge sources are constrained by reality: only `@marcusrbrown/infra` (`packages/cli`) is published, so the npm badge applies to the root and `packages/cli` only. Workflow badges use the GitHub-native endpoint (renders the last completed run's conclusion, correct even for environment-gated deploy workflows). Never add a badge whose endpoint does not resolve — verify with `curl -sI` before introducing a new one.
+</badges>
 
 ## Execution Flow
 
@@ -63,7 +75,7 @@ If scope specifies a single section, only update that section.
 
 | README Section       | Data Source                                             |
 | -------------------- | ------------------------------------------------------- |
-| Header + Badges      | Scorecard badge, repo metadata                          |
+| Header + Badges      | Centered badge row (npm, CI, CodeQL, Scorecard, License) + repo metadata |
 | Overview             | package-info description + workspace-packages           |
 | Prerequisites        | Bun version requirement                                 |
 | Quick Start          | Install + build commands                                |
@@ -78,7 +90,7 @@ If scope specifies a single section, only update that section.
 
 #### Formatting Rules
 
-1. **Badges**: Use `style=flat-square` — include OpenSSF Scorecard badge
+1. **Badges**: Centered `<p align="center">` row per the `<badges>` block — npm version, CI, CodeQL, OpenSSF Scorecard, License. shields.io badges use `style=flat-square`; GitHub-native workflow badges carry no style param. Only add a badge whose endpoint resolves.
 2. **Code blocks**: Use `bash` for shell, `json` for config, `text` for directory trees
 3. **Tables**: Use for secrets, workflows, package listings
 4. **No secrets**: Never include real secret values, only placeholder references

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Personal infrastructure management — deploy automation, operational CLI, and tooling.
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/marcusrbrown/infra/badge?style=flat-square)](https://scorecard.dev/viewer/?uri=github.com/marcusrbrown/infra)
+<p align="center">
+  <a href="https://www.npmjs.com/package/@marcusrbrown/infra"><img src="https://img.shields.io/npm/v/@marcusrbrown/infra?style=flat-square" alt="npm version"></a>
+  <a href="https://github.com/marcusrbrown/infra/actions/workflows/ci.yaml"><img src="https://github.com/marcusrbrown/infra/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/marcusrbrown/infra/actions/workflows/codeql.yaml"><img src="https://github.com/marcusrbrown/infra/actions/workflows/codeql.yaml/badge.svg" alt="CodeQL"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/marcusrbrown/infra"><img src="https://api.scorecard.dev/projects/github.com/marcusrbrown/infra/badge?style=flat-square" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/marcusrbrown/infra/blob/main/LICENSE"><img src="https://img.shields.io/github/license/marcusrbrown/infra?style=flat-square" alt="License"></a>
+</p>
 
 ## Overview
 

--- a/apps/cliproxy/README.md
+++ b/apps/cliproxy/README.md
@@ -1,5 +1,7 @@
 # CLIProxyAPI
 
+[![Deploy CLIProxy](https://github.com/marcusrbrown/infra/actions/workflows/deploy-cliproxy.yaml/badge.svg)](https://github.com/marcusrbrown/infra/actions/workflows/deploy-cliproxy.yaml)
+
 OAuth-authenticated Claude proxy at [cliproxy.fro.bot](https://cliproxy.fro.bot).
 
 Docker Compose stack (Caddy + `cli-proxy-api`) on a DigitalOcean droplet. CLI clients authenticate with bearer API keys; the proxy forwards requests to Claude using stored OAuth tokens. Caddy handles HTTPS termination with automatic Let's Encrypt certificates. OAuth tokens persist in the `cliproxy_auth` named volume across container recreates.

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -1,5 +1,7 @@
 # Gateway
 
+[![Deploy Gateway](https://github.com/marcusrbrown/infra/actions/workflows/deploy-gateway.yaml/badge.svg)](https://github.com/marcusrbrown/infra/actions/workflows/deploy-gateway.yaml)
+
 Fro Bot Discord client and workspace runner at [gateway.fro.bot](https://gateway.fro.bot).
 
 Three-service Docker Compose stack (gateway daemon, workspace executor, mitmproxy egress filter) on a dedicated DigitalOcean droplet. The upstream source is `fro-bot/agent`, pinned to the ref in [`apps/gateway/upstream.json`](upstream.json) (currently `v0.55.3`). The deploy builds Docker images in CI and pushes them to GHCR; the droplet only pulls prebuilt artifacts — it never builds images. Secrets are materialized as files on the droplet via SSH stdin, never via argv.

--- a/apps/keeweb/README.md
+++ b/apps/keeweb/README.md
@@ -1,5 +1,7 @@
 # KeeWeb
 
+[![Deploy KeeWeb](https://github.com/marcusrbrown/infra/actions/workflows/deploy-keeweb.yaml/badge.svg)](https://github.com/marcusrbrown/infra/actions/workflows/deploy-keeweb.yaml)
+
 Self-hosted KeeWeb v1.18.7 password manager at [kw.igg.ms](https://kw.igg.ms).
 
 Download-based build: `src/build.ts` fetches the upstream release archive from GitHub Releases, verifies its SHA-256, and produces a deploy-ready `dist/`. The Dropbox app secret is injected into `dist/config.json` at build time. The only Bash script in the repo is `apps/keeweb/deploy.sh`; all other scripts are TypeScript run via `bun run`.

--- a/apps/umami/README.md
+++ b/apps/umami/README.md
@@ -1,5 +1,7 @@
 # Umami
 
+[![Deploy Umami](https://github.com/marcusrbrown/infra/actions/workflows/deploy-umami.yaml/badge.svg)](https://github.com/marcusrbrown/infra/actions/workflows/deploy-umami.yaml)
+
 Privacy-respecting, self-hosted web analytics at [metrics.fro.bot](https://metrics.fro.bot).
 
 Three-service Docker Compose stack (umami + postgres + caddy) on a dedicated DigitalOcean droplet. Caddy handles automatic HTTPS. Postgres is reachable only on the internal compose network — port 5432 is never published to the host. Images are digest-pinned and tracked by Renovate. `DISABLE_TELEMETRY=1` and `PRIVATE_MODE=1` are set in the compose layer; Umami is cookie-free and respects Do-Not-Track by default.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,7 @@
 # @marcusrbrown/infra
 
+[![npm version](https://img.shields.io/npm/v/@marcusrbrown/infra?style=flat-square)](https://www.npmjs.com/package/@marcusrbrown/infra) [![npm downloads](https://img.shields.io/npm/dm/@marcusrbrown/infra?style=flat-square)](https://www.npmjs.com/package/@marcusrbrown/infra)
+
 Infrastructure management CLI — deploy automation, health checks, and MCP bridge.
 
 > **Requires [Bun](https://bun.sh)** — this package ships TypeScript source with a `#!/usr/bin/env bun` shebang.


### PR DESCRIPTION
Adds status badges across the READMEs.

- **Root README** — a centered row: npm version, CI, CodeQL, OpenSSF Scorecard, and License.
- **App READMEs** (`apps/keeweb`, `apps/cliproxy`, `apps/gateway`, `apps/umami`) — each gets its own deploy-workflow status badge.
- **`packages/cli`** — npm version and downloads, since that README is the published package page.
- **`packages/shared`** — left badge-free as an internal library.

The badge layout is captured in `.opencode/commands/generate-readme.md` and the `generating-project-docs` skill so future doc generation reproduces it. Only `@marcusrbrown/infra` is published, so npm badges are scoped to the root and the CLI package; every badge endpoint was checked to render before adding it.
