### PR TITLE
fix(vpn): correct deploy paths-filter for multiple source dirs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,21 +61,11 @@ jobs:
               - '!apps/umami/**/__fixtures__/**'
               - '!apps/umami/**/__snapshots__/**'
             vpn:
-              - 'apps/vpn/**'
-              - '!apps/vpn/**/*.md'
-              - '!apps/vpn/**/*.test.ts'
-              - '!apps/vpn/**/__fixtures__/**'
-              - '!apps/vpn/**/__snapshots__/**'
-              - 'packages/cli/src/commands/vpn/**'
-              - '!packages/cli/src/commands/vpn/**/*.md'
-              - '!packages/cli/src/commands/vpn/**/*.test.ts'
-              - '!packages/cli/src/commands/vpn/**/__fixtures__/**'
-              - '!packages/cli/src/commands/vpn/**/__snapshots__/**'
-              - 'packages/shared/vpn/**'
-              - '!packages/shared/vpn/**/*.md'
-              - '!packages/shared/vpn/**/*.test.ts'
-              - '!packages/shared/vpn/**/__fixtures__/**'
-              - '!packages/shared/vpn/**/__snapshots__/**'
+              - '{apps/vpn,packages/cli/src/commands/vpn,packages/shared/vpn}/**'
+              - '!**/*.md'
+              - '!**/*.test.ts'
+              - '!**/__fixtures__/**'
+              - '!**/__snapshots__/**'
 
   # Keep deploys independent by design: one app failing should not block the other.
   deploy-keeweb:


### PR DESCRIPTION
The `vpn` deploy paths-filter listed three positive directory globs (`apps/vpn`, `packages/cli/src/commands/vpn`, `packages/shared/vpn`) under `predicate-quantifier: every`. Because `every` requires a changed file to match *all* patterns and no file lives in all three directories, the filter never matched — so Deploy VPN was always skipped, including on the app's own merge.

The other app filters work because each has a single positive glob plus exclusions, which is the intended `every` use case.

The fix combines the three directories into one brace-expansion glob so `every` evaluates correctly:

```yaml
vpn:
  - '{apps/vpn,packages/cli/src/commands/vpn,packages/shared/vpn}/**'
  - '!**/*.md'
  - '!**/*.test.ts'
  - '!**/__fixtures__/**'
  - '!**/__snapshots__/**'
```

Verified with picomatch (the matcher dorny/paths-filter uses) that real source files in all three directories match while `*.md`, `*.test.ts`, fixtures, snapshots, and other apps are excluded.
