### PR TITLE
feat(dashboard): update image to 2026.06.47

### DIFF
--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
           - dashboard.fro.bot
 
   dashboard:
-    image: ghcr.io/fro-bot/dashboard:2026.06.41@sha256:7f34bd204e899981c573c884c321798876005ef15ebb7a9ada8982823ebb4314
+    image: ghcr.io/fro-bot/dashboard:2026.06.47@sha256:9b3a33cf6c35b21c594becdb7d86d5b5032ecc6153de96d62daf2a6b25179970
     restart: unless-stopped
     env_file:
       - path: .env


### PR DESCRIPTION
Update the dashboard image from `2026.06.41` to `2026.06.47`.

`2026.06.47` makes the dashboard an installable, offline-capable PWA (with prompt-to-update) and splits the Dockerfile into builder + runtime stages. This is the consumer half of the coordinated rollout with gateway v0.77.0 (now live).

Source-verified at the `2026.06.47` tag: no new required env vars, the server still binds `0.0.0.0:3000`, the health endpoint stays `/api/healthz`, the runtime stays non-root on `EXPOSE 3000`, the operator contract version stays `1.4.0` (matches the live gateway v0.77.0), and the same-origin `dashboard.fro.bot` Caddy alias requirement is unchanged.

Pinned by digest: `ghcr.io/fro-bot/dashboard:2026.06.47@sha256:9b3a33cf6c35b21c594becdb7d86d5b5032ecc6153de96d62daf2a6b25179970`. Released-image pull model — the deploy pulls the pinned digest. No changeset (apps/ deploy config only).
