### PR TITLE
fix(dashboard): add Caddy network alias for operator session validation

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -155,7 +155,7 @@ The operator UI is **enabled same-origin**. The deploy sets `DASHBOARD_OPERATOR_
 and `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` as static constants in the `.env` written by
 `buildEnvFileContents` — no new secrets required. The SSE run-stream UI is reachable at
 `https://dashboard.fro.bot/operator/*` behind the operator auth boundary. The gateway operator
-session mode is active (same-origin path); `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to
+session is the single auth authority; `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to
 `https://dashboard.fro.bot` and is not set explicitly.
 
 The ratified browser-visible operator API origin is `https://dashboard.fro.bot/operator/*`. The
@@ -168,6 +168,15 @@ block before the `dashboard:3000` catch-all in `apps/dashboard/config/Caddyfile`
 `{$GATEWAY_VPC_IP}:9300` over the VPC. The gateway operator listener is reachable from the
 dashboard droplet via the shared DigitalOcean VPC (`nyc1`; gateway VPC IP `10.116.0.3`, dashboard
 VPC IP `10.116.0.5` — example values; actual IPs are set via `GATEWAY_VPC_IP`).
+
+**Docker network alias:** The `caddy` service declares a Docker network alias `dashboard.fro.bot`
+on the shared `default` network. The dashboard server validates every request by calling
+`https://dashboard.fro.bot/operator/session` server-side. Without the alias, that call hairpins to
+the droplet's public IP — DigitalOcean has no NAT loopback, so it times out. The alias routes the
+call to Caddy via Docker DNS; Caddy's `/operator/*` handle block proxies it to the gateway VPC.
+Both services are explicitly attached to the `default` network so existing DNS (`dashboard:3000`)
+remains intact. The alias is in the committed `docker-compose.yaml` base file — not an override —
+because Phase 7.5 of the deploy removes any `docker-compose.override.yaml` on every run.
 
 **Route configuration:**
 
@@ -228,3 +237,9 @@ record.
 - **Never set `GATEWAY_VPC_IP` to a literal IP in the Caddyfile** — use `{$GATEWAY_VPC_IP}` and
   inject the value via the `caddy` service env. Hardcoded IPs break on droplet rebuild and make
   the config non-auditable.
+- **Never move the `dashboard.fro.bot` alias to a `docker-compose.override.yaml`** — Phase 7.5 of
+  the deploy runs `rm -f /opt/dashboard/docker-compose.override.yaml` on every deploy. The alias
+  must live in the committed base `docker-compose.yaml`.
+- **Never set `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=false`** — the gateway operator session
+  is the single auth authority. Setting it false disables session validation and breaks the operator
+  UI auth boundary.

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -52,7 +52,9 @@ Repository secret: `DIGITALOCEAN_ACCESS_TOKEN` (used by the provision script).
 
 ## Operator UI
 
-The operator UI is enabled same-origin. The deploy sets `DASHBOARD_OPERATOR_UI_ENABLED=true` and `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` as static constants in the `.env` — no new secrets required. The SSE run-stream UI is reachable at `https://dashboard.fro.bot/operator/*` behind the operator auth boundary. `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to `https://dashboard.fro.bot` and is not set explicitly.
+The operator UI is enabled same-origin. The deploy sets `DASHBOARD_OPERATOR_UI_ENABLED=true` and `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true` as static constants in the `.env` — no new secrets required. The gateway operator session is the single auth authority. The SSE run-stream UI is reachable at `https://dashboard.fro.bot/operator/*` behind the operator auth boundary. `DASHBOARD_GATEWAY_OPERATOR_ORIGIN` defaults to `https://dashboard.fro.bot` and is not set explicitly.
+
+The `caddy` service has a Docker network alias `dashboard.fro.bot` on the shared default network. The dashboard server validates sessions by calling `https://dashboard.fro.bot/operator/session` server-side; the alias routes that call to Caddy via Docker DNS (Caddy proxies `/operator/*` to the gateway VPC) instead of hairpinning to the droplet's public IP, which DigitalOcean does not NAT-loopback. The alias is in the committed `docker-compose.yaml` base file — not an override — because the deploy removes any override file on every run.
 
 ## Operations
 

