### PR TITLE
feat(dashboard): update image to 2026.06.41

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
           - dashboard.fro.bot
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.39@sha256:4e0fd3307b040d382523e4e24849a2bd8ee2fb56396694caf88166072646b38b
+    image: ghcr.io/fro-bot/dashboard:2026.06.41@sha256:7f34bd204e899981c573c884c321798876005ef15ebb7a9ada8982823ebb4314
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Update the deployed dashboard image from `2026.06.39` to `2026.06.41`.

**What it ships:** the web tool-approval UX — an allowlisted operator can decide a tool gate (`once`/`always`/`reject`) inline on a watched run from the browser, against gateway approval contract **1.4.0** (agent v0.76.0). Behind the existing `DASHBOARD_OPERATOR_UI_ENABLED` flag.

**Verified at-tag (commit `70e5724`):** no new required env/secrets, no new ports, healthcheck still `/api/healthz`, port 3000, non-root user unchanged. The operator-session validation path is unchanged, so the Caddy `dashboard.fro.bot` network alias remains required and sufficient; invalid-session recovery still redirects to the gateway login flow. `OPERATOR_CONTRACT_VERSION` and the vendored stream pin are both `1.4.0` and in sync.

Pin: `ghcr.io/fro-bot/dashboard:2026.06.41@sha256:7f34bd20...` (digest cross-verified against the GHCR registry).
