### PR TITLE
test(gateway): fix flaky compose-up filter matching random ControlPath

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3404,7 +3404,15 @@ describe('main() — compose-up args', () => {
     const {main} = await import('./deploy')
     const composeCmds: string[][] = []
     const {spawnFn} = makeSpawnMock(cmd => {
-      if (cmd.join(' ').includes('docker compose') && cmd.join(' ').includes('up')) {
+      // Match the remote command string (last argv element) to avoid false positives from
+      // the random ControlPath socket path (e.g. /tmp/gw-cm-<random>/cm-%C) which may
+      // contain the substring "up". The remote command for compose-up looks like:
+      //   docker compose --project-directory <dir> up -d --no-build ...
+      // whereas compose-pull looks like:
+      //   docker compose --project-directory <dir> pull
+      // Checking the last element for ' up ' (with spaces) reliably distinguishes them.
+      const remoteCmd = cmd.at(-1) ?? ''
+      if (remoteCmd.includes('docker compose') && remoteCmd.includes(' up ')) {
         composeCmds.push(cmd)
       }
       return undefined
@@ -3431,7 +3439,15 @@ describe('main() — compose-up args', () => {
     const {main} = await import('./deploy')
     const composeCmds: string[][] = []
     const {spawnFn} = makeSpawnMock(cmd => {
-      if (cmd.join(' ').includes('docker compose') && cmd.join(' ').includes('up')) {
+      // Match the remote command string (last argv element) to avoid false positives from
+      // the random ControlPath socket path (e.g. /tmp/gw-cm-<random>/cm-%C) which may
+      // contain the substring "up". The remote command for compose-up looks like:
+      //   docker compose --project-directory <dir> up -d --no-build ...
+      // whereas compose-pull looks like:
+      //   docker compose --project-directory <dir> pull
+      // Checking the last element for ' up ' (with spaces) reliably distinguishes them.
+      const remoteCmd = cmd.at(-1) ?? ''
+      if (remoteCmd.includes('docker compose') && remoteCmd.includes(' up ')) {
         composeCmds.push(cmd)
       }
       return undefined


### PR DESCRIPTION
Fix a nondeterministic failure in `apps/gateway/src/deploy.test.ts`.

The compose-up test filters matched captured spawn commands with `cmd.join(' ').includes('up')` — a loose substring match over the entire SSH argv, which includes the ControlMaster socket path (`/tmp/gw-cm-<random>`). When that random suffix happened to contain `up`, the `docker compose ... pull` command (no `--no-build`) matched the filter and became `composeCmds[0]`, so `expect(...).toContain('--no-build')` failed.

Fix: match against the remote command string (the last argv element, `cmd.at(-1)`) and check for `' up '` with surrounding spaces, which reliably distinguishes `docker compose ... up -d --no-build ...` from `docker compose ... pull` and excludes the ControlPath noise entirely.

Verified with 5 consecutive runs of the gateway test file (0 fail each) plus the full suite (1233 pass).
