### PR TITLE
feat(dashboard): enable operator UI same-origin (image 2026.06.34)

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -149,7 +149,14 @@ SSH auth during provisioning: when `DASHBOARD_SSH_KEY` is set, the script materi
 temp key file and pins it with `-i` + `IdentitiesOnly=yes` (no ssh-agent needed; cleaned up after).
 When unset, it falls back to ssh-agent.
 
-## Operator same-origin target
+## Operator UI (same-origin)
+
+The operator UI is **enabled same-origin**. The deploy sets `DASHBOARD_OPERATOR_UI_ENABLED=true`
+and `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` as static constants in the `.env` written by
+`buildEnvFileContents` — no new secrets required. The SSE run-stream UI is reachable at
+`https://dashboard.fro.bot/operator/*` behind the operator auth boundary. The gateway operator
+session mode is active (same-origin path); `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to
+`https://dashboard.fro.bot` and is not set explicitly.
 
 The ratified browser-visible operator API origin is `https://dashboard.fro.bot/operator/*`. The
 dashboard Caddy instance owns the `/operator/*` route and proxies it to the gateway operator

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -50,6 +50,10 @@ GitHub Environment: **`dashboard`**
 
 Repository secret: `DIGITALOCEAN_ACCESS_TOKEN` (used by the provision script).
 
+## Operator UI
+
+The operator UI is enabled same-origin. The deploy sets `DASHBOARD_OPERATOR_UI_ENABLED=true` and `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` as static constants in the `.env` — no new secrets required. The SSE run-stream UI is reachable at `https://dashboard.fro.bot/operator/*` behind the operator auth boundary. `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to `https://dashboard.fro.bot` and is not set explicitly.
+
 ## Operations
 
 Full deploy flow, secret rotation runbooks, upgrade flow, container hardening details, and anti-patterns: [`apps/dashboard/AGENTS.md`](AGENTS.md).

--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.30@sha256:bca84c93cecd90305229dfc3d2f8bc8a9fecf3cb4e75f9a264a8d1c4319c489c
+    image: ghcr.io/fro-bot/dashboard:2026.06.34@sha256:2d779f7e807bce8eab7c3726d3aee83587ff8a71913631ddacba28cea7902e7e
     restart: unless-stopped
     env_file:
       - path: .env

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -349,6 +349,9 @@ describe('.env file contents', () => {
     expect(contents).toContain('DASHBOARD_OAUTH_REDIRECT_URI=https://dashboard.fro.bot/auth/callback\n')
     // Image ref must NOT be in .env — it's pinned in docker-compose.yaml
     expect(contents).not.toContain('DASHBOARD_IMAGE_REF')
+    // Operator UI flags must always be present (static constants, not secrets)
+    expect(contents).toContain('DASHBOARD_OPERATOR_UI_ENABLED=true\n')
+    expect(contents).toContain('DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true\n')
   })
 
   it('does NOT put the raw PEM in .env', () => {

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -290,6 +290,8 @@ export function buildEnvFileContents(opts: {
     `DASHBOARD_OAUTH_REDIRECT_URI=https://${domain}/auth/callback`,
     `DASHBOARD_OPERATOR_LOGIN=${operatorLogin}`,
     `DASHBOARD_COOKIE_KEY=${cookieKey}`,
+    `DASHBOARD_OPERATOR_UI_ENABLED=true`,
+    `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true`,
     ...(gatewayVpcIp ? [`GATEWAY_VPC_IP=${gatewayVpcIp}`] : []),
     '',
   ]


### PR DESCRIPTION
Bumps the dashboard image to `2026.06.34` and enables the operator UI same-origin, completing the operator run-stream go-live now that the gateway is on v0.72.0 (the SSE producer, deployed and verified).

The dashboard deploy now sets two flags in the remote `.env`:

- `DASHBOARD_OPERATOR_UI_ENABLED=true` — mounts the operator UI, static assets, and the SSE run-stream consumer behind the operator auth boundary.
- `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` — selects the same-origin gateway-session mode (without it the UI renders a degraded separate-domains page).

`DASHBOARD_GATEWAY_OPERATOR_ORIGIN` is left unset — it defaults to `https://dashboard.fro.bot`, the correct pinned origin. The SSE consumer reaches the gateway over the existing same-origin `/operator/*` path (dashboard Caddy → gateway VPC `:9300`), so no new ingress or base-URL config is needed.

Verified against the dashboard source at the 2026.06.34 tag: no new required secrets, and no Dockerfile/port/healthcheck drift. The two flags are non-secret booleans, so they ship as deploy-script constants rather than seeded secrets — the operator UI is the intended permanent state.

- Image: `2026.06.30@sha256:bca84c93...` → `2026.06.34@sha256:2d779f7e807bce8eab7c3726d3aee83587ff8a71913631ddacba28cea7902e7e`