--- a/apps/dashboard/docker-compose.test.ts
+++ b/apps/dashboard/docker-compose.test.ts
@@ -35,4 +35,38 @@ describe('dashboard docker compose', () => {
   it('healthcheck references /api/healthz', () => {
     expect(compose).toContain('/api/healthz')
   })
+
+  it('caddy service has dashboard.fro.bot network alias on the default network', () => {
+    // The dashboard server validates operator sessions by calling
+    // https://dashboard.fro.bot/operator/session server-side. The alias routes
+    // that internal call to Caddy (which proxies /operator/* to the gateway VPC)
+    // instead of hairpinning to the droplet's public IP (DigitalOcean has no NAT loopback).
+    expect(compose).toContain('- dashboard.fro.bot')
+    // Alias must be nested under caddy's networks.default block
+    const caddySection = compose.slice(compose.indexOf('  caddy:'))
+    const nextServiceIdx = caddySection.indexOf('\n  dashboard:')
+    const caddyBlock = nextServiceIdx === -1 ? caddySection : caddySection.slice(0, nextServiceIdx)
+    expect(caddyBlock).toContain('aliases:')
+    expect(caddyBlock).toContain('- dashboard.fro.bot')
+  })
+
+  it('both caddy and dashboard services are on the default network (existing DNS intact)', () => {
+    // Ensures dashboard:3000 DNS still resolves — both services must be on the same network.
+    // When any service declares explicit networks:, Docker Compose stops auto-attaching others.
+    // Both must explicitly list default so caddy can reach dashboard:3000.
+    const caddySection = compose.slice(compose.indexOf('  caddy:'))
+    const dashboardSection = compose.slice(compose.indexOf('  dashboard:'))
+
+    // caddy must declare networks: with default
+    const caddyNetworksIdx = caddySection.indexOf('    networks:')
+    expect(caddyNetworksIdx).toBeGreaterThan(-1)
+    const caddyNetworksBlock = caddySection.slice(caddyNetworksIdx, caddyNetworksIdx + 200)
+    expect(caddyNetworksBlock).toContain('default:')
+
+    // dashboard must declare networks: with default
+    const dashboardNetworksIdx = dashboardSection.indexOf('    networks:')
+    expect(dashboardNetworksIdx).toBeGreaterThan(-1)
+    const dashboardNetworksBlock = dashboardSection.slice(dashboardNetworksIdx, dashboardNetworksIdx + 200)
+    expect(dashboardNetworksBlock).toContain('default:')
+  })
 })

--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -17,6 +17,15 @@ services:
     depends_on:
       dashboard:
         condition: service_healthy
+    # The dashboard server validates operator sessions by calling
+    # https://dashboard.fro.bot/operator/session server-side. Without this alias,
+    # that call hairpins to the droplet's public IP — DigitalOcean has no NAT
+    # loopback, so it times out. The alias routes the call to Caddy via Docker DNS;
+    # Caddy's /operator/* handle block proxies it to the gateway VPC.
+    networks:
+      default:
+        aliases:
+          - dashboard.fro.bot
 
   dashboard:
     image: ghcr.io/fro-bot/dashboard:2026.06.34@sha256:2d779f7e807bce8eab7c3726d3aee83587ff8a71913631ddacba28cea7902e7e
@@ -49,7 +58,13 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    networks:
+      default:
 
 volumes:
   caddy_data:
   caddy_config:
+
+networks:
+  default:
+    name: dashboard_default


### PR DESCRIPTION
Fixes a redirect loop that broke the dashboard monitoring page after enabling the gateway operator-session auth cutover (`DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED=true`).

## Root cause

With the session cutover enabled, the dashboard server validates every request by calling `/operator/session` server-side, resolved against `https://dashboard.fro.bot`. From inside its container the dashboard cannot reach its own public hostname — the request hairpins to the droplet's public IP, which DigitalOcean does not NAT-loopback, so it times out. Every authenticated request then failed validation and redirected to `/auth/login`, even after OAuth issued a valid session.

The gateway `/operator/session` endpoint itself is healthy and reachable over the VPC; only the dashboard server's same-origin call was failing.

## Fix

Add a Docker network alias `dashboard.fro.bot` to the `caddy` service. The dashboard container now resolves `dashboard.fro.bot` to the Caddy container via Docker DNS (stable across recreates, correct TLS SNI), and Caddy's existing `/operator/*` route proxies the call to the gateway VPC. The browser path is unchanged.

The alias lives in the committed base `docker-compose.yaml` — not an override — because the deploy removes any `docker-compose.override.yaml` on every run. Both services are explicitly attached to the `default` network so existing service DNS (`dashboard:3000`) stays intact.

Verified live: with the alias in place, the dashboard server's call to `https://dashboard.fro.bot/operator/session` returns a real response instead of timing out, session-validation failures dropped to zero, and the authenticated monitoring page loads.

- `docker-compose.yaml`: explicit `default` network + `dashboard.fro.bot` alias on `caddy`
- `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED` stays `true` (the intended single-auth cutover)
- Corrected the operator-UI docs and added guard anti-patterns
