### PR TITLE
chore(fro-bot): drop the redundant skip-cache schedule stopgap

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -578,8 +578,3 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.PROMPT }}
           timeout: 0
-          # The daily schedule reuses one per-cron session that grows unbounded and
-          # eventually no-ops. Skipping the session cache on the schedule run starts a
-          # fresh session so each autohealing pass executes and posts its report.
-          # Other triggers keep cache continuity for their issue/PR threads.
-          skip-cache: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
Removes the `skip-cache: ${{ github.event_name == 'schedule' }}` workaround from the Fro Bot workflow.

The stopgap forced a fresh session on scheduled runs because the agent keyed every daily run to one per-cron session that grew unbounded and eventually no-op'd. The pinned `fro-bot/agent` (v0.64.3) now scopes scheduled sessions per run natively, so the workaround is redundant — the daily autohealing run starts a fresh session on its own and resumes producing its report.
