### PR TITLE
fix(ci): decouple the dashboard deploy from the gateway deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -167,14 +167,11 @@ jobs:
       VPN_HOST: ${{ secrets.VPN_HOST }}
       VPN_PEERS: ${{ secrets.VPN_PEERS }}
 
-  # The dashboard operator route proxies to the gateway VPC bridge; needs: deploy-gateway
-  # orders dashboard after gateway and the if: lets dashboard proceed when gateway is skipped.
   deploy-dashboard:
-    needs: [detect-changes, deploy-gateway]
+    needs: detect-changes
     if: >-
-      !cancelled() &&
-      needs.deploy-gateway.result != 'failure' &&
-      (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.dashboard == 'true')
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.dashboard == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/deploy-dashboard.yaml

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -134,15 +134,12 @@ const fetchHealthzOk = async (_url: string, _opts?: RequestInit): Promise<Respon
 }
 
 /**
- * Fake fetch that fails for /api/healthz (simulating ACME cert lag) but returns 200
- * for /operator/health (so the same-origin check passes in tests that use this mock).
- * Tests that need /operator/health to fail should use a custom fetch mock.
+ * Fake fetch that fails for /api/healthz (simulating ACME cert lag).
+ * /operator/health also throws here — since Phase 12b is non-blocking, the deploy
+ * still completes. Tests that need /operator/health to return a specific status
+ * should use a custom fetch mock.
  */
-const fetchHealthzFail = async (url: string, _opts?: RequestInit): Promise<Response> => {
-  if (url.includes('/operator/health')) {
-    // Return 200 for the operator health check — this mock simulates ACME lag only for /api/healthz
-    return new Response(JSON.stringify({ok: true}), {status: 200})
-  }
+const fetchHealthzFail = async (_url: string, _opts?: RequestInit): Promise<Response> => {
   throw new Error('fetch failed')
 }
 
@@ -1157,20 +1154,21 @@ describe('validateEnv with GATEWAY_VPC_IP', () => {
   })
 })
 
-// ─── same-origin /operator/health 200 check ──────────────
+// ─── same-origin /operator/health advisory check (non-blocking) ──────────────
 //
-// The dashboard deploy owns the /operator/* Caddy route and runs after the gateway
-// deploy. Once the route is live, the runner can probe
-// https://dashboard.fro.bot/operator/health from the public internet (the dashboard
-// is publicly reachable via Caddy → VPC → gateway operator daemon).
+// Phase 12b probes https://dashboard.fro.bot/operator/health when GATEWAY_VPC_IP is set.
+// The check is advisory: a non-200 result or unreachable endpoint emits a warning and
+// the deploy continues. The gateway bridge is deployed independently; the dashboard
+// deploy must not depend on gateway readiness.
 //
 // Gate: GATEWAY_VPC_IP is set (i.e. the operator route is active).
-// Fail closed: /operator/health != 200 → deploy throws.
+// Non-blocking: /operator/health != 200 → warn and continue (never throws).
+// Success: /operator/health == 200 → log success.
 // Edge: GATEWAY_VPC_IP absent → check skipped (only the existing /api/healthz check runs).
 //
 // The public-denied gateway.fro.bot:9300 check and DO firewall readback belong to
 // the gateway deploy (Phase 8e). The DOCKER-USER readback belongs to Phase 8c.
