### PR TITLE
fix(cliproxy): move deploy healthcheck to Caddy for Debian-image compatibility

### DIFF
--- a/.changeset/cliproxy-healthcheck-caddy.md
+++ b/.changeset/cliproxy-healthcheck-caddy.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix cliproxy deploy healthcheck: probe the proxy backend from the Caddy container so deploys work on the upstream Debian-based image (v7.1.54+), and return the pin to v7.1.56.

--- a/apps/cliproxy/AGENTS.md
+++ b/apps/cliproxy/AGENTS.md
@@ -7,7 +7,7 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 | Task | Location | Notes |
 | --- | --- | --- |
 | Config templates | `config/config.yaml`, `config/Caddyfile` | Server template — runtime keys live on the droplet |
-| Docker stack | `docker-compose.yaml` | Caddy + cli-proxy-api, restart: unless-stopped, healthcheck on `/healthz` |
+| Docker stack | `docker-compose.yaml` | Caddy + cli-proxy-api, restart: unless-stopped, healthcheck on caddy probing `/healthz` |
 | Provision droplet | `server/provision-droplet.ts` | One-time. Refuses re-run on existing droplet without `--force` |
 | Deploy updates | `src/deploy.ts` | Preserves `config.yaml`, preflight management key check |
 | CLI commands | `packages/cli/src/commands/cliproxy/` | See packages/cli/AGENTS.md for command pattern |
