### PR TITLE
feat(dashboard): adopt the 0.0.0.0 bind fix (resolves the public 502)

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
         condition: service_healthy
 
   dashboard:
-    image: ghcr.io/marcusrbrown/infra-dashboard:250493945add33e30cf25ec890d7d1b37d31d00e
+    image: ghcr.io/marcusrbrown/infra-dashboard:ecfb88fddbb0516c8320d3d1fed66724433bfb1d
     restart: unless-stopped
     env_file:
       - path: .env

--- a/apps/dashboard/upstream.json
+++ b/apps/dashboard/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/dashboard",
-  "ref": "250493945add33e30cf25ec890d7d1b37d31d00e"
+  "ref": "ecfb88fddbb0516c8320d3d1fed66724433bfb1d"
 }


### PR DESCRIPTION
Bumps the pinned `fro-bot/dashboard` source to the commit that binds the server to `0.0.0.0` by default (configurable via `DASHBOARD_HOST`/`DASHBOARD_PORT`), so the Caddy sidecar can reach it across the container network.

Before this, the app bound `127.0.0.1`, so the container's own healthcheck passed while Caddy got connection-refused — public `https://dashboard.fro.bot/api/healthz` returned 502 despite a healthy container. The upstream fix resolves that.

The CI `build-images` job rebuilds the image from the new source ref to GHCR; the deploy pulls the digest-pinned artifact. No new secrets, ports, or compose changes — the new host/port env vars are optional with safe defaults.
