### PR TITLE
fix(ci): install doctl in the gateway deploy for the firewall reconcile

### DIFF
--- a/.github/workflows/deploy-gateway.yaml
+++ b/.github/workflows/deploy-gateway.yaml
@@ -188,6 +188,11 @@ jobs:
             exit 1
           fi
 
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
       - name: Configure SSH known_hosts
         run: mkdir -p ~/.ssh && cp .github/known_hosts ~/.ssh/known_hosts
 

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -440,6 +440,20 @@ describe('per-app invariants', () => {
     // SHA verification is wired in and was not accidentally stripped.
     expect(buildTs).toMatch(/const\s+EXPECTED_SHA256\s*=/)
   })
+
+  it('deploy-gateway.yaml installs doctl via digitalocean/action-doctl before the deploy step', async () => {
+    const text = await Bun.file(resolve(REPO_ROOT, '.github/workflows/deploy-gateway.yaml')).text()
+    // The firewall reconcile in apps/gateway/src/deploy.ts shells out to `doctl`.
+    // doctl is not pre-installed on GitHub Actions runners, so the deploy job must
+    // install it explicitly. This test ensures the dependency cannot silently regress.
+    expect(text).toMatch(/uses:\s+digitalocean\/action-doctl@[a-f0-9]{40}/)
+    // The install step must appear before the deploy step in the file
+    const doctlIndex = text.indexOf('digitalocean/action-doctl@')
+    const deployStepIndex = text.indexOf('name: Deploy gateway')
+    expect(doctlIndex).toBeGreaterThan(-1)
+    expect(deployStepIndex).toBeGreaterThan(-1)
+    expect(doctlIndex).toBeLessThan(deployStepIndex)
+  })
 })
 
 describe('findCrossOrgSecretsInherit', () => {


### PR DESCRIPTION
The gateway deploy's DigitalOcean Cloud Firewall reconcile (added in #603) shells out to `doctl`, but the GitHub Actions runner never installed it — provisioning runs `doctl` locally on the operator machine, so no workflow had ever needed it. The first post-#603 gateway deploy failed with `Executable not found in $PATH: "doctl"` immediately after applying the DOCKER-USER rule, before the firewall reconcile and verification.

## Fix

- Add a SHA-pinned `digitalocean/action-doctl` step to `deploy-gateway.yaml` before the deploy step, authenticated with `DIGITALOCEAN_ACCESS_TOKEN`.
- Add a conventions test so the doctl dependency for the firewall reconcile can't silently regress.

## Live state note

The failed deploy had already published the operator port VPC-scoped (`10.116.0.3:9300`) and applied the DOCKER-USER restriction (verified live) before erroring — so the operator port is currently VPC-bound and iptables-restricted. The only missing layer is the reboot-durable DO Cloud Firewall rule, which this fix lets the deploy complete on the next run.
