### PR TITLE
fix(dashboard): bound SSH status connection attempts

### DIFF
--- a/.changeset/dashboard-status-ssh-timeout.md
+++ b/.changeset/dashboard-status-ssh-timeout.md
@@ -1,0 +1,5 @@
+---
+"@marcusrbrown/infra": patch
+---
+
+Dashboard SSH-backed `status` and `logs` commands now fail fast when SSH cannot establish a connection to an unreachable or stale-DNS host. `status` preserves the SSH error detail in its output.

--- a/packages/cli/src/commands/dashboard/logs.test.ts
+++ b/packages/cli/src/commands/dashboard/logs.test.ts
@@ -167,6 +167,30 @@ describe('logs command', () => {
   })
 })
 
+// ─── SSH command includes ConnectTimeout ─────────────────────────────────────
+
+describe('streamDashboardLogs — SSH command includes ConnectTimeout', () => {
+  it('passes -o ConnectTimeout=10 to ssh', async () => {
+    delete process.env.CI
+
+    let capturedCmd: string[] = []
+    const spawnCapture: LogsSpawnFn = (cmd, _opts) => {
+      capturedCmd = cmd
+      return {exited: Promise.resolve(0)}
+    }
+
+    await streamDashboardLogs(
+      {host: 'dashboard.fro.bot', service: 'dashboard', tail: 100, allowCi: false},
+      spawnCapture,
+    )
+
+    const connectTimeoutIdx = capturedCmd.findIndex(arg => arg.startsWith('ConnectTimeout='))
+    expect(connectTimeoutIdx).toBeGreaterThan(-1)
+    expect(capturedCmd[connectTimeoutIdx - 1]).toBe('-o')
+    expect(capturedCmd[connectTimeoutIdx]).toBe('ConnectTimeout=10')
+  })
+})
+
 // ─── SSH command includes repo-pinned UserKnownHostsFile ─────────────────────
 
 describe('streamDashboardLogs — SSH command includes UserKnownHostsFile', () => {

--- a/packages/cli/src/commands/dashboard/logs.ts
+++ b/packages/cli/src/commands/dashboard/logs.ts
@@ -96,6 +96,8 @@ export async function streamDashboardLogs(
     '-o',
     'BatchMode=yes',
     '-o',
+    'ConnectTimeout=10',
+    '-o',
     'StrictHostKeyChecking=yes',
     ...buildKnownHostsArgs(),
     ...identityArgs,

--- a/packages/cli/src/commands/dashboard/status.test.ts
+++ b/packages/cli/src/commands/dashboard/status.test.ts
@@ -133,6 +133,40 @@ function makeSpawn(stdout: string, stderr = '', exitCode = 0): SpawnFn {
   }
 }
 
+// ─── SSH command includes ConnectTimeout ─────────────────────────────────────
+
+describe('getDashboardComposeStatus — SSH command includes ConnectTimeout', () => {
+  it('passes -o ConnectTimeout=10 to ssh', async () => {
+    let capturedCmd: string[] = []
+
+    const capturingSpawn: SpawnFn = (cmd, _opts) => {
+      capturedCmd = cmd
+      const enc = new TextEncoder()
+      return {
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(enc.encode(JSON.stringify([{Name: 'dashboard', State: 'running', Health: 'healthy'}])))
+            c.close()
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.close()
+          },
+        }),
+        exited: Promise.resolve(0),
+      }
+    }
+
+    await getDashboardComposeStatus('dashboard.fro.bot', capturingSpawn)
+
+    const connectTimeoutIdx = capturedCmd.findIndex(arg => arg.startsWith('ConnectTimeout='))
+    expect(connectTimeoutIdx).toBeGreaterThan(-1)
+    expect(capturedCmd[connectTimeoutIdx - 1]).toBe('-o')
+    expect(capturedCmd[connectTimeoutIdx]).toBe('ConnectTimeout=10')
+  })
+})
+
 // ─── SSH command includes repo-pinned UserKnownHostsFile ─────────────────────
 
 describe('getDashboardComposeStatus — SSH command includes UserKnownHostsFile', () => {
@@ -359,6 +393,28 @@ describe('status command', () => {
 
     expect(threw).toBe(false)
     expect(captured.stderr.join('')).toContain('Error')
+    expect(captured.exit?.code).toBe(1)
+  })
+
+  it('prints the SSH error message (not a generic no-services message) when SSH fails', async () => {
+    process.env.DASHBOARD_DOMAIN = 'dashboard.fro.bot'
+
+    const {ctx, captured} = createCapturedCtx()
+
+    try {
+      await dashboardStatusAction(
+        {},
+        ctx,
+        makeSpawn('', 'ssh: connect to host dashboard.fro.bot port 22: Connection timed out', 255),
+      )
+    } catch (error) {
+      if (!(error instanceof MockProcessExit)) throw error
+    }
+
+    const stderrText = captured.stderr.join('')
+    // Must surface the SSH failure detail, not the generic no-services fallback
+    expect(stderrText).toContain('SSH command failed')
+    expect(stderrText).not.toContain('No services reported by docker compose ps')
     expect(captured.exit?.code).toBe(1)
   })
 

--- a/packages/cli/src/commands/dashboard/status.ts
+++ b/packages/cli/src/commands/dashboard/status.ts
@@ -109,6 +109,8 @@ export async function getDashboardComposeStatus(
     '-o',
     'BatchMode=yes',
     '-o',
+    'ConnectTimeout=10',
+    '-o',
     'StrictHostKeyChecking=yes',
     ...knownHostsArgs,
     ...identityArgs,
@@ -250,7 +252,8 @@ export async function dashboardStatusAction(
   }
 
   if (result.services.length === 0) {
-    ctx.console.error(`Error: No services reported by docker compose ps`)
+    const msg = result.error ?? 'No services reported by docker compose ps'
+    ctx.console.error(`Error: ${msg}`)
     ctx.process.exit(1)
     return
   }


### PR DESCRIPTION
## Summary

- bound dashboard SSH-backed status and log connection attempts with `ConnectTimeout=10`
- preserve the SSH failure detail in `dashboard status` instead of replacing it with a generic empty-compose message
- add dashboard CLI regression coverage and a patch changeset

## Verification

- `bun test packages/cli/src/commands/dashboard/status.test.ts packages/cli/src/commands/dashboard/logs.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` (0 errors, existing warnings only)
- `git diff --check`
- bounded stale-DNS smoke: `dashboard status` exits in ~10s with SSH timeout detail
