### PR TITLE
fix(vpn): detect WAN interface at deploy time instead of hardcoding eth0

### DIFF
--- a/apps/vpn/src/deploy.test.ts
+++ b/apps/vpn/src/deploy.test.ts
@@ -144,21 +144,23 @@ describe('deploy', () => {
   it('runs all phases in order: server key, wg0.conf, sysctl, enable, restart, health gate', async () => {
     const calls: SpawnCall[] = []
 
-    // New call sequence (10 calls total, 0-peer roster triggers wipe guard):
+    // New call sequence (11 calls total, 0-peer roster triggers wipe guard):
     // 0: wipe guard: wg show wg0 dump (0 live peers → proceed)
     // 1: ensure server key (ssh)
     // 2: read server.pub (ssh)
-    // 3: ship placeholder wg0.conf to temp path (ssh stdin — writeRemoteFile)
-    // 4: awk substitution command (ssh — runCommand)
-    // 5: write wg-forwarding.conf (ssh stdin)
-    // 6: sysctl --system (ssh)
-    // 7: systemctl enable --now wg-quick@wg0 (ssh)
-    // 8: systemctl restart wg-quick@wg0 (ssh)
-    // 9: wg show wg0 (ssh)
+    // 3: ip route show default (WAN interface detection)
+    // 4: ship placeholder wg0.conf to temp path (ssh stdin — writeRemoteFile)
+    // 5: awk substitution command (ssh — runCommand)
+    // 6: write wg-forwarding.conf (ssh stdin)
+    // 7: sysctl --system (ssh)
+    // 8: systemctl enable --now wg-quick@wg0 (ssh)
+    // 9: systemctl restart wg-quick@wg0 (ssh)
+    // 10: wg show wg0 (ssh)
     const results = [
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (1 line = server only = 0 peers)
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution (server-side)
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf (stdin)
@@ -234,6 +236,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0}, // ensure server key (file exists, no-op)
       {stdout: 'EXISTINGPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -264,6 +267,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0}, // force-regenerate server key
       {stdout: 'NEWPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -351,6 +355,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'PUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -378,6 +383,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -408,6 +414,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -446,6 +453,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -482,6 +490,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -529,6 +538,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -605,6 +615,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -652,6 +663,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -688,6 +700,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -717,6 +730,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -746,6 +760,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -777,6 +792,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -806,6 +822,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -842,6 +859,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -874,6 +892,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -903,6 +922,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -935,6 +955,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
       {stdout: '', exitCode: 0},
@@ -1001,6 +1022,7 @@ describe('deploy', () => {
     const results = [
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -1064,6 +1086,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump (0 live peers → proceed)
       {stdout: '', exitCode: 0},
       {stdout: 'PUBKEY==\n', exitCode: 0},
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0},
@@ -1120,6 +1143,7 @@ describe('deploy', () => {
     const results = [
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -1152,6 +1176,7 @@ describe('deploy', () => {
       {stdout: 'server-line\n', exitCode: 0},
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -1175,6 +1200,7 @@ describe('deploy', () => {
     const results = [
       {stdout: '', exitCode: 0}, // ensure server key
       {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp\n', exitCode: 0}, // ip route show default
       {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
       {stdout: '', exitCode: 0}, // awk substitution
       {stdout: '', exitCode: 0}, // write wg-forwarding.conf
@@ -1194,6 +1220,76 @@ describe('deploy', () => {
       // (the wipe guard dump call only happens when incoming=0)
       const dumpCalls = calls.filter(c => c.cmd.join(' ').includes('wg show wg0 dump'))
       expect(dumpCalls).toHaveLength(0)
+    } finally {
+      rmSync(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ─── WAN interface detection ──────────────────────────────────────────────
+
+  it('detects WAN interface from ip route show default output and uses it in wg0.conf', async () => {
+    const calls: SpawnCall[] = []
+
+    // New call sequence (11 calls total, 0-peer roster triggers wipe guard):
+    // 0: wipe guard: wg show wg0 dump (0 live peers → proceed)
+    // 1: ensure server key
+    // 2: read server.pub
+    // 3: ip route show default (WAN interface detection → ens5)
+    // 4: ship placeholder wg0.conf to temp path (stdin)
+    // 5: awk substitution
+    // 6: write wg-forwarding.conf (stdin)
+    // 7: sysctl --system
+    // 8: systemctl enable --now
+    // 9: systemctl restart
+    // 10: wg show wg0
+    const results = [
+      {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump
+      {stdout: '', exitCode: 0}, // ensure server key
+      {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: 'default via 172.26.0.1 dev ens5 proto dhcp src 172.26.14.2 metric 100\n', exitCode: 0}, // ip route
+      {stdout: '', exitCode: 0}, // ship placeholder wg0.conf (stdin)
+      {stdout: '', exitCode: 0}, // awk substitution
+      {stdout: '', exitCode: 0}, // write wg-forwarding.conf
+      {stdout: '', exitCode: 0}, // sysctl --system
+      {stdout: '', exitCode: 0}, // systemctl enable --now
+      {stdout: '', exitCode: 0}, // systemctl restart
+      {stdout: 'interface: wg0\n  public key: FAKEPUBKEY==\n  peers: 0\n', exitCode: 0}, // wg show
+    ]
+
+    const mockSpawn = makeMockSpawn(calls, results)
+    const {dir, peersJsonPath} = makeTempPeersDir([])
+    try {
+      await deploy({env: BASE_ENV, spawn: mockSpawn, peersJsonPath})
+
+      // The ip route show default command must have been called
+      const routeCall = calls.find(c => c.cmd.join(' ').includes('ip route show default'))
+      expect(routeCall).toBeDefined()
+
+      // The shipped wg0.conf must use ens5 (detected), NOT eth0 (hardcoded)
+      const wgConfCall = calls.find(c => c.stdin !== undefined && c.stdin.includes('[Interface]'))
+      expect(wgConfCall).toBeDefined()
+      expect(wgConfCall?.stdin).toContain('ens5')
+      expect(wgConfCall?.stdin).not.toContain('eth0')
+    } finally {
+      rmSync(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('throws a clear error when ip route show default returns empty output', async () => {
+    const calls: SpawnCall[] = []
+    const results = [
+      {stdout: 'server-line\n', exitCode: 0}, // wipe guard dump
+      {stdout: '', exitCode: 0}, // ensure server key
+      {stdout: 'FAKEPUBKEY==\n', exitCode: 0}, // read server.pub
+      {stdout: '', exitCode: 0}, // ip route show default — empty output (detection fails)
+    ]
+
+    const mockSpawn = makeMockSpawn(calls, results)
+    const {dir, peersJsonPath} = makeTempPeersDir([])
+    try {
+      await expect(deploy({env: BASE_ENV, spawn: mockSpawn, peersJsonPath})).rejects.toThrow(
+        /WAN interface|ip route|default route/i,
+      )
     } finally {
       rmSync(dir, {recursive: true, force: true})
     }

--- a/apps/vpn/src/deploy.ts
+++ b/apps/vpn/src/deploy.ts
@@ -301,6 +301,42 @@ async function forceRegenerateServerKey(
 }
 
 /**
+ * Detects the WAN interface on the remote box by parsing `ip route show default`.
+ * Extracts the token after `dev` from the default route line.
+ *
+ * Fails closed with a clear error if detection returns empty — never silently
+ * falls back to a hardcoded interface name.
+ */
+async function detectWanInterface(
+  host: string,
+  deployEnv: DeployEnv,
+  spawnFn: SpawnFn,
+  keyPath?: string,
+  controlPath?: string,
+): Promise<string> {
+  const {stdout} = await runCommand(
+    'Detecting WAN interface (ip route show default)',
+    sshCommand(host, 'ip route show default', keyPath, controlPath),
+    deployEnv,
+    spawnFn,
+  )
+
+  // Parse the token after `dev` from the default route output.
+  // Example: "default via 172.26.0.1 dev ens5 proto dhcp src 172.26.14.2 metric 100"
+  const match = stdout.match(/\bdev\s+(\S+)/)
+  const iface = match?.[1]?.trim() ?? ''
+
+  if (!iface) {
+    throw new Error(
+      'Failed to detect WAN interface: `ip route show default` returned no default route with a `dev` field. ' +
+        'Cannot determine the correct interface for NAT MASQUERADE.',
+    )
+  }
+
+  return iface
+}
+
+/**
  * Renders wg0.conf SERVER-SIDE via SSH stdin.
  *
  * Security mechanism (the private key never leaves the box):
@@ -586,10 +622,14 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
     const serverPubKey = await readRemoteServerPub(host, deployEnv, spawnFn, keyPath, controlPath)
     console.warn(`\u001B[1;32m✓\u001B[0m Server public key: ${serverPubKey}`)
 
-    // Phase 5: Render wg0.conf server-side
+    // Phase 5: Detect WAN interface on the box, then render wg0.conf server-side.
+    // Detection runs `ip route show default` over SSH and parses the `dev <iface>` token.
+    // Fails closed with a clear error if the default route has no `dev` field.
+    const wanInterface = await detectWanInterface(host, deployEnv, spawnFn, keyPath, controlPath)
+
     // renderServerConfig is called locally with a placeholder key — the real key stays on the box.
     // The placeholder config is shipped via stdin; box-side awk substitutes the real key.
-    await renderWgConfServerSide(host, peers, 'eth0', deployEnv, spawnFn, keyPath, controlPath)
+    await renderWgConfServerSide(host, peers, wanInterface, deployEnv, spawnFn, keyPath, controlPath)
 
     // Phase 6: Write ip_forward sysctl config via stdin
     const forwardingConf = 'net.ipv4.ip_forward = 1\n'


### PR DESCRIPTION
The VPN server config hardcoded `eth0` as the WAN interface for the NAT masquerade rule, but the AWS Lightsail box's WAN interface is `ens5`. The rule `iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE` matched no traffic, so forwarded client packets left the box un-NAT'd with their private source address (`10.8.0.2`) and replies never returned. Split-tunnel clients saw total timeouts despite a healthy handshake.

Deploy now detects the WAN interface on the box by parsing `ip route show default` and renders the masquerade rule against the detected interface. It fails closed with a clear error if no default route with a `dev` field is found, rather than silently falling back to `eth0`.

Verified live: with the correct interface, `clob.polymarket.com` returns HTTP 200 through the tunnel while non-tunneled traffic keeps the real IP (split-tunnel intact). 1474 tests pass.
