### PR TITLE
chore(dashboard): bump image to 2026.06.30 (redacted repo-name logging)

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.16@sha256:73b05ae9a4d6530287e5662abaccfe23f7d3b44bcb50a2be545904681a72efa9
+    image: ghcr.io/fro-bot/dashboard:2026.06.30@sha256:bca84c93cecd90305229dfc3d2f8bc8a9fecf3cb4e75f9a264a8d1c4319c489c
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Bumps the dashboard image from `2026.06.16` to `2026.06.30` to adopt the upstream fix for private repo names being logged in plaintext.

During the dashboard Phase 1 live verification, container logs were found to print a private repo name in a `[warning]` line during per-repo fetch. I filed `fro-bot/dashboard#54`; it was fixed by `fro-bot/dashboard` PR #55 (`fix(aggregator): redact private repo names from operational logs`, commit `62461b8`) and shipped in the `2026.06.30` release.

Verified the fix commit is in the `2026.06.30` tag (not relying on release timing) and that the deploy contract is unchanged: only a minor Dockerfile tweak, no new required env (the new `DASHBOARD_OPERATOR_UI_ENABLED` is optional/default-false), `/api/healthz` and the listen port unchanged. `docker compose config` parses with the new digest pin.

After deploy, re-verify container logs no longer print private repo names.
