### PR TITLE
fix(vpn): forward VPN_PEERS through the deploy router

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -146,3 +146,4 @@ jobs:
     secrets:
       VPN_SSH_KEY: ${{ secrets.VPN_SSH_KEY }}
       VPN_HOST: ${{ secrets.VPN_HOST }}
+      VPN_PEERS: ${{ secrets.VPN_PEERS }}


### PR DESCRIPTION
The `deploy-vpn` reusable workflow declares `VPN_PEERS` as a secret input and forwards it to the deploy step, but the `Deploy` router never passed `VPN_PEERS` into the reusable workflow. A CI VPN deploy therefore ran with an empty roster and aborted at the empty-roster wipe guard.

One line: forward `VPN_PEERS` from the router into `deploy-vpn`, matching the existing `VPN_SSH_KEY`/`VPN_HOST` passthrough.
