### PR TITLE
feat(cliproxy): probe upstream provider auth in status

### DIFF
--- a/.changeset/cliproxy-provider-auth-check.md
+++ b/.changeset/cliproxy-provider-auth-check.md
@@ -1,0 +1,5 @@
+---
+"@marcusrbrown/infra": minor
+---
+
+Add an upstream provider-auth probe to `cliproxy status`. The new check sends a minimal Anthropic completion through the proxy (via `--api-key` or `CLIPROXY_API_KEY`) and reports an error with a `cliproxy login claude` remediation when the proxy's upstream Claude auth is unavailable — catching expired-OAuth failures that the `/healthz` and management checks miss. Skips gracefully when no downstream API key is configured.

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -28,6 +28,7 @@ Commands:
 
     --url [url]                        Base URL for CLIProxyAPI health checks. Falls back to CLIPROXY_URL or https://cliproxy.fro.bot.
     --key [key]                        Management API key. Falls back to CLIPROXY_MANAGEMENT_KEY when omitted.
+    --api-key [key]                    Downstream API key (bearer) for the upstream provider-auth probe. Falls back to CLIPROXY_API_KEY. Skipped when absent.
     --verbose                          Enable verbose output for all commands
 
 

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -3,6 +3,7 @@ import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 import {createCapturedCtx, expectCapturedToInclude, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
 import {
   checkHttpReachability,
+  checkProviderAuth,
   checkUsageStats,
   checkVersion,
   cliproxyStatusAction,
@@ -837,5 +838,320 @@ describe('cliproxyStatusAction — ambient key does not follow agent-supplied UR
 
     const output = [...captured.stdout, ...captured.stderr].join('\n')
     expect(output).toMatch(/CLIPROXY_MANAGEMENT_KEY|no key|skipping/i)
+  })
+})
+
+// ─── checkProviderAuth ────────────────────────────────────────────────────────
+
+describe('checkProviderAuth', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns ok when POST /v1/chat/completions returns 200', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify({choices: [{message: {content: 'pong'}}]}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('ok')
+    expect(result.title).toBe('Upstream provider auth (anthropic)')
+    expect(result.summary).toContain('anthropic route OK')
+    expect(result.summary).toContain('claude-sonnet-4-6')
+  })
+
+  it('returns error when POST returns 401', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('Unauthorized', {status: 401}))
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('error')
+    expect(result.summary).toContain('401')
+    expect(result.summary).toContain('cliproxy login claude')
+  })
+
+  it('returns error when POST returns 503 with auth_unavailable body', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () => new Response('auth_unavailable: no auth available (providers=claude)', {status: 503}),
+    )
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('error')
+    expect(result.summary).toContain('503')
+    expect(result.summary).toContain('cliproxy login claude')
+  })
+
+  it('returns error when POST returns 503 with "no auth available" in body', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('no auth available', {status: 503}))
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('error')
+    expect(result.summary).toContain('cliproxy login claude')
+  })
+
+  it('returns error when POST returns 503 with "providers=claude" in body', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () => new Response('{"error":"providers=claude unavailable"}', {status: 503}),
+    )
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('error')
+    expect(result.summary).toContain('cliproxy login claude')
+  })
+
+  it('returns warning when POST returns 503 without auth-unavailable markers', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('Service Unavailable', {status: 503}))
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('warning')
+    expect(result.summary).toContain('503')
+    expect(result.summary).not.toContain('cliproxy login claude')
+  })
+
+  it('returns warning when POST returns other non-2xx (e.g. 500)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => new Response('Internal Server Error', {status: 500}))
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('warning')
+    expect(result.summary).toContain('500')
+  })
+
+  it('returns warning (not error) when fetch throws (network/timeout)', async () => {
+    globalThis.fetch = createFetchImplementation(async () => {
+      throw new Error('The operation was aborted due to timeout')
+    })
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(result.level).toBe('warning')
+    expect(result.summary).toContain('Anthropic probe failed')
+    expect(result.summary).toContain('aborted')
+  })
+
+  it('never includes the apiKey in summary or details', async () => {
+    const secretKey = 'super-secret-api-key-do-not-leak'
+
+    globalThis.fetch = createFetchImplementation(async () => new Response('Unauthorized', {status: 401}))
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', secretKey)
+
+    expect(result.summary).not.toContain(secretKey)
+    const detailsText = (result.details ?? []).join('\n')
+    expect(detailsText).not.toContain(secretKey)
+  })
+
+  it('uses the default model claude-sonnet-4-6 when no model override given', async () => {
+    let capturedBody = ''
+
+    globalThis.fetch = createFetchImplementation(async (_url, init) => {
+      capturedBody = typeof init?.body === 'string' ? init.body : ''
+      return new Response(JSON.stringify({choices: []}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    })
+
+    await checkProviderAuth('https://cliproxy.example.com', 'test-api-key')
+
+    expect(capturedBody).toContain('claude-sonnet-4-6')
+  })
+
+  it('uses the model override when options.model is provided', async () => {
+    let capturedBody = ''
+
+    globalThis.fetch = createFetchImplementation(async (_url, init) => {
+      capturedBody = typeof init?.body === 'string' ? init.body : ''
+      return new Response(JSON.stringify({choices: []}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    })
+
+    await checkProviderAuth('https://cliproxy.example.com', 'test-api-key', {model: 'claude-opus-4-5'})
+
+    expect(capturedBody).toContain('claude-opus-4-5')
+    expect(capturedBody).not.toContain('claude-sonnet-4-6')
+  })
+
+  it('includes verbose details (URL, model, status) when verbose=true', async () => {
+    globalThis.fetch = createFetchImplementation(
+      async () =>
+        new Response(JSON.stringify({choices: []}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    )
+
+    const result = await checkProviderAuth('https://cliproxy.example.com', 'test-api-key', {verbose: true})
+
+    expect(result.details).toBeDefined()
+    const detailsText = (result.details ?? []).join('\n')
+    expect(detailsText).toContain('https://cliproxy.example.com')
+    expect(detailsText).toContain('claude-sonnet-4-6')
+  })
+})
+
+// ─── cliproxyStatusAction — provider auth wiring ─────────────────────────────
+
+describe('cliproxyStatusAction — provider auth probe wiring', () => {
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalEnv = {
+      CLIPROXY_URL: process.env.CLIPROXY_URL,
+      CLIPROXY_MANAGEMENT_KEY: process.env.CLIPROXY_MANAGEMENT_KEY,
+      CLIPROXY_API_KEY: process.env.CLIPROXY_API_KEY,
+    }
+    delete process.env.CLIPROXY_URL
+    delete process.env.CLIPROXY_MANAGEMENT_KEY
+    delete process.env.CLIPROXY_API_KEY
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = v
+      }
+    }
+    globalThis.fetch = originalFetch
+  })
+
+  it('shows a warning (not error) when no provider key is available', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toMatch(/CLIPROXY_API_KEY|skipping upstream provider probe/i)
+    // Must be a warning, not an error — no exit(1) for missing key
+    expect(captured.exit).toBeNull()
+  })
+
+  it('runs the provider auth probe when --api-key is provided', async () => {
+    const fetchedUrls: string[] = []
+
+    globalThis.fetch = createFetchImplementation(async url => {
+      fetchedUrls.push(url)
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v1/chat/completions'))
+        return new Response(JSON.stringify({choices: []}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyStatusAction({url: 'https://cliproxy.example.com', apiKey: 'my-api-key'}, ctx)
+
+    expect(fetchedUrls.some(u => u.includes('/v1/chat/completions'))).toBe(true)
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toContain('Upstream provider auth')
+  })
+
+  it('does NOT forward ambient CLIPROXY_API_KEY to an explicit --url override', async () => {
+    process.env.CLIPROXY_API_KEY = 'ambient-api-key-secret'
+
+    const capturedAuthHeaders: string[] = []
+
+    globalThis.fetch = createFetchImplementation(async (url, init) => {
+      const hdrs = init?.headers
+      let auth: string | null = null
+      if (hdrs instanceof Headers) {
+        auth = hdrs.get('authorization')
+      } else if (hdrs !== null && hdrs !== undefined && typeof hdrs === 'object') {
+        const hdrsObj = hdrs as Record<string, string>
+        auth = hdrsObj.authorization ?? hdrsObj.Authorization ?? null
+      }
+      if (auth) capturedAuthHeaders.push(auth)
+
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v1/chat/completions')) return new Response(JSON.stringify({choices: []}), {status: 200})
+      return new Response('ok', {status: 200})
+    })
+
+    const {ctx} = createCapturedCtx()
+    // Explicit --url override to a non-trusted host — ambient key must NOT follow
+    await cliproxyStatusAction({url: 'https://evil.example.com'}, ctx)
+
+    // The ambient API key must not appear in any Authorization header sent to evil host
+    expect(capturedAuthHeaders.some(h => h.includes('ambient-api-key-secret'))).toBe(false)
+  })
+
+  it('uses ambient CLIPROXY_API_KEY when URL is the trusted default', async () => {
+    process.env.CLIPROXY_API_KEY = 'ambient-api-key-trusted'
+
+    const capturedAuthHeaders: string[] = []
+
+    globalThis.fetch = createFetchImplementation(async (url, init) => {
+      const hdrs = init?.headers
+      let auth: string | null = null
+      if (hdrs instanceof Headers) {
+        auth = hdrs.get('authorization')
+      } else if (hdrs !== null && hdrs !== undefined && typeof hdrs === 'object') {
+        const hdrsObj = hdrs as Record<string, string>
+        auth = hdrsObj.authorization ?? hdrsObj.Authorization ?? null
+      }
+      if (auth) capturedAuthHeaders.push(auth)
+
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v1/chat/completions'))
+        return new Response(JSON.stringify({choices: []}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      // Management endpoints — return ok so management checks don't block
+      if (url.includes('/v0/management/config'))
+        return new Response('{}', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/usage-queue'))
+        return new Response('[]', {status: 200, headers: {'content-type': 'application/json'}})
+      if (url.includes('/v0/management/latest-version'))
+        return new Response(JSON.stringify({'latest-version': 'v1.0.0'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      return new Response('ok', {status: 200})
+    })
+
+    const {ctx} = createCapturedCtx()
+    // Default trusted URL — ambient key SHOULD be used
+    await cliproxyStatusAction({url: 'https://cliproxy.fro.bot'}, ctx)
+
+    expect(capturedAuthHeaders.some(h => h.includes('ambient-api-key-trusted'))).toBe(true)
+  })
+
+  it('provider auth error (401) causes exit(1) — dead upstream is a real error', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.includes('/healthz')) return new Response('ok', {status: 200})
+      if (url.includes('/v1/chat/completions')) return new Response('Unauthorized', {status: 401})
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    let threw: unknown
+    try {
+      await cliproxyStatusAction({url: 'https://cliproxy.example.com', apiKey: 'my-api-key'}, ctx)
+    } catch (error) {
+      threw = error
+    }
+
+    expect(threw).toBeInstanceOf(MockProcessExit)
+    expect(captured.exit?.code).toBe(1)
   })
 })

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -226,6 +226,113 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
   }
 }
 
+const DEFAULT_PROVIDER_MODEL = 'claude-sonnet-4-6'
+
+export interface ProviderAuthOptions {
+  model?: string
+  verbose?: boolean
+}
+
+/**
+ * Probe the upstream provider auth by sending a minimal chat completion request.
+ * Returns a CheckResult — never throws.
+ *
+ * - 200 → ok
+ * - 401 OR (503 with auth-unavailable body markers) → error with remediation hint
+ * - other non-2xx → warning (don't fail status on unrelated upstream issues)
+ * - fetch throw (timeout/network) → warning (flaky probe should not fail status)
+ *
+ * The apiKey is NEVER included in summary or details output.
+ */
+export async function checkProviderAuth(
+  baseUrl: string,
+  apiKey: string,
+  options?: ProviderAuthOptions,
+): Promise<CheckResult> {
+  const model = options?.model ?? DEFAULT_PROVIDER_MODEL
+  const verbose = options?.verbose === true
+  const endpoint = `${baseUrl}/v1/chat/completions`
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{role: 'user', content: 'ping'}],
+        max_tokens: 1,
+      }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    })
+
+    const details: string[] = []
+    if (verbose) {
+      details.push(`URL: ${endpoint}`)
+      details.push(`Model: ${model}`)
+      details.push(`Status: ${response.status}`)
+    }
+
+    if (response.ok) {
+      return {
+        title: 'Upstream provider auth (anthropic)',
+        level: 'ok',
+        summary: `anthropic route OK (${model})`,
+        details: details.length > 0 ? details : undefined,
+      }
+    }
+
+    // 401 is always an auth failure
+    if (response.status === 401) {
+      return {
+        title: 'Upstream provider auth (anthropic)',
+        level: 'error',
+        summary: `Anthropic upstream auth unavailable (${response.status}) — run: cliproxy login claude`,
+        details: details.length > 0 ? details : undefined,
+      }
+    }
+
+    // 503 may be auth_unavailable — check body for known markers
+    if (response.status === 503) {
+      let bodyText = ''
+      try {
+        bodyText = await response.text()
+      } catch {
+        // ignore body read failure
+      }
+
+      const isAuthUnavailable = /auth_unavailable|no auth available|providers=claude/i.test(bodyText)
+
+      if (isAuthUnavailable) {
+        return {
+          title: 'Upstream provider auth (anthropic)',
+          level: 'error',
+          summary: `Anthropic upstream auth unavailable (${response.status}) — run: cliproxy login claude`,
+          details: details.length > 0 ? details : undefined,
+        }
+      }
+    }
+
+    // Any other non-2xx: warning (don't fail status on unrelated upstream issues)
+    return {
+      title: 'Upstream provider auth (anthropic)',
+      level: 'warning',
+      summary: `Anthropic probe returned HTTP ${response.status}`,
+      details: details.length > 0 ? details : undefined,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      title: 'Upstream provider auth (anthropic)',
+      level: 'warning',
+      summary: `Anthropic probe failed: ${message}`,
+      details: verbose ? [`URL: ${endpoint}`, `Model: ${model}`] : undefined,
+    }
+  }
+}
+
 /**
  * Probe the management API with a cheap auth check before issuing parallel calls.
  * Returns null on success, or a CheckResult describing the auth failure.
@@ -377,6 +484,8 @@ export async function getCliproxyStatusSummary(baseUrl: string, key: string, ver
 export interface StatusOptions {
   url?: string
   key?: string
+  /** Downstream API key (bearer) for the upstream provider-auth probe. Maps from --api-key CLI flag. */
+  apiKey?: string
   verbose?: boolean
 }
 
