### PR TITLE
docs: capture bun build publish model + cliproxy management-field apply pattern

### DIFF
--- a/docs/solutions/best-practices/cli-bun-build-publish-model-2026-06-20.md
+++ b/docs/solutions/best-practices/cli-bun-build-publish-model-2026-06-20.md
@@ -1,0 +1,76 @@
+---
+title: Bundling the published CLI with bun build to reuse private workspace code
+date: 2026-06-20
+category: best-practices
+module: packages/cli
+problem_type: architecture_pattern
+component: tooling
+severity: high
+applies_when:
+  - "Adding a build/bundle step to a published package that runs raw TypeScript today"
+  - "A published package needs to reuse a private workspace package without breaking external installs"
+  - "Bundling a CLI that reads packaged assets or reaches monorepo-relative paths at runtime"
+tags: [bun-build, packaging, monorepo, workspace, dist, known-hosts, exports]
+---
+
+# Bundling the published CLI with bun build to reuse private workspace code
+
+## Context
+
+`packages/cli` (`@marcusrbrown/infra`) shipped **raw TypeScript** run directly under Bun (`bin: src/cli.ts`, `files: ["src/"]`, no build step). That made it impossible to import the private workspace package `@marcusrbrown/infra-shared`: a `workspace:*` runtime dependency cannot resolve outside the monorepo, which broke external `npm install`/`bunx` (the published 0.10.0 regression — `src/lib/ssh-identity.ts` existed only as a hand-maintained copy of a shared helper to avoid the dependency).
+
+The fix was a `bun build` publish step (run at `prepack`) that emits a bundled `dist/` with the public deps left external and `infra-shared` **inlined**, removing the `packages/cli ↛ packages/shared` boundary. Doing this safely surfaced several non-obvious traps.
+
+## Guidance
+
+**Bundle only what must be bundled — keep library subpath exports as source.**
+The bin (`src/cli.ts`) is bundled because it imports `infra-shared`, which must inline for external installs. But a library subpath export like `./vpn/peers` should ship as **raw source**, not from `dist/`. In-repo consumers and `bun test --recursive` resolve the workspace package through its `exports` map **at runtime**, and CI runs `bun install --frozen-lockfile --ignore-scripts`, which skips `prepack` so `dist/` is never built. Pointing `exports.default` at `dist/` therefore breaks every in-repo consumer with `Cannot find module`. Point the export at `src/...`, list that one source file in `files`, and only bundle the bin.
+
+```jsonc
+// packages/cli/package.json
+"exports": {
+  "./vpn/peers": {
+    "types": "./src/commands/vpn/peers.ts",   // in-repo TS consumer (moduleResolution: Bundler reads exports)
+    "default": "./src/commands/vpn/peers.ts"  // ship as source — NOT ./dist/...
+  }
+},
+"bin": { "infra": "./dist/cli.js" },           // only the bin is bundled
+"files": ["dist", "src/commands/vpn/peers.ts"],
+"scripts": { "prepack": "bun run build" },
+"devDependencies": { "@marcusrbrown/infra-shared": "workspace:*" }  // build-time only, inlined — NEVER a runtime dependency
+```
+
+**Inline the private dep explicitly; keep public deps external.** Use `bun build` with `target: bun`, `format: esm`, and an explicit `external: [...]` list of the real npm deps. Do **not** use `--packages=external` — it externalizes `infra-shared` too, defeating the purpose. Assert in a test that `dist/cli.js` has no `infra-shared` import and retains the external dep specifiers.
+
+**Resolve packaged assets with Bun's file-asset loader, not `import.meta.dir` arithmetic.** A flat bundle changes `import.meta.dir`, breaking relative asset paths. `import x from './resources/known_hosts' with {type: 'file'}` makes `bun build` copy the asset to `dist/` (content-hashed) and rewrite the path automatically. Keep the fail-closed contract — resolution must throw if the asset is missing, never fall back to a system file. Byte-compare the shipped copy against the source-of-truth in a drift-guard test.
+
+**Path mapping does not fix runtime file reads.** `tsconfig paths` and package `imports` are import-*specifier* resolution only; they cannot compute a runtime filesystem path for `Bun.file`/`readFile`. For monorepo-relative reads in source-only commands (deploy/client commands that never run in a published install), replace brittle `resolve(import.meta.dir, '../../../', ...)` with one repo-root-discovery helper that walks up to a workspace marker — depth-independent, so it survives bundling.
+
+**Verify the bundle on every merge, not just the first release.** Because CI and contributors run raw `src/` while releases ship `dist/`, the bundle is a code path source runs never exercise — a "works locally, broken when published" drift class. Add a CI job that builds → `bun pm pack` → installs the tarball in an isolated dir → runs `infra --help` AND a real command that resolves the packaged asset (proves the asset ships and resolves outside the monorepo). Pin the Bun version so bundler-semantics drift can't silently change `dist/`.
+
+## Why This Matters
+
+The publish model had already broken external installs once (0.10.0). Each trap here re-introduces that class of failure in a way the normal `bun test` / `tsc` gate does **not** catch:
+
+- The `dist/` export trap failed only in CI's `--ignore-scripts` environment (local runs had `dist/` built), so it passed local gates and Fro Bot caught it on the PR.
+- The asset-resolution trap would fail-closed on a clean install only — `infra --help` alone wouldn't surface it; you must run a command that resolves the asset.
+- Capturing it means the next person adding shared code to the published CLI imports from `@marcusrbrown/infra-shared` and it just inlines, instead of re-deriving the boundary the hard way.
+
+## When to Apply
+
+- Adding a build step to a package that currently publishes raw source.
+- Deciding whether a subpath export should ship bundled or as source (rule: bundle the bin that needs inlined deps; ship libraries consumed in-repo as source).
+- Shipping a non-JS asset that code resolves at runtime through a bundle.
+- Replacing `import.meta.dir` depth arithmetic that a bundle would break.
+
+## Examples
+
+**Broken (CI Test failure):** `exports["./vpn/peers"].default = "./dist/commands/vpn/peers.js"` → `apps/vpn` and `bun test --recursive` fail with `Cannot find module '@marcusrbrown/infra/vpn/peers'` because CI never builds `dist/`.
+
+**Fixed:** export points at `./src/commands/vpn/peers.ts`, `files` includes that one source file, only the bin is bundled. Verified: `rm -rf packages/cli/dist && bun test --recursive` passes (the CI condition), and a clean-room `bun add <tarball>` + `npm install -g` both run `infra --help` and reach the `known_hosts` path with no fail-closed error and no `infra-shared` in the install.
+
+## Related
+
+- `docs/solutions/integration-issues/ssh-agent-too-many-authentication-failures-2026-06-13.md` — the same `packages/cli` cannot-import-`infra-shared` constraint forced a CLI-local duplicate (`ssh-identity.ts`); this lesson removes that constraint.
+- `docs/solutions/workflow-issues/renovate-changesets-monorepo-targeting-2026-04-15.md` — adjacent published-package/release-pipeline boundary concerns.
+- Shipped in PR #624 / `@marcusrbrown/infra@0.13.2`.

