### PR TITLE
fix(vpn): exclude apps/vpn from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "changelog": ["@svitejs/changesets-changelog-github-compact", {"repo": "marcusrbrown/infra"}],
   "commit": false,
   "fixed": [],
-  "ignore": [],
+  "ignore": ["@marcusrbrown/infra-vpn"],
   "linked": [],
   "privatePackages": {"tag": true, "version": true},
   "updateInternalDependencies": "patch"

--- a/apps/vpn/CHANGELOG.md
+++ b/apps/vpn/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @marcusrbrown/infra-vpn
-
-## 0.0.1
-### Patch Changes
-
-- Updated dependencies [[`bf94d76`](https://github.com/marcusrbrown/infra/commit/bf94d76e9b0e9d2e590f3ce6230110888daf9eed)]:
-  - @marcusrbrown/infra@0.10.1

--- a/apps/vpn/package.json
+++ b/apps/vpn/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@marcusrbrown/infra-vpn",
-  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The `0.10.1` release versioned `apps/vpn` (bumped it to `0.0.1` and generated `apps/vpn/CHANGELOG.md`). It shouldn't — `apps/vpn` is a private deployable, and no other app participates in Changesets.

The cause: `apps/vpn` gained a workspace dependency on the published `@marcusrbrown/infra` package (to import the VPN peer model), so Changesets treated it as a dependent and bumped it whenever the CLI released.

The fix matches the other private apps and adds an explicit guard:

- Remove the `version` field from `apps/vpn/package.json` (the other private apps — cliproxy, umami, keeweb — have none)
- Add `@marcusrbrown/infra-vpn` to the Changesets `ignore` list so a dependency on the published package can never pull it back in
- Delete the generated `apps/vpn/CHANGELOG.md`

Verified by simulating a release with a real `@marcusrbrown/infra` changeset: `apps/vpn` is no longer versioned and no CHANGELOG is regenerated.
