### PR TITLE
fix(gateway): resolve the gateway droplet by name in the firewall reconcile

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -10794,13 +10794,14 @@ describe('DO Cloud Firewall reconcile', () => {
       ) {
         return makeSpawnResult({stdout: `${DASHBOARD_DROPLET_ID}\n`})
       }
-      // doctl compute droplet get <gateway-host> --format ID (to find its firewall)
+      // doctl compute droplet get gateway --format ID (to find its firewall)
+      // Must use the droplet NAME 'gateway', not the FQDN (GATEWAY_HOST).
       if (
         cmdStr.includes('doctl') &&
         cmdStr.includes('compute') &&
         cmdStr.includes('droplet') &&
         cmdStr.includes('get') &&
-        cmdStr.includes('gateway.fro.bot')
+        cmd[4] === 'gateway'
       ) {
         return makeSpawnResult({stdout: `${GATEWAY_DROPLET_ID}\n`})
       }
@@ -10873,7 +10874,7 @@ describe('DO Cloud Firewall reconcile', () => {
         cmdStr.includes('compute') &&
         cmdStr.includes('droplet') &&
         cmdStr.includes('get') &&
-        cmdStr.includes('gateway.fro.bot')
+        cmd[4] === 'gateway'
       ) {
         return makeSpawnResult({stdout: `${GATEWAY_DROPLET_ID}\n`})
       }
@@ -11045,7 +11046,7 @@ describe('DO Cloud Firewall reconcile', () => {
         cmdStr.includes('compute') &&
         cmdStr.includes('droplet') &&
         cmdStr.includes('get') &&
-        cmdStr.includes('gateway.fro.bot')
+        cmd[4] === 'gateway'
       ) {
         return makeSpawnResult({stdout: `${GATEWAY_DROPLET_ID}\n`})
       }
@@ -11098,7 +11099,7 @@ describe('DO Cloud Firewall reconcile', () => {
         cmdStr.includes('compute') &&
         cmdStr.includes('droplet') &&
         cmdStr.includes('get') &&
-        cmdStr.includes('gateway.fro.bot')
+        cmd[4] === 'gateway'
       ) {
         return makeSpawnResult({stdout: `${GATEWAY_DROPLET_ID}\n`})
       }
@@ -11137,6 +11138,63 @@ describe('DO Cloud Firewall reconcile', () => {
     })
 
     expect(dangerousCalls).toHaveLength(0)
+  })
+
+  test('gateway droplet lookup uses droplet name "gateway", never GATEWAY_HOST FQDN', async () => {
+    // Regression: the gateway droplet get must pass the droplet NAME ('gateway'),
+    // not GATEWAY_HOST ('gateway.fro.bot'). doctl expects a name, not a domain.
+    const {main} = await import('./deploy')
+    const dropletGetArgs: string[] = []
+    let inboundRulesCallCount = 0
+
+    const {spawnFn} = makeSpawnMock(cmd => {
+      const cmdStr = cmd.join(' ')
+      // Capture the argument passed to `doctl compute droplet get`
+      if (
+        cmdStr.includes('doctl') &&
+        cmdStr.includes('compute') &&
+        cmdStr.includes('droplet') &&
+        cmdStr.includes('get')
+      ) {
+        // cmd[4] is the name/identifier argument
+        if (cmd[4] !== undefined && cmd[4] !== 'dashboard') {
+          dropletGetArgs.push(cmd[4])
+        }
+        if (cmd[4] === 'gateway') return makeSpawnResult({stdout: `${GATEWAY_DROPLET_ID}\n`})
+        if (cmd[4] === 'dashboard') return makeSpawnResult({stdout: `${DASHBOARD_DROPLET_ID}\n`})
+      }
+      if (cmdStr.includes('doctl') && cmdStr.includes('firewall') && cmdStr.includes('list-by-droplet')) {
+        return makeSpawnResult({stdout: FIREWALL_LIST_NO_9300})
+      }
+      if (
+        cmdStr.includes('doctl') &&
+        cmdStr.includes('firewall') &&
+        cmdStr.includes('get') &&
+        cmdStr.includes('InboundRules')
+      ) {
+        inboundRulesCallCount++
+        return makeSpawnResult({
+          stdout: inboundRulesCallCount === 1 ? FIREWALL_INBOUND_NO_9300 : FIREWALL_INBOUND_WITH_9300,
+        })
+      }
+      return undefined
+    })
+
+    await main({
+      env: makeFirewallEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+      tcpConnect: tcpConnectRefused,
+    })
+
+    // The gateway droplet get must use the droplet name 'gateway', not the FQDN.
+    expect(dropletGetArgs).toHaveLength(1)
+    expect(dropletGetArgs[0]).toBe('gateway')
+    // Must NOT pass the FQDN (GATEWAY_HOST value from makeEnv = 'gateway.fro.bot')
+    expect(dropletGetArgs[0]).not.toBe('gateway.fro.bot')
+    expect(dropletGetArgs[0]).not.toContain('.')
   })
 })
 

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -89,6 +89,17 @@ export interface DeployArgs {
 const REMOTE_DIR = '/opt/gateway'
 
 /**
+ * DigitalOcean droplet name for the gateway — matches the provisioner's DROPLET_NAME constant.
+ * Distinct from GATEWAY_HOST (the FQDN); doctl expects the droplet name, not the domain.
+ */
+const GATEWAY_DROPLET_NAME = 'gateway'
+
+/**
+ * DigitalOcean droplet name for the dashboard — sibling constant for symmetry with GATEWAY_DROPLET_NAME.
+ */
+const DASHBOARD_DROPLET_NAME = 'dashboard'
+
+/**
  * The Docker Compose project name for the gateway stack.
  * Derived from `name: fro-bot` in the upstream fro-bot/agent compose.yaml.
  * Docker Compose prefixes network names with the project name, so the
@@ -2862,7 +2873,7 @@ SCRIPT`
       // Uses `doctl compute droplet get <name> --format ID --no-header`.
       const {stdout: dashboardIdRaw} = await runCommandWithTimeout(
         'Resolving dashboard droplet ID',
-        ['doctl', 'compute', 'droplet', 'get', 'dashboard', '--format', 'ID', '--no-header'],
+        ['doctl', 'compute', 'droplet', 'get', DASHBOARD_DROPLET_NAME, '--format', 'ID', '--no-header'],
         doctlEnv,
         spawnFn,
         DOCTL_TIMEOUT_MS,
@@ -2870,16 +2881,17 @@ SCRIPT`
       const dashboardDropletId = dashboardIdRaw.trim()
       if (!dashboardDropletId) {
         throw new Error(
-          'Dashboard droplet "dashboard" not found in DigitalOcean account. ' +
+          `Dashboard droplet "${DASHBOARD_DROPLET_NAME}" not found in DigitalOcean account. ` +
             'Run `doctl compute droplet list` to see available droplets. ' +
             'The DO Cloud Firewall reconcile cannot proceed without the dashboard droplet ID.',
         )
       }
 
       // Step 2: Resolve the gateway droplet ID (needed to find its firewall).
+      // Uses the droplet NAME (GATEWAY_DROPLET_NAME = 'gateway'), not GATEWAY_HOST (the FQDN).
       const {stdout: gatewayIdRaw} = await runCommandWithTimeout(
         'Resolving gateway droplet ID',
-        ['doctl', 'compute', 'droplet', 'get', host, '--format', 'ID', '--no-header'],
+        ['doctl', 'compute', 'droplet', 'get', GATEWAY_DROPLET_NAME, '--format', 'ID', '--no-header'],
         doctlEnv,
         spawnFn,
         DOCTL_TIMEOUT_MS,
@@ -2887,7 +2899,7 @@ SCRIPT`
       const gatewayDropletId = gatewayIdRaw.trim()
       if (!gatewayDropletId) {
         throw new Error(
-          `Gateway droplet "${host}" not found in DigitalOcean account. ` +
+          `Gateway droplet "${GATEWAY_DROPLET_NAME}" not found in DigitalOcean account. ` +
             'Run `doctl compute droplet list` to see available droplets.',
         )
       }


### PR DESCRIPTION
The gateway DO Cloud Firewall reconcile resolved the gateway droplet ID by passing `GATEWAY_HOST` (the FQDN `gateway.fro.bot`) to `doctl compute droplet get`, which expects the droplet **name**, not the domain. The deploy failed at "Resolving gateway droplet ID" with `Error: Droplet with the name "gateway.fro.bot" could not be found.`

The DigitalOcean droplet is named `gateway` (matching the provisioner's `DROPLET_NAME`). The dashboard lookup in the same reconcile block already used the literal droplet name `dashboard` correctly.

## Fix

- Add named constants `GATEWAY_DROPLET_NAME = 'gateway'` and `DASHBOARD_DROPLET_NAME = 'dashboard'`, distinct from `GATEWAY_HOST` (the FQDN).
- Resolve the gateway droplet by `GATEWAY_DROPLET_NAME`, mirroring the dashboard lookup; update the error message accordingly.
- Regression test asserts the gateway droplet is resolved by the name `gateway`, never the FQDN.

This was the last blocker preventing the firewall reconcile from completing; the deploy had already published the VPC-scoped port and applied + verified the DOCKER-USER rule before this step.
