### PR TITLE
feat(vpn): register poly split-tunnel peer

### DIFF
--- a/apps/vpn/config/peers.json
+++ b/apps/vpn/config/peers.json
@@ -1,3 +1,9 @@
 {
-  "peers": []
+  "peers": [
+    {
+      "name": "poly",
+      "publicKey": "Sg1owQaGZFaqUK7Zd84pwbI3PgXp3zEbFWRIikZFzS0=",
+      "tunnelIp": "10.8.0.2"
+    }
+  ]
 }


### PR DESCRIPTION
Registers the first VPN peer: `poly` (tunnel IP `10.8.0.2`), a split-tunnel client that routes only Polymarket hosts through the egress box. Only the public key is tracked; the client config with the private key stays local (gitignored).

Already deployed and verified live: the box shows the peer with `allowed ips: 10.8.0.2/32`. The CI deploy on merge is an idempotent re-apply.