@@ -395,6 +504,10 @@ export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCt
     // An explicit --key is always honored (operator knows what they're doing).
     // An ambient env key is only forwarded when the resolved baseUrl is trusted.
     const managementKey = options.key ?? (urlIsExplicitlyOverridden ? undefined : process.env.CLIPROXY_MANAGEMENT_KEY)
+
+    // Provider (downstream) API key for the upstream provider-auth probe.
+    // Same trusted-URL guard: ambient CLIPROXY_API_KEY only follows to the trusted URL.
+    const providerKey = options.apiKey ?? (urlIsExplicitlyOverridden ? undefined : process.env.CLIPROXY_API_KEY)
 
     ctx.console.log('CLIProxyAPI status')
     ctx.console.log('')
@@ -417,6 +530,17 @@ export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCt
     } else {
       capturedUsageResult = mgmt.usage
       results.push(mgmt.usage, mgmt.version)
+    }
+
+    // Upstream provider-auth probe — only when a downstream API key is available.
+    if (providerKey) {
+      results.push(await checkProviderAuth(baseUrl, providerKey, {verbose}))
+    } else {
+      results.push({
+        title: 'Upstream provider auth',
+        level: 'warning',
+        summary: 'CLIPROXY_API_KEY not set — skipping upstream provider probe.',
+      })
     }
 
     for (const result of results) {
@@ -459,6 +583,14 @@ export function registerCliproxyStatus(cli: ReturnType<typeof goke>): void {
     .option(
       '--key [key]',
       z.string().describe('Management API key. Falls back to CLIPROXY_MANAGEMENT_KEY when omitted.'),
+    )
+    .option(
+      '--api-key [key]',
+      z
+        .string()
+        .describe(
+          'Downstream API key (bearer) for the upstream provider-auth probe. Falls back to CLIPROXY_API_KEY. Skipped when absent.',
+        ),
     )
     .option('--verbose', 'Enable verbose output for all commands')
     .action(cliproxyStatusAction)


### PR DESCRIPTION
Adds an upstream provider-auth probe to `cliproxy status`, closing the monitoring gap that let a Claude OAuth expiry break every Anthropic-routed Fro Bot repo while `cliproxy status` stayed green.

## What it does

`checkProviderAuth` sends a minimal Anthropic completion (`claude-sonnet-4-6`, `max_tokens: 1`) through the proxy with a downstream API key and interprets the result:
- `200` → OK (`anthropic route OK`)
- `401`, or `503` with `auth_unavailable` / `providers=claude` markers → **error** with remediation `run: cliproxy login claude`
- other non-2xx → warning; probe network error → warning (a flaky probe must not fail status)

A dead Anthropic upstream now makes `cliproxy status` exit non-zero so monitoring catches it.

## Wiring

- New `--api-key` flag, falling back to `CLIPROXY_API_KEY`, with the **same trusted-URL guard** as the management key (ambient key only attaches to the trusted/default URL, never to an explicit `--url`).
- Skips gracefully (warning, not error) when no downstream key is configured.
- `getCliproxyStatusSummary` (unified `infra status`) is unchanged — the probe is scoped to the detailed `cliproxy status` command.

## Verified live

Against the proxy: `[OK] Upstream provider auth (anthropic) — anthropic route OK (claude-sonnet-4-6)`. 20 new tests cover the 200/401/503-markers/503-no-markers/500/throw cases, key-never-leaked, default+override model, graceful skip, and the trusted-URL guard.