@@ -24,7 +24,8 @@ OAuth-authenticated Claude proxy at `cliproxy.fro.bot`. Docker Compose stack (Ca
 ## DOCKER STACK
 
 - **Caddy**: HTTPS termination, auto Let's Encrypt. `restart: unless-stopped`.
-- **cli-proxy-api**: `eceasy/cli-proxy-api` (pinned digest, Renovate-managed). Alpine 3.22 base. `restart: unless-stopped`. Healthcheck: `wget --spider -q http://localhost:8317/healthz` (purpose-built liveness endpoint, available since v6.9.31; `wget` is in the base, `curl` is not).
+- **cli-proxy-api**: `eceasy/cli-proxy-api` v7.1.56 (pinned digest, Renovate-managed). Debian bookworm base (v7.1.54+, no wget/curl). `restart: unless-stopped`. No container healthcheck — the upstream Debian image ships no probe tools; Caddy probes the backend instead (see below).
+- **Healthcheck**: lives on the `caddy` service, not `cli-proxy-api`. Caddy (alpine, has wget) runs `wget --spider -q http://cli-proxy-api:8317/healthz` across the compose network. `docker compose up -d --wait` gates on Caddy-healthy, which transitively proves the proxy is serving.
 - **Volumes**: `caddy_data`, `caddy_config`, `cliproxy_auth` (OAuth tokens persist here across container recreates).
 - **Env file**: `MANAGEMENT_PASSWORD` injected from host `.env` into the container.
 
@@ -79,7 +80,7 @@ Anthropic-only repos use the single-provider subset of these shapes (unchanged f
 - **Never assume management API body shapes** — empirically verified, not guessed (incident: 2026-04-07).
 - **v7 IP-bans the caller after 5 consecutive bad management-key attempts (~30 min).** Management flows probe `/v0/management/config` once before issuing parallel calls so a wrong key costs a single failed attempt, never an escalating burst.
 - **Never commit `MANAGEMENT_PASSWORD`** — it lives in the droplet's `.env` and the local `CLIPROXY_MANAGEMENT_KEY` secret.
-- **Never use `curl` in healthchecks** — only `wget` is in the Alpine base.
+- **Never use `curl` in healthchecks** — only `wget` is in the Alpine base (Caddy image). The cli-proxy-api image (Debian bookworm, v7.1.54+) has no probe tools; healthcheck belongs on the caddy service.
 
 ## NOTES
 

--- a/apps/cliproxy/docker-compose.yaml
+++ b/apps/cliproxy/docker-compose.yaml
@@ -12,21 +12,24 @@ services:
       - caddy_data:/data
       - caddy_config:/config
       - ./config/Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      cli-proxy-api:
+        condition: service_started
+    healthcheck:
+      test: [CMD, wget, --spider, -q, 'http://cli-proxy-api:8317/healthz']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   cli-proxy-api:
-    image: eceasy/cli-proxy-api:v7.1.50@sha256:889746f2dc85c73171fa0d401e55b51f0cc25d28d8f834a09b3fbe34806d75e6
+    image: eceasy/cli-proxy-api:v7.1.56@sha256:0e7daf455117edf85d1219fde337e7121a6480f704e868fb936b5e2828e466fd
     restart: unless-stopped
     env_file:
       - path: .env
         required: false
     environment:
       MANAGEMENT_PASSWORD: ${MANAGEMENT_PASSWORD:-}
-    healthcheck:
-      test: [CMD, wget, --spider, -q, 'http://localhost:8317/healthz']
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
     volumes:
       - cliproxy_auth:/root/.cli-proxy-api
       - ./config/config.yaml:/CLIProxyAPI/config.yaml

--- a/apps/cliproxy/src/deploy.ts
+++ b/apps/cliproxy/src/deploy.ts
@@ -215,9 +215,9 @@ async function deploy(): Promise<void> {
 
   await runCommand(
     'Updating Docker Compose stack',
-    // --wait blocks until cli-proxy-api reports healthy per its Docker healthcheck
-    // (start_period: 10s, retries: 3). --wait-timeout caps the block at 90s.
-    // The healthCheck() below is the app-level verification layer on top.
+    // --wait blocks until caddy reports healthy; caddy's healthcheck probes
+    // http://cli-proxy-api:8317/healthz, so a healthy caddy transitively proves
+    // the proxy is serving. --wait-timeout caps the block at 90s.
     sshCommand(host, `cd ${REMOTE_DIR} && docker compose pull && docker compose up -d --wait --wait-timeout 90`),
     env,
   )


### PR DESCRIPTION
## Root cause

Upstream `eceasy/cli-proxy-api` v7.1.54 migrated its image base from Alpine to `debian:bookworm`, which ships no `wget`/`curl`/`busybox`. The cli-proxy-api service's Docker healthcheck is `wget --spider -q http://localhost:8317/healthz` — on the Debian image that `wget` binary does not exist, so the healthcheck fails with `exec: "wget": executable file not found`, the container is marked unhealthy, and `docker compose up -d --wait` times out → the deploy exits 1. The proxy server is healthy the whole time (serves `/healthz` 200); only the healthcheck command is broken.

This broke deploys on every v7.1.54+ image. The stopgap (#463) rolled back to v7.1.50 (Alpine, where busybox provides `wget`), but that strands cliproxy on a pre-v7.1.54 version permanently.

## Fix

Move the HTTP healthcheck to the `caddy` service, which uses `caddy:2.11.3-alpine` and does have `wget`. Caddy probes the proxy backend across the compose network (`http://cli-proxy-api:8317/healthz`), so a healthy Caddy transitively proves the proxy is serving — verified live that the Caddy container reaches the backend and gets `{"status":"ok"}`.

- `cli-proxy-api`: remove the healthcheck (the minimal Debian image can't self-probe), keep `restart: unless-stopped`
- `caddy`: add a healthcheck probing `cli-proxy-api:8317/healthz` + `depends_on: cli-proxy-api: condition: service_started`
- Return the pin to **v7.1.56** (the fix makes it deploy-safe again)

The deploy's `--wait` now gates on Caddy-healthy (which probes the proxy), and the existing app-level `healthCheck()` against `/v0/management/config` remains as a second gate.

This is version-agnostic: future Debian-based releases deploy fine because the healthcheck lives in the Alpine Caddy container.
