### PR TITLE
feat(dashboard): update image to 2026.06.39

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
           - dashboard.fro.bot
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.36@sha256:f17f507bd2572edc0336ee70ed897a1e61441b6a72a949702c79495c20c4b5c3
+    image: ghcr.io/fro-bot/dashboard:2026.06.39@sha256:4e0fd3307b040d382523e4e24849a2bd8ee2fb56396694caf88166072646b38b
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Update the deployed dashboard image from `2026.06.36` to `2026.06.39`.

**What it ships:**
- Operator run-output channel (contract 1.3.0) — the operator UI now consumes the gateway run-output SSE stream. Behind the existing `DASHBOARD_OPERATOR_UI_ENABLED` flag.
- Aligns the bundled `fro-bot/agent` to v0.74.0 (already live on the gateway).

**Verified at-tag (commit `e156198`):** no new required env/secrets, no new ports, healthcheck still `/api/healthz`, container port 3000, non-root user unchanged. The operator-session validation path is unchanged, so the Caddy `dashboard.fro.bot` network alias remains required and sufficient.

Pin: `ghcr.io/fro-bot/dashboard:2026.06.39@sha256:4e0fd330...`