-// This unit adds only the same-origin health check that the dashboard deploy owns.
+// This unit covers only the same-origin advisory check that the dashboard deploy owns.
 
 describe('dashboard verification: same-origin /operator/health 200 check', () => {
   // ── Happy path ──────────────────────────────────────────────────────────────
@@ -1199,11 +1197,12 @@ describe('dashboard verification: same-origin /operator/health 200 check', () =>
     expect(probedUrls.some(u => u.includes('/operator/health'))).toBe(true)
   })
 
-  // ── Error: /operator/health != 200 → fail closed ────────────────────────────
+  // ── Non-blocking: /operator/health != 200 → warn and continue ───────────────
 
-  it('error: GATEWAY_VPC_IP set + /operator/health returns 503 → deploy fails closed', async () => {
+  it('non-blocking: GATEWAY_VPC_IP set + /operator/health returns 503 → deploy warns and completes', async () => {
     const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
 
+    // Deploy must complete (not throw) even when /operator/health returns 503
     await expect(
       deploy({
         env: VALID_ENV,
@@ -1219,12 +1218,13 @@ describe('dashboard verification: same-origin /operator/health 200 check', () =>
         probeIntervalMs: 0,
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/operator.*health|health.*operator|\/operator\/health/i)
+    ).resolves.toBeUndefined()
   })
 
-  it('error: GATEWAY_VPC_IP set + /operator/health returns 404 → deploy fails closed', async () => {
+  it('non-blocking: GATEWAY_VPC_IP set + /operator/health returns 404 → deploy warns and completes', async () => {
     const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
 
+    // Deploy must complete (not throw) even when /operator/health returns 404
     await expect(
       deploy({
         env: VALID_ENV,
@@ -1240,7 +1240,7 @@ describe('dashboard verification: same-origin /operator/health 200 check', () =>
         probeIntervalMs: 0,
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/operator.*health|health.*operator|\/operator\/health/i)
+    ).resolves.toBeUndefined()
   })
 
   // ── Edge: GATEWAY_VPC_IP absent → check skipped ──────────────────────────────
@@ -1359,9 +1359,9 @@ describe('dashboard verification: same-origin /operator/health 200 check', () =>
 
 // ─── [P1] /operator/health retry loop ────────────────────────────────────────
 //
-// Phase 12b must retry the /operator/health check with bounded attempts,
-// matching the existing /api/healthz probe pattern. Fail closed after all
-// attempts exhausted.
+// Phase 12b retries the /operator/health check with bounded attempts,
+// matching the existing /api/healthz probe pattern. Non-blocking: after all
+// attempts exhausted, emits a warning and continues (never throws).
 
 describe('dashboard verification: /operator/health retry loop (P1 fix)', () => {
   it('succeeds on a later attempt (retry works)', async () => {
@@ -1393,10 +1393,11 @@ describe('dashboard verification: /operator/health retry loop (P1 fix)', () => {
     expect(operatorHealthAttempts).toBeGreaterThanOrEqual(3)
   })
 
-  it('fails closed after all attempts non-200', async () => {
+  it('warns and completes after all attempts non-200 (non-blocking)', async () => {
     const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
     let operatorHealthAttempts = 0
 
+    // Deploy must complete (not throw) even after exhausting all /operator/health attempts
     await expect(
       deploy({
         env: VALID_ENV,
@@ -1413,16 +1414,17 @@ describe('dashboard verification: /operator/health retry loop (P1 fix)', () => {
         probeIntervalMs: 0,
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/operator.*health|health.*operator|\/operator\/health/i)
+    ).resolves.toBeUndefined()
 
     // Must have exhausted all attempts
     expect(operatorHealthAttempts).toBe(3)
   })
 
-  it('connection error on all attempts → fails closed', async () => {
+  it('connection error on all attempts → warns and completes (non-blocking)', async () => {
     const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
     let operatorHealthAttempts = 0
 
+    // Deploy must complete (not throw) even when all /operator/health probes throw
     await expect(
       deploy({
         env: VALID_ENV,
@@ -1439,7 +1441,7 @@ describe('dashboard verification: /operator/health retry loop (P1 fix)', () => {
         probeIntervalMs: 0,
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/operator.*health|health.*operator|\/operator\/health/i)
+    ).resolves.toBeUndefined()
 
     expect(operatorHealthAttempts).toBeGreaterThanOrEqual(1)
   })

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -727,24 +727,24 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       spawnFn,
     )
 
-    // Phase 12b: Same-origin /operator/health 200 check.
+    // Phase 12b: Same-origin /operator/health advisory check (non-blocking).
     //
     // Gated on GATEWAY_VPC_IP being set — this indicates the /operator/* Caddy route is active.
     // When GATEWAY_VPC_IP is absent, the route is not configured and this check is skipped.
     //
-    // The dashboard deploy owns the /operator/* Caddy route and runs after the gateway deploy.
-    // Once Caddy is up (Phase 11), the runner can probe https://dashboard.fro.bot/operator/health
-    // from the public internet — the route proxies through Caddy → VPC → gateway operator daemon.
+    // The gateway bridge is deployed independently; the dashboard deploy must not depend on
+    // gateway readiness. A non-200 result (or unreachable endpoint) emits a warning and
+    // continues — it does NOT fail the deploy. The dashboard is standalone.
     //
-    // Fail closed: /operator/health != 200 → deploy throws.
-    // This proves the same-origin path works end-to-end (Caddy route + VPC reach + daemon guard).
+    // When the probe succeeds (200), the success is logged as confirmation that the
+    // same-origin path is working end-to-end (Caddy route + VPC reach + gateway daemon).
     //
     // The public-denied gateway.fro.bot:9300 check and DO firewall readback belong to the
     // gateway deploy (Phase 8e). The DOCKER-USER readback belongs to Phase 8c of the gateway deploy.
     if (validated.GATEWAY_VPC_IP) {
       // Bounded retry loop — DO firewall propagation and Caddy↔backend startup timing can
       // cause transient failures. Mirrors the /api/healthz probe pattern (probeAttempts /
-      // probeIntervalMs). Fail closed after all attempts exhausted.
+      // probeIntervalMs). Advisory only: never throws regardless of outcome.
       const operatorHealthUrl = `https://${host}/operator/health`
       console.warn(`\u001B[1;34m==>\u001B[0m Probing same-origin operator health endpoint: ${operatorHealthUrl}`)
       let operatorHealthOk = false
@@ -770,22 +770,22 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
         }
       }
 
-      if (!operatorHealthOk) {
-        if (lastOperatorHealthError !== undefined) {
-          throw new Error(
-            `Same-origin operator health check failed after ${probeAttempts} attempt(s): could not reach ${operatorHealthUrl}. ` +
-              `Ensure the gateway deploy has completed (VPC port publish + DOCKER-USER + DO firewall) ` +
-              `before deploying the dashboard /operator/* route. ` +
-              `Last error: ${lastOperatorHealthError}`,
-          )
-        }
-        throw new Error(
-          `Same-origin operator health check failed after ${probeAttempts} attempt(s): ${operatorHealthUrl} returned HTTP ${lastOperatorHealthStatus} (expected 200). ` +
-            `The /operator/* Caddy route is active but the gateway operator daemon is not healthy. ` +
-            `Check the gateway operator service and ensure the VPC path is correctly configured.`,
+      if (operatorHealthOk) {
+        console.warn(`\u001B[1;32m✓\u001B[0m Same-origin operator health check passed: ${operatorHealthUrl} → 200`)
+      } else if (lastOperatorHealthError) {
+        console.warn(
+          `\u001B[1;33m[warn]\u001B[0m Same-origin operator health check did not pass after ${probeAttempts} attempt(s): ` +
+            `could not reach ${operatorHealthUrl}. ` +
+            `The gateway bridge may not be live yet or the firewall has not propagated. ` +
+            `Last error: ${lastOperatorHealthError}`,
+        )
+      } else {
+        console.warn(
+          `\u001B[1;33m[warn]\u001B[0m Same-origin operator health check did not pass after ${probeAttempts} attempt(s): ` +
+            `${operatorHealthUrl} returned HTTP ${lastOperatorHealthStatus} (expected 200). ` +
+            `The gateway bridge may not be live yet — verify the gateway deploy has completed.`,
         )
       }
-      console.warn(`\u001B[1;32m✓\u001B[0m Same-origin operator health check passed: ${operatorHealthUrl} → 200`)
     }
 
     // Phase 12: Public HTTPS probe (warning-only — Caddy ACME cert may still be issuing)

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1151,30 +1151,30 @@ describe('deploy.yaml: aggregate router forwards VPC bridge secrets', () => {
   }
 })
 
-// ─── deploy.yaml: gateway→dashboard ordering (PR #603) ───────────────────────
+// ─── deploy.yaml: deploy-dashboard is decoupled from deploy-gateway ──────────
 //
-// The dashboard operator route depends on the gateway VPC bridge being live.
-// deploy-dashboard must declare needs: deploy-gateway so it runs after the
-// gateway deploy, and its if: must reference needs.deploy-gateway.result so
-// it proceeds when gateway is skipped (unchanged) but blocks on gateway failure.
+// The dashboard is a standalone deployment. A gateway failure or slowness must
+// not block dashboard deploys. deploy-dashboard must NOT declare needs: deploy-gateway,
+// and its if: must NOT reference needs.deploy-gateway — locking in the decoupling
+// so it cannot silently regress.
 
-describe('deploy.yaml: deploy-dashboard is ordered after deploy-gateway', () => {
+describe('deploy.yaml: deploy-dashboard is decoupled from deploy-gateway', () => {
   const DEPLOY_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy.yaml')
 
-  it('deploy-dashboard needs: includes deploy-gateway', async () => {
+  it('deploy-dashboard needs: does NOT include deploy-gateway (standalone job)', async () => {
     const text = await Bun.file(DEPLOY_WORKFLOW).text()
     const parsed = parseYaml(text) as {
       jobs?: {'deploy-dashboard'?: {needs?: string | string[]}}
     }
     const needs = parsed?.jobs?.['deploy-dashboard']?.needs ?? []
     const needsArr = Array.isArray(needs) ? needs : [needs]
-    expect(needsArr).toContain('deploy-gateway')
+    expect(needsArr).not.toContain('deploy-gateway')
   })
 
-  it('deploy-dashboard if: references needs.deploy-gateway.result (fail-aware ordering)', async () => {
+  it('deploy-dashboard if: does NOT reference needs.deploy-gateway (no gateway coupling)', async () => {
     const text = await Bun.file(DEPLOY_WORKFLOW).text()
-    // Plain-text check: the if: expression must reference needs.deploy-gateway.result
-    // so that dashboard is blocked on gateway failure, not just ordered after it.
-    expect(text).toMatch(/needs\.deploy-gateway\.result/)
+    // The if: expression must not reference needs.deploy-gateway in any form —
+    // gateway state must not gate the dashboard deploy.
+    expect(text).not.toMatch(/needs\.deploy-gateway/)
   })
 })


### PR DESCRIPTION
The gateway deploy must never block the dashboard deployment. A prior change made `deploy-dashboard` depend on `deploy-gateway` (to avoid a race where the dashboard `/operator/*` route deploys before the gateway bridge is up), but that coupling let a gateway failure or slowness stall an unrelated dashboard deploy. The dashboard is a standalone app.

## What changed

- **`deploy.yaml`**: `deploy-dashboard` reverts to `needs: detect-changes` with the standard independent `if:` — same shape as every other app deploy. No gateway coupling.
- **`apps/dashboard/src/deploy.ts`**: the same-origin `/operator/health` check is now **advisory** — it warns (never throws) when the operator route isn't reachable, since the gateway VPC bridge is deployed independently and may not be live at dashboard-deploy time. The dashboard's own `/api/healthz` probe stays fail-closed.
- Conventions tests now assert the decoupling (dashboard does not need gateway).

## Tradeoff

The original race (dashboard `/operator/*` route live before the gateway bridge) is now handled by the advisory check + the fact that the operator route simply 502s until the gateway side is up — a transient, self-resolving state, not a deploy failure. Deployment independence is the priority.
