### PR TITLE
fix(gateway): reclaim droplet disk before pulling images

### DIFF
--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -10894,3 +10894,151 @@ describe('gateway verification: public-denied probe uses TCP connect (P2 fix)', 
     ).resolves.toBeUndefined()
   })
 })
+
+// ─── disk-reclaim (docker prune) before pull ─────────────────────────────────
+
+describe('disk-reclaim prune before pull', () => {
+  let upstreamPath: string
+  let originalUpstream: string | undefined
+
+  beforeEach(() => {
+    upstreamPath = join(import.meta.dir, '..', 'upstream.json')
+    originalUpstream = existsSync(upstreamPath) ? readFileSync(upstreamPath, 'utf-8') : undefined
+    writeFileSync(upstreamPath, JSON.stringify({repo: 'fro-bot/agent', ref: 'v0.44.0'}))
+  })
+
+  afterEach(() => {
+    if (originalUpstream === undefined) {
+      try {
+        rmSync(upstreamPath)
+      } catch {
+        // ignore
+      }
+    } else {
+      writeFileSync(upstreamPath, originalUpstream)
+    }
+  })
+
+  test('deploy spawns docker image prune -af and docker builder prune -af before docker compose pull', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    // Extract the remote command string from each SSH call (last element of argv)
+    const remoteCmds = calls.filter(cmd => cmd[0] === 'ssh').map(cmd => cmd.at(-1) ?? '')
+
+    const imagePruneIdx = remoteCmds.findIndex(s => s.includes('docker image prune'))
+    const builderPruneIdx = remoteCmds.findIndex(s => s.includes('docker builder prune'))
+    const pullIdx = remoteCmds.findIndex(s => s.includes('docker compose') && s.includes(' pull'))
+
+    expect(imagePruneIdx).toBeGreaterThanOrEqual(0)
+    expect(builderPruneIdx).toBeGreaterThanOrEqual(0)
+    expect(pullIdx).toBeGreaterThanOrEqual(0)
+
+    // Both prune steps must precede the pull
+    expect(imagePruneIdx).toBeLessThan(pullIdx)
+    expect(builderPruneIdx).toBeLessThan(pullIdx)
+  })
+
+  test('docker image prune uses -af flag (all unused images, force)', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    const remoteCmds = calls.filter(cmd => cmd[0] === 'ssh').map(cmd => cmd.at(-1) ?? '')
+    const imagePruneCmd = remoteCmds.find(s => s.includes('docker image prune'))
+
+    expect(imagePruneCmd).toBeDefined()
+    expect(imagePruneCmd).toContain('-af')
+
+    // Safety: never prune volumes (OAuth tokens, workspace repos, S3 state must persist)
+    // and never use the broad `docker system prune` which can reach volumes/networks.
+    for (const cmd of remoteCmds) {
+      expect(cmd).not.toContain('--volumes')
+      expect(cmd).not.toContain('docker system prune')
+    }
+  })
+
+  test('docker builder prune uses -af flag (all cache, force)', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock()
+
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    const remoteCmds = calls.filter(cmd => cmd[0] === 'ssh').map(cmd => cmd.at(-1) ?? '')
+    const builderPruneCmd = remoteCmds.find(s => s.includes('docker builder prune'))
+
+    expect(builderPruneCmd).toBeDefined()
+    expect(builderPruneCmd).toContain('-af')
+  })
+
+  test('prune failure is best-effort: docker compose pull still runs when image prune exits non-zero', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const last = cmd.at(-1) ?? ''
+      // Fail the image prune step
+      if (last.includes('docker image prune')) {
+        return makeSpawnResult({exitCode: 1, stderr: 'prune failed: device busy'})
+      }
+      return undefined
+    })
+
+    // Deploy must succeed despite prune failure
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    const remoteCmds = calls.filter(cmd => cmd[0] === 'ssh').map(cmd => cmd.at(-1) ?? '')
+    const pullCmd = remoteCmds.find(s => s.includes('docker compose') && s.includes(' pull'))
+    expect(pullCmd).toBeDefined()
+  })
+
+  test('prune failure is best-effort: docker compose pull still runs when builder prune exits non-zero', async () => {
+    const {main} = await import('./deploy')
+    const {spawnFn, calls} = makeSpawnMock(cmd => {
+      const last = cmd.at(-1) ?? ''
+      // Fail the builder prune step
+      if (last.includes('docker builder prune')) {
+        return makeSpawnResult({exitCode: 1, stderr: 'prune failed: daemon error'})
+      }
+      return undefined
+    })
+
+    // Deploy must succeed despite prune failure
+    await main({
+      env: makeEnv(),
+      args: [],
+      fetch: makeDiscordFetch([{name: 'ping'}]),
+      sleep: async () => {},
+      spawn: spawnFn,
+    })
+
+    const remoteCmds = calls.filter(cmd => cmd[0] === 'ssh').map(cmd => cmd.at(-1) ?? '')
+    const pullCmd = remoteCmds.find(s => s.includes('docker compose') && s.includes(' pull'))
+    expect(pullCmd).toBeDefined()
+  })
+})

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -2568,6 +2568,38 @@ SCRIPT`
       spawnFn,
     )
 
+    // Phase 7b: Reclaim disk before pulling new images (best-effort, non-fatal).
+    //
+    // The droplet only PULLS prebuilt images — it never builds. Superseded image versions
+    // and build cache accumulate unbounded until the disk hits 100% and `docker compose pull`
+    // fails with "no space left on device". Pruning BEFORE pull is intentional: the
+    // about-to-be-pulled image is not present yet, and running containers protect their
+    // current images (docker image prune -a only removes images not referenced by any
+    // container — running or stopped).
+    //
+    // SAFETY CONSTRAINTS:
+    //   - Do NOT use `docker system prune --volumes` — volumes (OAuth tokens, workspace
+    //     repos, S3 state) must NEVER be pruned.
+    //   - `docker image prune -af` removes all images not referenced by any container.
+    //     Running containers protect their images; only superseded versions are reclaimed.
+    //   - `docker builder prune -af` clears build cache. Safe: the off-droplet build model
+    //     means the droplet never builds, so build cache is pure waste.
+    //   - Prune is BEST-EFFORT: a prune failure must NOT abort the deploy. Reclaiming disk
+    //     is housekeeping; if it fails the pull may still succeed or fail on its own.
+    for (const [label, cmd] of [
+      ['Pruning unused images (disk reclaim)', `docker image prune -af`],
+      ['Pruning build cache (disk reclaim)', `docker builder prune -af`],
+    ] as const) {
+      try {
+        await runCommand(label, sshCommand(host, cmd, keyPath, controlPath), deployEnv, spawnFn)
+      } catch (error) {
+        console.warn(
+          `[deploy] ${label} failed (non-fatal, continuing):`,
+          error instanceof Error ? error.message : error,
+        )
+      }
+    }
+
     // Phase 8: Pull prebuilt GHCR images, then bring up the stack without building.
     // The compose.override.yaml written in phase 5b pins gateway and workspace to the
     // CI-pushed digests. docker compose pull fetches those exact images; docker compose up


### PR DESCRIPTION
The gateway droplet uses an off-droplet GHCR build model: each deploy pulls prebuilt images and never prunes. Superseded image versions and build cache accumulate unbounded until the droplet disk hits 100% and `docker compose pull` fails with "no space left on device" — which just broke a deploy (production stayed up on the old images, since the pull fails before any container is recreated).

This adds a best-effort disk-reclaim step before the pull:

- `docker image prune -af` — removes images not referenced by any container. Running containers protect their images, so only superseded versions are reclaimed.
- `docker builder prune -af` — clears build cache, which is pure waste under the off-droplet model (the droplet never builds).

Both are best-effort: a prune failure logs a warning and the deploy continues to the pull. Volumes (OAuth tokens, workspace repos, S3 state) are never touched — no `--volumes`, no `docker system prune`. Tests assert the prune runs before the pull, stays non-fatal on failure, and never reaches volumes.