--- a/docs/solutions/best-practices/cliproxy-management-api-field-apply-2026-06-20.md
+++ b/docs/solutions/best-practices/cliproxy-management-api-field-apply-2026-06-20.md
@@ -1,0 +1,69 @@
+---
+title: Applying CLIProxyAPI config fields at deploy time via the management API
+date: 2026-06-20
+category: best-practices
+module: apps/cliproxy
+problem_type: architecture_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Setting a CLIProxyAPI config field at deploy time without overwriting config.yaml"
+  - "Applying oauth-model-alias (or any management field) that must not wipe runtime api-keys"
+  - "Reading back a management mutation to confirm it took effect"
+tags: [cliproxy, management-api, oauth-model-alias, config-yaml, model-aliasing, deploy, fail-closed]
+---
+
+# Applying CLIProxyAPI config fields at deploy time via the management API
+
+## Context
+
+The cliproxy deploy must **not** upload `config.yaml` (it holds runtime `api-keys` added via the management API — overwriting it wipes them, the recurring cliproxy-first-deploy incident). So when a config field is genuinely version-controlled — here, an `oauth-model-alias` block mapping short Anthropic model ids to their dated upstream models — it has to be applied a different way: a field-scoped PUT to the management API after the stack is healthy, leaving the rest of `config.yaml` untouched.
+
+This is the safe alternative to `--force-config` for managed config fields. Getting it right surfaced one trap that returns HTTP 200 while silently doing nothing.
+
+## Guidance
+
+**PUT the bare object — wrapper shapes silently no-op.** `PUT /v0/management/oauth-model-alias` stores the value only when the body is the **bare object** `{claude: [...]}`. The `{value: ...}` and `{oauth-model-alias: ...}` wrappers return `200 {"status":"ok"}` but store **nothing** (verified live). A wrapper looks successful and isn't.
+
+```ts
+// applyOAuthModelAlias — body IS the field value, no wrapper
+await fetch(`${baseUrl}/v0/management/oauth-model-alias`, {
+  method: 'PUT',
+  headers: managementHeaders(key),          // x-management-key, NOT Authorization: Bearer
+  body: JSON.stringify({claude: [...]}),     // bare object — no {value} / {oauth-model-alias} wrapper
+  signal: AbortSignal.timeout(10_000),
+})
+```
+
+**Read back and fail closed.** Because a 200 doesn't prove the write landed, GET the field, compare with order-insensitive set-equality, and fail the deploy on mismatch with a diff. This catches the silent-no-op PUT and any future contract change. Add a **bounded retry** (e.g. 0/500/1000ms) on mismatch only — the daemon may hot-reload config asynchronously after the PUT, so the immediate GET can race a stale read. Retry on mismatch; let real HTTP errors propagate.
+
+**Tolerate server-side type variance on read-back.** The management API may return a boolean field (`fork`) as a JSON string (`"true"`). Normalize during parse (accept `true`/`false`/`"true"`/`"false"`) so a legitimate-but-unexpected serialization doesn't fail every deploy with a false mismatch.
+
+**Never touch the api-keys array.** A field-scoped PUT to `oauth-model-alias` is inherently safe — it reads and writes only that field, never the `api-keys` array. This is the property that makes it the right tool instead of `--force-config`.
+
+**Fail early on missing credentials.** If the managed field is present in the tracked config but `CLIPROXY_MANAGEMENT_KEY` is unset, fail in the pre-deploy check **before** the container restart — not ~90s later after `docker compose up --wait`. Reading the tracked config in the preflight makes the failure cheap and obvious.
+
+**`fork: true` for listing parity.** For model aliasing specifically, `fork: true` keeps both the short alias and the dated upstream id in `/v1/models`, so harnesses that enumerate models (like `opencode models`) see the short id as a real, usable entry — not just a routing rewrite.
+
+## Why This Matters
+
+The bare-object trap is the dangerous one: a deploy that PUTs a wrapper shape gets a 200, reports success, and applies nothing — the aliases silently never exist. Only the read-back-and-compare step turns that into a loud deploy failure. The pattern (bare-object field PUT → read-back → fail-closed → bounded retry → never touch api-keys) generalizes to any CLIProxyAPI management field that must be applied without uploading `config.yaml`.
+
+## When to Apply
+
+- Applying any version-controlled CLIProxyAPI management field at deploy time without overwriting `config.yaml`.
+- Any management-API mutation where a 200 does not prove the value persisted (read-back is mandatory).
+- Model aliasing to close a harness short-id gap (use `fork: true`).
+
+## Examples
+
+**Live verification of the shipped pattern:** after deploy, `/v0/management/oauth-model-alias` returned the 7-entry `claude` set; `/v1/models` listed both `claude-haiku-4-5` and `claude-haiku-4-5-20251001`; a `/v1/chat/completions` with the short id `claude-haiku-4-5` returned 200 with response `model: claude-haiku-4-5-20251001` (routed to the dated upstream); the api-key count was unchanged (24).
+
+**Helper location:** the management HTTP primitives (`managementHeaders`, `requestJson`, `HTTP_TIMEOUT_MS`, `parseManagementKeyList`) plus the alias functions live in `packages/shared/cliproxy/management.ts`, consumed by both `apps/cliproxy` deploy and the `packages/cli` commands — possible now that the published CLI inlines `infra-shared` at build time (see the bun-build publish-model doc).
+
+## Related
+
+- `docs/solutions/workflow-issues/cliproxy-first-deploy-cascade-2026-04-06.md` — why `config.yaml` upload is skipped (runtime api-keys); this pattern is the safe alternative for managed fields.
+- `docs/solutions/best-practices/major-version-upstream-upgrade-playbook-2026-05-29.md` — verifying CLIProxyAPI management-endpoint contracts at a tag (the bare-object shape is exactly the kind of contract to re-verify on upgrades).
+- `docs/solutions/best-practices/cli-bun-build-publish-model-2026-06-20.md` — the boundary removal that let the management helpers move to `packages/shared`.
+- Shipped in PR #626 / `@marcusrbrown/infra@0.13.3`.


