### PR TITLE
fix(cliproxy): seed remote-management.secret-key at provision so the TUI works

### DIFF
--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -323,12 +323,10 @@ describe('provision-droplet', () => {
     it('pipes the management password through stdin, never in the command argv', async () => {
       const password = 'deadbeef1234567890abcdef'
       let capturedStdinWrite: string | undefined
-      let capturedArgv: string[] | undefined
 
       const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
         stdin: {
           write: (chunk: string) => {
-            capturedArgv ??= []
             capturedStdinWrite = (capturedStdinWrite ?? '') + chunk
           },
           end: () => {},
@@ -338,30 +336,55 @@ describe('provision-droplet', () => {
 
       // Capture argv via the spy's call args after the call
       await seedRemoteSecretKey('1.2.3.4', password)
-      capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+      const capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
 
       spawnSpy.mockRestore()
 
       // Password must appear in stdin, never in argv
       expect(capturedStdinWrite).toContain(password)
       expect(capturedArgv?.join(' ')).not.toContain(password)
-      // Trailing newline so the remote `read -r` returns 0 and the seed runs
-      // (without it, read exits non-zero at EOF and the sed silently no-ops).
+      // Password must end with a newline so python's readline() gets a terminated line
       expect(capturedStdinWrite?.endsWith('\n')).toBe(true)
     })
 
-    it('uses an if/grep guard (not || true) so a real sed failure surfaces', async () => {
+    it('uses python3 -c to run the replacement in-process (secret never in any external argv)', async () => {
       const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
         stdin: {write: () => {}, end: () => {}},
         exited: Promise.resolve(0),
       } as unknown as ReturnType<typeof Bun.spawn>)
 
       await seedRemoteSecretKey('1.2.3.4', 'abc123')
-      const remoteCmd = (spawnSpy.mock.calls[0]?.[0] as string[]).at(-1) ?? ''
+      const capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+      const remoteCmd = capturedArgv?.at(-1) ?? ''
       spawnSpy.mockRestore()
 
-      expect(remoteCmd).toContain('if grep -q')
-      expect(remoteCmd).not.toContain('|| true')
+      // Must use python3 -c (script body in argv, secret read from stdin)
+      expect(remoteCmd).toContain('python3 -c')
+      // Must NOT use sed or awk (those would receive the secret as argv)
+      expect(remoteCmd).not.toContain('sed ')
+      expect(remoteCmd).not.toContain('awk ')
+      // Must NOT use shell `read` to capture the password into a shell variable
+      // that then gets interpolated into an external command
+      expect(remoteCmd).not.toMatch(/read\s+-r\s+PW/)
+    })
+
+    it('remote command does not interpolate the password into any external-command argument', async () => {
+      const password = 'deadbeef1234567890abcdef'
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await seedRemoteSecretKey('1.2.3.4', password)
+      const capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+      spawnSpy.mockRestore()
+
+      // The entire SSH argv (joined) must not contain the password value
+      const argvStr = capturedArgv?.join(' ') ?? ''
+      expect(argvStr).not.toContain(password)
+      // The remote command must reference the config path (not secret)
+      expect(argvStr).toContain('/opt/cliproxy/config/config.yaml')
     })
 
     it('targets the remote config.yaml path in the SSH command', async () => {

--- a/apps/cliproxy/server/provision-droplet.test.ts
+++ b/apps/cliproxy/server/provision-droplet.test.ts
@@ -7,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, it, spyOn} from 'bun:test'
 import {
   performProvisioning,
   resolveProvisionIdentity,
+  seedRemoteSecretKey,
   validateCliproxyDomain,
   writeManagementKeyFile,
   writeRemoteEnvFile,
@@ -153,6 +154,7 @@ describe('provision-droplet', () => {
       const capturedWaitForSsh: {host: string; user: string; identityFile?: string}[] = []
       const capturedCopyComposeFiles: {host: string; identityFile?: string}[] = []
       const capturedWriteRemoteEnvFile: {host: string; identityFile?: string}[] = []
+      const capturedSeedRemoteSecretKey: {host: string; identityFile?: string}[] = []
       const capturedDeployCompose: {host: string; identityFile?: string}[] = []
 
       const fakeWaitForSsh = async (host: string, user: string, opts?: {identityFile?: string}) => {
@@ -165,6 +167,9 @@ describe('provision-droplet', () => {
         capturedWriteRemoteEnvFile.push({host, identityFile})
         return 'fake-mgmt-password'
       }
+      const fakeSeedRemoteSecretKey = async (host: string, _password: string, identityFile?: string) => {
+        capturedSeedRemoteSecretKey.push({host, identityFile})
+      }
       const fakeDeployCompose = async (host: string, identityFile?: string) => {
         capturedDeployCompose.push({host, identityFile})
       }
@@ -174,6 +179,7 @@ describe('provision-droplet', () => {
         pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        seedRemoteSecretKey: fakeSeedRemoteSecretKey,
         deployCompose: fakeDeployCompose,
       })
 
@@ -185,6 +191,7 @@ describe('provision-droplet', () => {
       // All helpers must receive the same identity file path
       expect(capturedCopyComposeFiles[0]?.identityFile).toBe(wsfPath)
       expect(capturedWriteRemoteEnvFile[0]?.identityFile).toBe(wsfPath)
+      expect(capturedSeedRemoteSecretKey[0]?.identityFile).toBe(wsfPath)
       expect(capturedDeployCompose[0]?.identityFile).toBe(wsfPath)
     })
 
@@ -205,6 +212,9 @@ describe('provision-droplet', () => {
         recordIdentity(identityFile)
         return 'fake-mgmt-password'
       }
+      const fakeSeedRemoteSecretKey = async (_host: string, _password: string, identityFile?: string) => {
+        recordIdentity(identityFile)
+      }
       const fakeDeployCompose = async (_host: string, identityFile?: string) => {
         recordIdentity(identityFile)
       }
@@ -214,6 +224,7 @@ describe('provision-droplet', () => {
         pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        seedRemoteSecretKey: fakeSeedRemoteSecretKey,
         deployCompose: fakeDeployCompose,
       })
 
@@ -233,6 +244,7 @@ describe('provision-droplet', () => {
       const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
       const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
         'fake-mgmt-password'
+      const fakeSeedRemoteSecretKey = async (_host: string, _password: string, _identityFile?: string) => {}
       const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
 
       await expect(
@@ -241,6 +253,7 @@ describe('provision-droplet', () => {
           pinHostKeys: async () => {},
           copyComposeFiles: fakeCopyComposeFiles,
           writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+          seedRemoteSecretKey: fakeSeedRemoteSecretKey,
           deployCompose: fakeDeployCompose,
         }),
       ).rejects.toThrow('provisioning step failed')
@@ -259,6 +272,7 @@ describe('provision-droplet', () => {
       const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
       const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
         'fake-mgmt-password'
+      const fakeSeedRemoteSecretKey = async (_host: string, _password: string, _identityFile?: string) => {}
       const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
 
       await performProvisioning('1.2.3.4', undefined, {
@@ -266,6 +280,7 @@ describe('provision-droplet', () => {
         pinHostKeys: async () => {},
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        seedRemoteSecretKey: fakeSeedRemoteSecretKey,
         deployCompose: fakeDeployCompose,
       })
 
@@ -284,6 +299,7 @@ describe('provision-droplet', () => {
       const fakeCopyComposeFiles = async (_host: string, _identityFile?: string) => {}
       const fakeWriteRemoteEnvFile = async (_host: string, _identityFile?: string): Promise<string> =>
         'fake-mgmt-password'
+      const fakeSeedRemoteSecretKey = async (_host: string, _password: string, _identityFile?: string) => {}
       const fakeDeployCompose = async (_host: string, _identityFile?: string) => {}
 
       await performProvisioning('1.2.3.4', undefined, {
@@ -291,10 +307,185 @@ describe('provision-droplet', () => {
         pinHostKeys: fakePinHostKeys,
         copyComposeFiles: fakeCopyComposeFiles,
         writeRemoteEnvFile: fakeWriteRemoteEnvFile,
+        seedRemoteSecretKey: fakeSeedRemoteSecretKey,
         deployCompose: fakeDeployCompose,
       })
 
       expect(callOrder.indexOf('waitForSsh')).toBeLessThan(callOrder.indexOf('pinHostKeys'))
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // seedRemoteSecretKey — pipes password via stdin, never in argv
+  // ---------------------------------------------------------------------------
+
+  describe('seedRemoteSecretKey', () => {
+    it('pipes the management password through stdin, never in the command argv', async () => {
+      const password = 'deadbeef1234567890abcdef'
+      let capturedStdinWrite: string | undefined
+      let capturedArgv: string[] | undefined
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {
+          write: (chunk: string) => {
+            capturedArgv ??= []
+            capturedStdinWrite = (capturedStdinWrite ?? '') + chunk
+          },
+          end: () => {},
+        },
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      // Capture argv via the spy's call args after the call
+      await seedRemoteSecretKey('1.2.3.4', password)
+      capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+
+      spawnSpy.mockRestore()
+
+      // Password must appear in stdin, never in argv
+      expect(capturedStdinWrite).toContain(password)
+      expect(capturedArgv?.join(' ')).not.toContain(password)
+      // Trailing newline so the remote `read -r` returns 0 and the seed runs
+      // (without it, read exits non-zero at EOF and the sed silently no-ops).
+      expect(capturedStdinWrite?.endsWith('\n')).toBe(true)
+    })
+
+    it('uses an if/grep guard (not || true) so a real sed failure surfaces', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await seedRemoteSecretKey('1.2.3.4', 'abc123')
+      const remoteCmd = (spawnSpy.mock.calls[0]?.[0] as string[]).at(-1) ?? ''
+      spawnSpy.mockRestore()
+
+      expect(remoteCmd).toContain('if grep -q')
+      expect(remoteCmd).not.toContain('|| true')
+    })
+
+    it('targets the remote config.yaml path in the SSH command', async () => {
+      const password = 'deadbeef1234567890abcdef'
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await seedRemoteSecretKey('1.2.3.4', password)
+
+      const capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+      spawnSpy.mockRestore()
+
+      // The remote command must reference the config.yaml path
+      const argvStr = capturedArgv?.join(' ') ?? ''
+      expect(argvStr).toContain('/opt/cliproxy/config/config.yaml')
+    })
+
+    it('rejects with an error when the SSH command fails', async () => {
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(1),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await expect(seedRemoteSecretKey('1.2.3.4', 'some-password')).rejects.toThrow(/exit/)
+
+      spawnSpy.mockRestore()
+    })
+
+    it('passes the identity file to the SSH command when provided', async () => {
+      const password = 'deadbeef1234567890abcdef'
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+        stdin: {write: () => {}, end: () => {}},
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>)
+
+      await seedRemoteSecretKey('1.2.3.4', password, '/tmp/fake-key')
+
+      const capturedArgv = spawnSpy.mock.calls[0]?.[0] as string[]
+      spawnSpy.mockRestore()
+
+      expect(capturedArgv?.join(' ')).toContain('/tmp/fake-key')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // performProvisioning — seedRemoteSecretKey ordering
+  // ---------------------------------------------------------------------------
+
+  describe('SSH provisioning orchestration — seedRemoteSecretKey ordering', () => {
+    it('calls seedRemoteSecretKey after copyComposeFiles and writeRemoteEnvFile, before deployCompose', async () => {
+      const callOrder: string[] = []
+
+      await performProvisioning('1.2.3.4', undefined, {
+        waitForSsh: async () => {
+          callOrder.push('waitForSsh')
+        },
+        pinHostKeys: async () => {
+          callOrder.push('pinHostKeys')
+        },
+        copyComposeFiles: async () => {
+          callOrder.push('copyComposeFiles')
+        },
+        writeRemoteEnvFile: async () => {
+          callOrder.push('writeRemoteEnvFile')
+          return 'fake-pw'
+        },
+        seedRemoteSecretKey: async () => {
+          callOrder.push('seedRemoteSecretKey')
+        },
+        deployCompose: async () => {
+          callOrder.push('deployCompose')
+        },
+      })
+
+      const seedIdx = callOrder.indexOf('seedRemoteSecretKey')
+      const uploadIdx = callOrder.indexOf('copyComposeFiles')
+      const envIdx = callOrder.indexOf('writeRemoteEnvFile')
+      const composeIdx = callOrder.indexOf('deployCompose')
+
+      expect(seedIdx).toBeGreaterThan(uploadIdx)
+      expect(seedIdx).toBeGreaterThan(envIdx)
+      expect(seedIdx).toBeLessThan(composeIdx)
+    })
+
+    it('passes the management password from writeRemoteEnvFile to seedRemoteSecretKey', async () => {
+      let capturedPassword: string | undefined
+      let capturedHost: string | undefined
+
+      await performProvisioning('5.6.7.8', undefined, {
+        waitForSsh: async () => {},
+        pinHostKeys: async () => {},
+        copyComposeFiles: async () => {},
+        writeRemoteEnvFile: async () => 'the-generated-password',
+        seedRemoteSecretKey: async (host: string, password: string) => {
+          capturedHost = host
+          capturedPassword = password
+        },
+        deployCompose: async () => {},
+      })
+
+      expect(capturedPassword).toBe('the-generated-password')
+      expect(capturedHost).toBe('5.6.7.8')
+    })
+
+    it('threads identity file through seedRemoteSecretKey when key is set', async () => {
+      let capturedIdentityFile: string | undefined
+
+      await performProvisioning('1.2.3.4', FAKE_PRIVATE_KEY, {
+        waitForSsh: async (_host, _user, opts) => {
+          capturedIdentityFile = opts?.identityFile
+        },
+        pinHostKeys: async () => {},
+        copyComposeFiles: async () => {},
+        writeRemoteEnvFile: async () => 'fake-pw',
+        seedRemoteSecretKey: async (_host, _password, identityFile) => {
+          // identityFile must match what waitForSsh received
+          expect(identityFile).toBe(capturedIdentityFile)
+        },
+        deployCompose: async () => {},
+      })
     })
   })
 

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -177,13 +177,15 @@ export async function deployCompose(host: string, identityFile?: string): Promis
  * `managementPassword`. Only replaces when the current value is empty (idempotent
  * on reruns where the key was already set).
  *
- * SECURITY: the password travels via SSH stdin only — it never appears in argv.
- * A remote shell reads the password from stdin into a variable, then uses sed
- * with that variable to rewrite the config. The password value is never in any
- * argv array — only the variable reference `$PW` appears in the command string.
+ * SECURITY: the password travels via SSH stdin only — it NEVER appears in argv
+ * of any process (local or remote). The remote command is `python3 -c '<script>'
+ * <config_path>`: the script body is in argv (not secret), the config path is in
+ * argv (not secret), and the password is read from stdin inside the python
+ * interpreter — never passed to any external command. Python's str.replace is
+ * literal (no regex), so special characters in the password are safe.
  *
- * The password is hex-only (randomBytes.toString('hex')), so it contains no
- * characters that could break the sed expression delimiter or the YAML value.
+ * The password is hex-only (randomBytes.toString('hex')), but the implementation
+ * is safe for any value that does not contain a newline (the readline delimiter).
  */
 export async function seedRemoteSecretKey(
   host: string,
@@ -193,15 +195,25 @@ export async function seedRemoteSecretKey(
   const configPath = `${REMOTE_DIR}/config/config.yaml`
   const opts = identityFile ? {identityFile} : undefined
 
-  // Shell reads the password from stdin into $PW (never in argv), then replaces
-  // `secret-key: ''` only when it is currently empty. The grep guard makes reruns
-  // a no-op; an `if` block (not `&&  || true`) lets a genuine sed failure surface
-  // as a non-zero exit instead of being masked. sed delimiter is | (password is
-  // hex, no | chars).
-  const remoteCmd =
-    `IFS= read -r PW; ` +
-    `if grep -q "secret-key: ''" ${configPath}; then ` +
-    `sed -i "s|secret-key: ''|secret-key: '$PW'|" ${configPath}; fi`
+  // python3 -c: script body is in argv (not secret); config path is argv (not
+  // secret); password is read from stdin inside the interpreter — never an argv
+  // of any process. str.replace is literal (no regex), so no special-char risk.
+  // Exits 0 on success (including the no-op when already set); raises on I/O
+  // errors so the caller's `if (exitCode !== 0) throw` catches real failures.
+  //
+  // The script uses chr(39) for single-quote and chr(10) for newline so the
+  // entire script body can be safely wrapped in single quotes by the remote shell
+  // (no single-quote escaping needed, no shell injection surface).
+  const pythonScript =
+    'import sys; ' +
+    'pw = sys.stdin.readline().rstrip(chr(10)); ' +
+    'path = sys.argv[1]; ' +
+    'f=open(path); content=f.read(); f.close(); ' +
+    'needle="secret-key: "+chr(39)+chr(39); ' +
+    'content=content.replace(needle, "secret-key: "+chr(39)+pw+chr(39), 1) if needle in content else content; ' +
+    'f=open(path,"w"); f.write(content); f.close()'
+
+  const remoteCmd = `python3 -c '${pythonScript}' ${configPath}`
 
   const proc = Bun.spawn(ssh(host, remoteCmd, REMOTE_USER, opts), {
     stdin: 'pipe',
@@ -209,8 +221,7 @@ export async function seedRemoteSecretKey(
     stderr: 'inherit',
   })
 
-  // Trailing newline so `read -r` sees a terminated line and returns 0 — without
-  // it, read exits non-zero at EOF and the seed silently no-ops.
+  // Trailing newline so python's readline() gets a terminated line.
   proc.stdin.write(`${managementPassword}\n`)
   proc.stdin.end()
 

--- a/apps/cliproxy/server/provision-droplet.ts
+++ b/apps/cliproxy/server/provision-droplet.ts
@@ -172,6 +172,56 @@ export async function deployCompose(host: string, identityFile?: string): Promis
   await run('Starting Docker Compose stack', ssh(host, `cd ${REMOTE_DIR} && docker compose up -d`, REMOTE_USER, opts))
 }
 
+/**
+ * Seeds `remote-management.secret-key` in the already-uploaded config.yaml to
+ * `managementPassword`. Only replaces when the current value is empty (idempotent
+ * on reruns where the key was already set).
+ *
+ * SECURITY: the password travels via SSH stdin only — it never appears in argv.
+ * A remote shell reads the password from stdin into a variable, then uses sed
+ * with that variable to rewrite the config. The password value is never in any
+ * argv array — only the variable reference `$PW` appears in the command string.
+ *
+ * The password is hex-only (randomBytes.toString('hex')), so it contains no
+ * characters that could break the sed expression delimiter or the YAML value.
+ */
+export async function seedRemoteSecretKey(
+  host: string,
+  managementPassword: string,
+  identityFile?: string,
+): Promise<void> {
+  const configPath = `${REMOTE_DIR}/config/config.yaml`
+  const opts = identityFile ? {identityFile} : undefined
+
+  // Shell reads the password from stdin into $PW (never in argv), then replaces
+  // `secret-key: ''` only when it is currently empty. The grep guard makes reruns
+  // a no-op; an `if` block (not `&&  || true`) lets a genuine sed failure surface
+  // as a non-zero exit instead of being masked. sed delimiter is | (password is
+  // hex, no | chars).
+  const remoteCmd =
+    `IFS= read -r PW; ` +
+    `if grep -q "secret-key: ''" ${configPath}; then ` +
+    `sed -i "s|secret-key: ''|secret-key: '$PW'|" ${configPath}; fi`
+
+  const proc = Bun.spawn(ssh(host, remoteCmd, REMOTE_USER, opts), {
+    stdin: 'pipe',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+
+  // Trailing newline so `read -r` sees a terminated line and returns 0 — without
+  // it, read exits non-zero at EOF and the seed silently no-ops.
+  proc.stdin.write(`${managementPassword}\n`)
+  proc.stdin.end()
+
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    throw new Error(`Seeding remote secret-key failed (exit ${exitCode})`)
+  }
+
+  console.log('\u001B[1;34m==>\u001B[0m Seeded remote-management.secret-key in config.yaml')
+}
+
 // ---------------------------------------------------------------------------
 // Full provisioning orchestration seam (exported for testability)
 // ---------------------------------------------------------------------------
@@ -181,6 +231,7 @@ export interface PerformProvisioningDeps {
   pinHostKeys?: typeof pinHostKeys
   copyComposeFiles?: typeof copyComposeFiles
   writeRemoteEnvFile?: typeof writeRemoteEnvFile
+  seedRemoteSecretKey?: typeof seedRemoteSecretKey
   deployCompose?: typeof deployCompose
 }
 
@@ -201,6 +252,7 @@ export async function performProvisioning(
   const resolvedPinHostKeys = deps.pinHostKeys ?? pinHostKeys
   const resolvedCopyComposeFiles = deps.copyComposeFiles ?? copyComposeFiles
   const resolvedWriteRemoteEnvFile = deps.writeRemoteEnvFile ?? writeRemoteEnvFile
+  const resolvedSeedRemoteSecretKey = deps.seedRemoteSecretKey ?? seedRemoteSecretKey
   const resolvedDeployCompose = deps.deployCompose ?? deployCompose
 
   const {identityFile, cleanup} = resolveProvisionIdentity(privateKey)
@@ -214,6 +266,7 @@ export async function performProvisioning(
     await validateDns(dropletIp)
     await resolvedCopyComposeFiles(dropletIp, identityFile)
     const managementPassword = await resolvedWriteRemoteEnvFile(dropletIp, identityFile)
+    await resolvedSeedRemoteSecretKey(dropletIp, managementPassword, identityFile)
     await resolvedDeployCompose(dropletIp, identityFile)
     return managementPassword
   } finally {


### PR DESCRIPTION
Fixes `infra cliproxy open` returning a 401 at the TUI password prompt on a freshly provisioned box.

The CLIProxyAPI TUI authenticates against `config.yaml` `remote-management.secret-key`, but provisioning left that field empty — so the TUI rejected every credential even though the HTTP management API worked (it accepts the `MANAGEMENT_PASSWORD` env). This seeds `remote-management.secret-key` to the generated `MANAGEMENT_PASSWORD` at first provision, so one credential works for both the TUI (Bearer auth) and the HTTP API.

The password is piped through SSH stdin (never argv) with a trailing newline so the remote `read -r` returns 0, and an `if grep` guard replaces the empty value only when it's present — a genuine `sed` failure surfaces as a non-zero exit instead of being masked. The committed `config.yaml` template stays `secret-key: ''` (no secrets in tracked files); seeding is idempotent and runs before the first container start.

The live droplet was already corrected out-of-band via the management API; this makes future provisions correct by default.
