### PR TITLE
feat(dashboard): bump image to 2026.06.35 (operator launch surface)

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
           - dashboard.fro.bot
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.34@sha256:2d779f7e807bce8eab7c3726d3aee83587ff8a71913631ddacba28cea7902e7e
+    image: ghcr.io/fro-bot/dashboard:2026.06.35@sha256:21671f6e79b2f86e9bc332158aafd7133dd06b1c9c4751a8865d21fc033d257e
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Bumps the dashboard image to `2026.06.35`, which adds the operator launch surface (repos list, launch, and observe) on top of the operator run-stream SSE consumer — the UI for the gateway v0.73.0 operator-web work (deployed and verified).

Verified against the dashboard source at the 2026.06.35 tag: no new required secrets, no new operator flags, and no Dockerfile/port/healthcheck drift. The existing operator-UI flags (`DASHBOARD_OPERATOR_UI_ENABLED`, `DASHBOARD_GATEWAY_OPERATOR_SESSION_ENABLED`) and the Caddy `dashboard.fro.bot` network alias for server-side session validation continue to apply unchanged.

- Image: `2026.06.34@sha256:2d779f7e...` → `2026.06.35@sha256:21671f6e79b2f86e9bc332158aafd7133dd06b1c9c4751a8865d21fc033d257e`
