### PR TITLE
fix(mcp): wire Discord MCP env from .env and gate destructive tools

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -9,6 +9,29 @@
       "command": ["bun", "run", "packages/cli/src/cli.ts", "mcp"],
       "enabled": true,
     },
+    "discord": {
+      "type": "local",
+      // opencode's {env:VAR} interpolation reads opencode's own process env, which
+      // does NOT carry repo-root .env (Bun only auto-loads .env for the `infra`
+      // bun-run server, not this docker server). Docker's --env-file also rejects
+      // .env because the multi-line VPN_SSH_KEY PEM has whitespace it can't parse.
+      // So source .env in a shell wrapper (shell handles the PEM fine) and forward
+      // ONLY the two Discord vars into the container via -e. No secrets in this file.
+      "command": [
+        "sh",
+        "-c",
+        "set -a; . ./.env; set +a; exec docker run --rm -i -e DISCORD_TOKEN -e DISCORD_GUILD_ID saseq/discord-mcp:1.0.0",
+      ],
+      // Disabled by default — requires Docker + .env-local DISCORD_TOKEN/DISCORD_GUILD_ID.
+      // Flip to true to enable, then restart opencode (config is not hot-reloaded).
+      "enabled": false,
+      // The saseq/discord-mcp image is a Spring Boot (JVM) server whose cold
+      // start — JVM boot + Discord gateway connect — measures ~30s before it
+      // answers the MCP initialize handshake. opencode applies this value as
+      // the connect timeout (mcp.timeout ?? 30000); 30000 races the boot and
+      // yields "Connection closed" (-32000). 60000 gives comfortable headroom.
+      "timeout": 60000,
+    },
   },
   // Defense-in-depth permission backstop for sensitive infra tools.
   // Primary gate: these 6 commands are NOT in MCP_ALLOWLIST (packages/cli/src/commands/mcp.ts)
@@ -34,5 +57,31 @@
     "infra_vpn_client_add": "deny",
     "infra_vpn_client_list": "deny",
     "infra_vpn_client_remove": "deny",
+    // Discord MCP (saseq/discord-mcp) exposes 65 guild tools. opencode resolves
+    // the LAST matching permission rule, so the wildcard baseline comes first and
+    // the explicit denies below it win for destructive tools. Tool ids use the
+    // `<server>_<tool>` form — here `discord_<tool>`.
+    // Baseline: every Discord tool prompts; nothing auto-runs.
+    "discord_*": "ask",
+    // Deny: irreversible member actions, content/structure deletion, voice yanks.
+    "discord_ban_member": "deny",
+    "discord_unban_member": "deny",
+    "discord_kick_member": "deny",
+    "discord_timeout_member": "deny",
+    "discord_remove_timeout": "deny",
+    "discord_disconnect_member": "deny",
+    "discord_move_member": "deny",
+    "discord_modify_voice_state": "deny",
+    "discord_delete_channel": "deny",
+    "discord_delete_category": "deny",
+    "discord_delete_message": "deny",
+    "discord_delete_private_message": "deny",
+    "discord_delete_role": "deny",
+    "discord_remove_role": "deny",
+    "discord_delete_webhook": "deny",
+    "discord_delete_emoji": "deny",
+    "discord_delete_invite": "deny",
+    "discord_delete_guild_scheduled_event": "deny",
+    "discord_delete_channel_permission_overwrite": "deny",
   },
 }


### PR DESCRIPTION
Adds a Discord MCP server to the OpenCode config (disabled by default) for direct guild integration alongside the deployed gateway, and fixes two startup problems found while wiring it.

**Shipped disabled.** `enabled: false` so a fresh checkout or CI/Fro Bot harness never tries to launch a Docker container it can't run. Flip to `true` locally (requires Docker + `.env` with `DISCORD_TOKEN`/`DISCORD_GUILD_ID`) and restart OpenCode to use it.

**Credentials weren't reaching the container.** OpenCode's `{env:VAR}` interpolation reads OpenCode's own process environment, which doesn't carry the repo-root `.env` — Bun auto-loads `.env` only for the `bun run` infra server, not a `docker run` server. So the Discord vars resolved to empty strings, the container failed Discord login, and exited immediately with `MCP error -32000`. Docker's `--env-file .env` isn't an option either: its strict parser rejects `.env` because the multi-line `VPN_SSH_KEY` PEM contains whitespace. The fix sources `.env` in a shell wrapper (the shell parses the PEM fine) and forwards only the two Discord vars into the container via `-e`, keeping the rest of `.env` out of the container and all secret values out of the config file.

**JVM cold start raced the connect timeout.** The `saseq/discord-mcp` image is a Spring Boot server that takes ~30s to answer the MCP initialize handshake; the default 30000ms connect timeout lost the race. Raised to 60000.

**Destructive-tool guardrails.** The server exposes 65 guild tools including irreversible ones (bans, kicks, timeouts, channel/message/role deletion). Added permission denies for the 19 destructive tools with a `discord_*` ask baseline, mirroring the existing infra MCP defense-in-depth pattern. Resolution verified against OpenCode's wildcard matcher.

Verified end-to-end with the server temporarily enabled: it logs into the guild and lists all 65 tools, and the conventions suite passes.
