### PR TITLE
feat(dashboard): update image to 2026.06.36

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
           - dashboard.fro.bot
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.35@sha256:21671f6e79b2f86e9bc332158aafd7133dd06b1c9c4751a8865d21fc033d257e
+    image: ghcr.io/fro-bot/dashboard:2026.06.36@sha256:f17f507bd2572edc0336ee70ed897a1e61441b6a72a949702c79495c20c4b5c3
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Updates the dashboard image to `2026.06.36`, which completes the operator-session re-auth fix alongside gateway v0.74.0.

In gateway-session mode, the dashboard now redirects an invalid/expired operator session to the gateway login flow (`/operator/auth/github/start?return_to=/operator`) instead of the deprecated Arctic `/auth/login`. Paired with the gateway's v0.74.0 `return_to` redirect, this closes the loop: after a gateway restart wipes the in-memory operator session, an operator is sent through the gateway login and returned to `/operator` — no redirect loop, no GitHub OAuth rate-limiting.

Source-verified at the tag: no new required env/secrets, healthcheck unchanged (`/api/healthz`), and the single-origin `/operator/session` validation model still holds (the Caddy `dashboard.fro.bot` alias remains required and is in the base compose).

- Image pin → `ghcr.io/fro-bot/dashboard:2026.06.36@sha256:f17f507b…`