### PR DESCRIPTION
Captures two durable lessons from the recent CLI publish-model and cliproxy model-aliasing work, so future changes in these areas don't re-derive the gotchas.

## `cli-bun-build-publish-model`

The published CLI now bundles with `bun build` to inline the private `infra-shared` package. The non-obvious traps: only the bin is bundled while library subpath exports ship as source (because CI's `--ignore-scripts` never builds `dist/`, and in-repo consumers resolve through the exports map at runtime); packaged assets use Bun's `with {type: 'file'}` loader to survive bundling; `tsconfig paths`/package `imports` can't fix runtime file reads (repo-root discovery replaces brittle `import.meta.dir` arithmetic); and the bundle is verified on every merge via a clean-room install.

## `cliproxy-management-api-field-apply`

Applying a version-controlled CLIProxyAPI config field (`oauth-model-alias`) at deploy time via the management API instead of uploading `config.yaml` (which would wipe runtime api-keys). The sharp trap: the field PUT must be a bare object — `{value: ...}` / `{oauth-model-alias: ...}` wrappers return 200 but store nothing — so the deploy reads back and fails closed, with a bounded retry for the daemon's async config reload and tolerance for the server returning `fork` as a string.

Both are knowledge-track docs cross-linked to the adjacent cliproxy/packaging solutions. Docs-only — no changeset.
