### PR TITLE
fix(fro-bot): stop checking out PR-head code in the secret-bearing job

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -534,16 +534,15 @@ jobs:
         )
       )
     steps:
+      # Always check out the default ref. Resolving a PR head here is unsafe:
+      # an issue_comment on a fork PR is exposed only at github.event.issue.pull_request,
+      # so the job-level fork guard (which reads github.event.pull_request) does not apply,
+      # and a PR-head ref would pull fork-controlled code into a secret-bearing run.
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          ref: >-
-            ${{
-              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
-              || github.event.pull_request.head.sha
-              || ''
-            }}
+          persist-credentials: false
           token: ${{ secrets.FRO_BOT_PAT }}
 
       # Pin Node.js because Fro Bot runs `bun run lint` / `bunx tsc` which


### PR DESCRIPTION
Closes #545.

`issue_comment` events expose a PR only at `github.event.issue.pull_request`, so the job-level fork guard — which reads `github.event.pull_request` — does not apply to PR comments. The checkout step previously resolved `refs/pull/<n>/head` for comment-on-PR events, which pulled fork-controlled code into a run that holds `FRO_BOT_PAT` and the OpenCode secrets.

The checkout now always uses the default ref and no longer persists credentials, so a comment on a fork PR can never bring untrusted code into the secret-bearing steps. PR review on the `pull_request` event is unaffected; `@fro-bot` comments now operate on the default branch.

No fork PR has ever been opened against this repo, so the path was never exercised.
