### PR TITLE
fix(fro-bot): self-dispatch the daily schedule for a fresh session per run

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -522,7 +522,6 @@ jobs:
           !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
           (github.event.pull_request.user.login || '') != 'fro-bot'
         ) ||
-        github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
         (
           (github.event_name == 'issue_comment' ||
@@ -579,3 +578,19 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.PROMPT }}
           timeout: 0
+
+  # The daily schedule self-dispatches so each autohealing run executes on workflow_dispatch,
+  # which the upstream harness keys to a fresh per-run session. A direct schedule trigger
+  # reuses one stable per-cron session that grows unbounded and eventually no-ops.
+  dispatch-daily:
+    name: Dispatch daily autohealing run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch fresh daily autohealing run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run fro-bot.yaml --ref main


### PR DESCRIPTION
Fixes the daily autohealing run silently producing no Daily Autohealing Report.

**Root cause.** The upstream harness keys a `schedule` run's session from the cron string, so every daily run resumes one stable thread. That thread grows without bound; once large, the agent resumes it, takes a single step, and exits with zero tool calls — no report is created, yet the run still reports success. `session-retention` can't help because the daily session is always the most-recently-updated one, so it's never pruned. There is no consumer-side input to force a fresh session for schedule runs (tracked upstream at fro-bot/agent#898).

**Fix.** A `workflow_dispatch` run gets a fresh per-run session. The daily cron now drives a small `dispatch-daily` job that re-invokes this workflow via `gh workflow run` with an empty prompt, so each autohealing pass executes on a fresh session and reaches the report step. The empty-prompt dispatch path already resolves to the daily schedule prompt. The dispatch job runs only on `schedule` and the main job no longer triggers on `schedule` directly, so there is no re-dispatch loop. `actions: write` is scoped to the dispatch job only.

Verified by a manual dispatch that ran the full pass and created the dated report issue.
