### PR TITLE
fix(fro-bot): skip session cache on scheduled runs for a fresh session

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -579,3 +579,8 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.PROMPT }}
           timeout: 0
+          # The daily schedule reuses one per-cron session that grows unbounded and
+          # eventually no-ops. Skipping the session cache on the schedule run starts a
+          # fresh session so each autohealing pass executes and posts its report.
+          # Other triggers keep cache continuity for their issue/PR threads.
+          skip-cache: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
Fixes the daily autohealing run silently producing no Daily Autohealing Report.

**Root cause.** The upstream harness keys a `schedule` run's session from the cron string, so every daily run resumes one stable session. That session grows without bound; once large, the agent resumes it, takes a single step, and exits with zero tool calls — no report is created, yet the run still reports success. There is no consumer-side input to force a fresh session, and session retention never prunes the always-recent daily session (tracked upstream at fro-bot/agent#898).

**Fix.** The action exposes a `skip-cache` input ("skip session cache restore"). Scoping it to the schedule event (`skip-cache: ${{ github.event_name == 'schedule' }}`) starts the daily run with no restored session cache, so the harness finds no prior per-cron session and runs on a fresh one — the autohealing pass executes and posts its report. Other triggers keep cache continuity for their issue/PR threads.

One job, one agent call, no added permissions, keeps the existing PAT. The next scheduled run is the live confirmation.
