### PR TITLE
test(gateway): raise timeout on docker compose config integration test

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3845,7 +3845,7 @@ networks:
     } finally {
       rm(testDir, {recursive: true, force: true})
     }
-  })
+  }, 30000)
 })
 
 // ─── Off-droplet image build: override, pull-then-up, digest verification ─────


### PR DESCRIPTION
The compose-merge integration test in `apps/gateway/src/deploy.test.ts` shells out to a real `docker compose config` subprocess to prove the generated override appends mounts rather than replacing them. On a slow CI runner that subprocess can exceed Bun's default 5000ms per-test timeout — it flaked a docs-only PR at 5712ms. Gives that one test an explicit 30s timeout so real-Docker latency can't flake the suite.
