### PR TITLE
fix(dashboard): persist OAuth callback URL

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -29,7 +29,8 @@ Caddy depends on the `dashboard` service being healthy before starting.
 4. Remote prep: `mkdir -p /opt/dashboard/config` on the droplet.
 5. Materializes `/opt/dashboard/.env` over SSH **stdin** (never argv). The `.env` includes
    `DASHBOARD_GITHUB_APP_KEY_FILE=/run/secrets/github-app.pem` (the file path only — the PEM content
-   is never written to `.env`).
+   is never written to `.env`) and `DASHBOARD_OAUTH_REDIRECT_URI=https://$DASHBOARD_DOMAIN/auth/callback`
+   (derived from `DASHBOARD_DOMAIN`; no separate secret required).
 6. Uploads `docker-compose.yaml` and `config/Caddyfile` via `scp`.
 7. **Uploads the GitHub App private key** to `/opt/dashboard/config/github-app.pem` (0600) via SSH
    stdin — never as an env var, never logged. PEM bytes flow through stdin only; `umask 077` plus an

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -295,6 +295,8 @@ describe('.env file contents', () => {
     expect(contents).toContain('DASHBOARD_COOKIE_KEY=cookiekey\n')
     // App key must be a FILE path, not the PEM content
     expect(contents).toContain('DASHBOARD_GITHUB_APP_KEY_FILE=/run/secrets/github-app.pem\n')
+    // OAuth redirect URI must be derived from domain, not hardcoded to localhost
+    expect(contents).toContain('DASHBOARD_OAUTH_REDIRECT_URI=https://dashboard.fro.bot/auth/callback\n')
     // Image ref must NOT be in .env — it's in docker-compose.override.yaml
     expect(contents).not.toContain('DASHBOARD_IMAGE_REF')
   })

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -219,6 +219,7 @@ export function buildEnvFileContents(opts: {
     `DASHBOARD_GITHUB_APP_KEY_FILE=/run/secrets/github-app.pem\n` +
     `DASHBOARD_OAUTH_CLIENT_ID=${oauthClientId}\n` +
     `DASHBOARD_OAUTH_CLIENT_SECRET=${oauthClientSecret}\n` +
+    `DASHBOARD_OAUTH_REDIRECT_URI=https://${domain}/auth/callback\n` +
     `DASHBOARD_OPERATOR_LOGIN=${operatorLogin}\n` +
     `DASHBOARD_COOKIE_KEY=${cookieKey}\n`
   )


### PR DESCRIPTION
## Summary
- write the dashboard OAuth callback URL into the deployed `.env`
- derive the callback from `DASHBOARD_DOMAIN` instead of adding another secret
- document the deployed env contract

## Verification
- `bun test apps/dashboard/src/deploy.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- `git diff --check`

## Production
Applied the same config repair directly to the live dashboard and verified `/auth/login` sends GitHub `redirect_uri=https://dashboard.fro.bot/auth/callback`.
