### PR TITLE
feat(dashboard): dispatch versioned releases

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -1,11 +1,62 @@
+# Dispatch input contract (dashboard-release-dispatch-v1):
+#
+#   version          CalVer string (YYYY.MM.N, e.g. 2026.06.47). Optional.
+#                    When set, the deploy resolves the GHCR image digest,
+#                    cross-checks it against `digest` (if provided), generates
+#                    a pinned docker-compose.yaml, and opens an audit PR to
+#                    record the updated pin.
+#
+#   digest           Expected sha256 digest (e.g. sha256:abc...). Optional.
+#                    When set alongside `version`, the resolved digest must
+#                    match this value exactly — mismatch fails hard.
+#
+#   contract_version Contract fuse. Must equal "dashboard-release-dispatch-v1"
+#                    when any versioned-release input (version, digest, OR
+#                    contract_version itself) is non-empty. Prevents stale or
+#                    accidental dispatch payloads from deploying.
+#
+# No-version fallback: omit all three inputs (or leave empty). The committed
+# docker-compose.yaml digest is the source of truth; no audit PR is opened.
+
 name: Deploy Dashboard
 
-permissions:
-  contents: read
+run-name: Deploy dashboard ${{ inputs.version || 'latest pin' }}
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: CalVer version to deploy (e.g. 2026.06.47). Leave empty to use committed pin.
+        required: false
+        type: string
+        default: ''
+      digest:
+        description: Expected sha256 digest (e.g. sha256:abc...). Leave empty to skip cross-check.
+        required: false
+        type: string
+        default: ''
+      contract_version:
+        description: 'Contract fuse — must be "dashboard-release-dispatch-v1" when version, digest, or contract_version is set.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
+    inputs:
+      version:
+        description: CalVer version to deploy (e.g. 2026.06.47). Leave empty to use committed pin.
+        required: false
+        type: string
+        default: ''
+      digest:
+        description: Expected sha256 digest (e.g. sha256:abc...). Leave empty to skip cross-check.
+        required: false
+        type: string
+        default: ''
+      contract_version:
+        description: 'Contract fuse — must be "dashboard-release-dispatch-v1" when version, digest, or contract_version is set.'
+        required: false
+        type: string
+        default: ''
     secrets:
       DASHBOARD_SSH_KEY:
         required: true
@@ -25,18 +76,95 @@ on:
         required: true
       GATEWAY_VPC_IP:
         required: false
+      APPLICATION_ID:
+        required: true
+      APPLICATION_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: deploy-dashboard-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  deploy-dashboard:
+  # Pre-gate: no-secret validation. Runs before the environment gate so the
+  # approver sees the version and any input errors before spending an approval.
+  validate-inputs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Log version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_DIGEST: ${{ inputs.digest }}
+        run: |
+          printf 'version: %s\n' "${INPUT_VERSION:-"(none — using committed pin)"}"
+          printf 'digest:  %s\n' "${INPUT_DIGEST:-"(none — no cross-check)"}"
+
+      - name: Validate digest format
+        if: inputs.digest != ''
+        env:
+          INPUT_DIGEST: ${{ inputs.digest }}
+        run: |
+          digest="${INPUT_DIGEST}"
+          if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            printf 'Invalid digest %q: must match sha256:<64 hex chars> (e.g. sha256:abc...def).\n' "$digest"
+            echo "Rejected: malformed digests are not accepted."
+            exit 1
+          fi
+
+      - name: Validate CalVer format
+        if: inputs.version != ''
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="${INPUT_VERSION}"
+          if ! [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+$ ]]; then
+            printf 'Invalid version %q: must match YYYY.MM.N (e.g. 2026.06.47).\n' "$version"
+            echo "Rejected: 'latest', semver, and injection strings are not accepted."
+            exit 1
+          fi
+
+      - name: Validate contract fuse
+        if: inputs.version != '' || inputs.digest != '' || inputs.contract_version != ''
+        env:
+          INPUT_CONTRACT_VERSION: ${{ inputs.contract_version }}
+        run: |
+          contract="${INPUT_CONTRACT_VERSION}"
+          expected="dashboard-release-dispatch-v1"
+          if [[ "$contract" != "$expected" ]]; then
+            echo "Release dispatch contract mismatch."
+            printf 'Expected contract_version=%q but got %q.\n' "$expected" "$contract"
+            printf 'Set contract_version to %q when dispatching a versioned release.\n' "$expected"
+            exit 1
+          fi
+
+      - name: Validate input mode
+        if: inputs.version == '' && (inputs.digest != '' || inputs.contract_version != '')
+        run: |
+          echo "Invalid deploy input mode: version is required when digest or contract_version is set."
+          echo "Either omit all inputs (no-version fallback) or provide version + contract_version=dashboard-release-dispatch-v1."
+          exit 1
+
+  deploy-dashboard:
+    needs: validate-inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: dashboard
     steps:
+      - name: Get app token
+        id: get-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -54,6 +182,8 @@ jobs:
           DASHBOARD_OAUTH_CLIENT_SECRET: ${{ secrets.DASHBOARD_OAUTH_CLIENT_SECRET }}
           DASHBOARD_OPERATOR_LOGIN: ${{ secrets.DASHBOARD_OPERATOR_LOGIN }}
           DASHBOARD_COOKIE_KEY: ${{ secrets.DASHBOARD_COOKIE_KEY }}
+          APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+          APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
         run: |
           missing=()
           [[ -n "${DASHBOARD_SSH_KEY}" ]] || missing+=("DASHBOARD_SSH_KEY")
@@ -64,6 +194,8 @@ jobs:
           [[ -n "${DASHBOARD_OAUTH_CLIENT_SECRET}" ]] || missing+=("DASHBOARD_OAUTH_CLIENT_SECRET")
           [[ -n "${DASHBOARD_OPERATOR_LOGIN}" ]] || missing+=("DASHBOARD_OPERATOR_LOGIN")
           [[ -n "${DASHBOARD_COOKIE_KEY}" ]] || missing+=("DASHBOARD_COOKIE_KEY")
+          [[ -n "${APPLICATION_ID}" ]] || missing+=("APPLICATION_ID")
+          [[ -n "${APPLICATION_PRIVATE_KEY}" ]] || missing+=("APPLICATION_PRIVATE_KEY")
           if (( ${#missing[@]} > 0 )); then
             echo "Missing required secret(s): ${missing[*]}"
             exit 1
@@ -83,4 +215,55 @@ jobs:
           DASHBOARD_OPERATOR_LOGIN: ${{ secrets.DASHBOARD_OPERATOR_LOGIN }}
           DASHBOARD_COOKIE_KEY: ${{ secrets.DASHBOARD_COOKIE_KEY }}
           GATEWAY_VPC_IP: ${{ secrets.GATEWAY_VPC_IP }}
+          DEPLOY_VERSION: ${{ inputs.version }}
+          DEPLOY_DIGEST: ${{ inputs.digest }}
+          DEPLOY_CONTRACT_VERSION: ${{ inputs.contract_version }}
         run: bun run --cwd apps/dashboard deploy
+
+      - name: Open audit PR for compose pin
+        if: inputs.version != ''
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          GIT_USER_NAME: ${{ format('{0}[bot]', steps.get-app-token.outputs.app-slug) }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          version="${INPUT_VERSION}"
+
+          # Revalidate CalVer before constructing branch/commit strings.
+          # Prevents unsanitized ref names from reaching git/gh argv.
+          if ! [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+$ ]]; then
+            printf 'Audit step: invalid version %q — must match YYYY.MM.N.\n' "$version"
+            exit 1
+          fi
+
+          # Unique branch per run to avoid collision on re-runs of the same version.
+          branch="dashboard-pin-${version}-${GITHUB_RUN_ID}"
+          commit_msg="chore(dashboard): pin image to ${version}"
+
+          USER_ID=$(gh api "/users/${GIT_USER_NAME}" --jq .id)
+          git config user.name "${GIT_USER_NAME}"
+          git config user.email "${USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+
+          git checkout -b "${branch}"
+          git add apps/dashboard/docker-compose.yaml
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit — compose pin already up to date."
+            exit 0
+          fi
+
+          git commit -m "${commit_msg}"
+          git push origin "${branch}" --force-with-lease
+
+          # Open PR if none exists for this branch (open PRs only — closed stale PRs are not reused).
+          existing_pr=$(gh pr list --state open --head "${branch}" --json url --jq '.[0].url' 2>/dev/null)
+          if [[ -n "${existing_pr}" ]]; then
+            echo "Audit PR already exists: ${existing_pr}"
+          else
+            gh pr create \
+              --title "${commit_msg}" \
+              --body "Pins the dashboard image to \`${version}\` after a successful deploy. Merge to record the audit trail in main." \
+              --head "${branch}" \
+              --base main
+          fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -167,9 +167,8 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.dashboard == 'true'
-    permissions:
-      contents: read
+      (needs.detect-changes.outputs.dashboard == 'true' &&
+       !startsWith(github.event.head_commit.message, 'chore(dashboard): pin image to '))
     uses: ./.github/workflows/deploy-dashboard.yaml
     secrets:
       DASHBOARD_SSH_KEY: ${{ secrets.DASHBOARD_SSH_KEY }}
@@ -181,3 +180,5 @@ jobs:
       DASHBOARD_OPERATOR_LOGIN: ${{ secrets.DASHBOARD_OPERATOR_LOGIN }}
       DASHBOARD_COOKIE_KEY: ${{ secrets.DASHBOARD_COOKIE_KEY }}
       GATEWAY_VPC_IP: ${{ secrets.GATEWAY_VPC_IP }}
+      APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+      APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -1,4 +1,5 @@
-import {readFileSync} from 'node:fs'
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
 import {describe, expect, it} from 'bun:test'
@@ -7,7 +8,11 @@ import {
   assertRunningImageDigest,
   buildEnvFileContents,
   deploy,
+  generateComposeContent,
   parseComposeImageDigest,
+  RELEASE_CONTRACT_VERSION,
+  validateCalVer,
+  validateContractVersion,
   validateEnv,
   validateGatewayVpcIp,
   validateSecretValue,
@@ -1487,5 +1492,964 @@ describe('dashboard verification: /operator/health retry loop (P1 fix)', () => {
     ).resolves.toBeUndefined()
 
     expect(operatorHealthAttempts).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ─── validateCalVer ───────────────────────────────────────────────────────────
+
+describe('validateCalVer', () => {
+  it('accepts a valid CalVer string', () => {
+    expect(() => validateCalVer('2026.06.15')).not.toThrow()
+    expect(() => validateCalVer('2026.06.47')).not.toThrow()
+    expect(() => validateCalVer('2024.01.0')).not.toThrow()
+  })
+
+  it('rejects "latest"', () => {
+    expect(() => validateCalVer('latest')).toThrow(/version/)
+  })
+
+  it('rejects an empty string', () => {
+    expect(() => validateCalVer('')).toThrow(/version/)
+  })
+
+  it('rejects a semver string (not CalVer)', () => {
+    expect(() => validateCalVer('1.2.3')).toThrow(/version/)
+  })
+
+  it('rejects a version with extra components', () => {
+    expect(() => validateCalVer('2026.06.15.1')).toThrow(/version/)
+  })
+
+  it('rejects a version with non-numeric parts', () => {
+    expect(() => validateCalVer('2026.06.abc')).toThrow(/version/)
+  })
+
+  it('rejects injection strings', () => {
+    expect(() => validateCalVer('2026.06.15; rm -rf /')).toThrow(/version/)
+    expect(() => validateCalVer('$(evil)')).toThrow(/version/)
+    expect(() => validateCalVer('`evil`')).toThrow(/version/)
+  })
+
+  it('rejects a version starting with a dash', () => {
+    expect(() => validateCalVer('-oProxyCommand=x')).toThrow(/version/)
+  })
+})
+
+// ─── validateContractVersion ──────────────────────────────────────────────────
+
+describe('validateContractVersion', () => {
+  it('passes when contract matches the expected constant and version is set', () => {
+    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '2026.06.15', '')).not.toThrow()
+  })
+
+  it('passes when contract matches and digest is set', () => {
+    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '', `sha256:${'a'.repeat(64)}`)).not.toThrow()
+  })
+
+  it('passes when contract matches and both version and digest are set', () => {
+    expect(() =>
+      validateContractVersion(RELEASE_CONTRACT_VERSION, '2026.06.15', `sha256:${'a'.repeat(64)}`),
+    ).not.toThrow()
+  })
+
+  it('passes when all inputs are empty (no-version fallback — contract not required)', () => {
+    expect(() => validateContractVersion('', '', '')).not.toThrow()
+  })
+
+  it('throws when version is set but contract is empty', () => {
+    expect(() => validateContractVersion('', '2026.06.15', '')).toThrow(/contract/)
+  })
+
+  it('throws when digest is set but contract is empty', () => {
+    expect(() => validateContractVersion('', '', `sha256:${'a'.repeat(64)}`)).toThrow(/contract/)
+  })
+
+  it('throws when contract is wrong (version set)', () => {
+    expect(() => validateContractVersion('wrong-contract', '2026.06.15', '')).toThrow(/contract/)
+  })
+
+  it('throws when contract is wrong (digest set)', () => {
+    expect(() => validateContractVersion('wrong-contract', '', `sha256:${'a'.repeat(64)}`)).toThrow(/contract/)
+  })
+
+  it('RELEASE_CONTRACT_VERSION is a stable non-empty string', () => {
+    expect(typeof RELEASE_CONTRACT_VERSION).toBe('string')
+    expect(RELEASE_CONTRACT_VERSION.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── generateComposeContent ───────────────────────────────────────────────────
+
+describe('generateComposeContent', () => {
+  const SAMPLE_COMPOSE = `services:
+  dashboard:
+    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}
+    restart: unless-stopped
+`
+
+  it('replaces the image line with version@digest', () => {
+    const newDigest = `sha256:${'b'.repeat(64)}`
+    const result = generateComposeContent(SAMPLE_COMPOSE, '2026.06.47', newDigest)
+    expect(result).toContain(`ghcr.io/fro-bot/dashboard:2026.06.47@${newDigest}`)
+  })
+
+  it('does not contain the old version after replacement', () => {
+    const newDigest = `sha256:${'b'.repeat(64)}`
+    const result = generateComposeContent(SAMPLE_COMPOSE, '2026.06.47', newDigest)
+    expect(result).not.toContain('2026.06.15@sha256:')
+  })
+
+  it('preserves the rest of the compose file', () => {
+    const newDigest = `sha256:${'b'.repeat(64)}`
+    const result = generateComposeContent(SAMPLE_COMPOSE, '2026.06.47', newDigest)
+    expect(result).toContain('restart: unless-stopped')
+  })
+
+  it('throws when no fro-bot/dashboard image line is found', () => {
+    const badCompose = `services:\n  other:\n    image: nginx:latest\n`
+    expect(() => generateComposeContent(badCompose, '2026.06.47', `sha256:${'b'.repeat(64)}`)).toThrow()
+  })
+})
+
+// ─── versioned deploy path ────────────────────────────────────────────────────
+//
+// When version + contractVersion are provided:
+// - resolves digest via `docker buildx imagetools inspect`
+// - compares resolved digest to dispatched digest (if provided)
+// - generates compose content with version@resolvedDigest
+// - uploads generated compose (not the committed file)
+// - verifies running image against resolvedDigest
+
+const RESOLVED_DIGEST = `sha256:${'c'.repeat(64)}`
+
+/**
+ * Builds happy-path responses for a versioned deploy.
+ * Prepends the imagetools inspect call (returns resolved digest) before the
+ * standard deploy sequence. The compose upload is now via stdin (writeRemoteFile),
+ * so the scp call for docker-compose.yaml is replaced by a stdin write.
+ *
+ * Call order for versioned deploy:
+ *   0: docker buildx imagetools inspect (resolve digest)
+ *   1: mkdir -p /opt/dashboard/config
+ *   2: write .env (stdin)
+ *   3: write docker-compose.yaml (stdin — generated content)
+ *   4: scp Caddyfile
+ *   5: write github-app.pem (stdin)
+ *   6: chmod 0600 github-app.pem
+ *   7: chown 1000:1000 github-app.pem
+ *   8: rm -f docker-compose.override.yaml
+ *   9: docker compose pull
+ *  10: docker compose up -d --no-build --wait dashboard
+ *  11: docker inspect (resolve image SHA)
+ *  12: docker inspect (RepoDigests)
+ *  13: docker compose up -d --no-build --wait caddy
+ *  14: (buffer)
+ */
+function makeVersionedHappyPathResponses(): SpawnResult[] {
+  const repoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@${RESOLVED_DIGEST}`])
+  return [
+    makeSpawnResult(RESOLVED_DIGEST), // 0: imagetools inspect → resolved digest
+    makeSpawnResult(), // 1: mkdir
+    makeSpawnResult(), // 2: write .env
+    makeSpawnResult(), // 3: write docker-compose.yaml (stdin)
+    makeSpawnResult(), // 4: scp Caddyfile
+    makeSpawnResult(), // 5: write github-app.pem
+    makeSpawnResult(), // 6: chmod 0600
+    makeSpawnResult(), // 7: chown 1000:1000
+    makeSpawnResult(), // 8: rm -f docker-compose.override.yaml
+    makeSpawnResult(), // 9: compose pull
+    makeSpawnResult(), // 10: compose up dashboard
+    makeSpawnResult('sha256:imageid123'), // 11: docker inspect (image SHA)
+    makeSpawnResult(repoDigestsJson), // 12: docker inspect (RepoDigests)
+    makeSpawnResult(), // 13: compose up caddy
+    makeSpawnResult(), // 14: buffer
+  ]
+}
+
+describe('versioned deploy path', () => {
+  it('rejects invalid CalVer before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: 'latest',
+        contractVersion: RELEASE_CONTRACT_VERSION,
+      }),
+    ).rejects.toThrow(/version/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects missing contract when version is set, before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        contractVersion: '',
+      }),
+    ).rejects.toThrow(/contract/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects wrong contract when version is set, before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        contractVersion: 'wrong-contract-v99',
+      }),
+    ).rejects.toThrow(/contract/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects digest mismatch when resolved digest differs from dispatched digest', async () => {
+    const wrongDispatchedDigest = `sha256:${'d'.repeat(64)}`
+    const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: wrongDispatchedDigest,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/digest/)
+  })
+
+  it('completes successfully with valid version + matching digest + correct contract', async () => {
+    const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('uploads generated compose content with version@resolvedDigest via stdin', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      version: '2026.06.47',
+      digest: RESOLVED_DIGEST,
+      contractVersion: RELEASE_CONTRACT_VERSION,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    // The compose upload must contain the version@resolvedDigest image reference
+    const composeWrite = calls.find(c => c.stdinData.includes('fro-bot/dashboard:2026.06.47@'))
+    expect(composeWrite).toBeDefined()
+    expect(composeWrite?.stdinData).toContain(`ghcr.io/fro-bot/dashboard:2026.06.47@${RESOLVED_DIGEST}`)
+  })
+
+  it('verifies running image against resolvedDigest (not committed compose digest)', async () => {
+    // The RepoDigests response matches RESOLVED_DIGEST (not COMPOSE_DIGEST)
+    const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    // Should pass because makeVersionedHappyPathResponses returns RESOLVED_DIGEST in RepoDigests
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('fails when running image digest does not match resolvedDigest', async () => {
+    const wrongRepoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@sha256:${'e'.repeat(64)}`])
+    const responses = makeVersionedHappyPathResponses()
+    // Override the RepoDigests response (index 12) with a mismatched digest
+    responses[12] = makeSpawnResult(wrongRepoDigestsJson)
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/digest/)
+  })
+
+  it('calls docker buildx imagetools inspect to resolve digest', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      version: '2026.06.47',
+      digest: RESOLVED_DIGEST,
+      contractVersion: RELEASE_CONTRACT_VERSION,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const imagetoolsCall = calls.find(c => c.cmd.join(' ').includes('imagetools inspect'))
+    expect(imagetoolsCall).toBeDefined()
+    expect(imagetoolsCall?.cmd.join(' ')).toContain('ghcr.io/fro-bot/dashboard:2026.06.47')
+  })
+
+  it('succeeds without dispatched digest (resolves and uses resolved digest only)', async () => {
+    const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    // No dispatched digest — should resolve and use the resolved digest
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: '',
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+// ─── no-version fallback ──────────────────────────────────────────────────────
+//
+// When no version is dispatched, the committed compose file is the source of
+// truth. No imagetools inspect, no generated compose content, no audit commit.
+
+describe('no-version fallback', () => {
+  it('uses committed compose digest when no version is provided', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    // No imagetools inspect call
+    const imagetoolsCall = calls.find(c => c.cmd.join(' ').includes('imagetools inspect'))
+    expect(imagetoolsCall).toBeUndefined()
+  })
+
+  it('does not upload generated compose content (uses committed file via scp)', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    // The compose upload must be via scp (not stdin with generated content)
+    const scpComposeCall = calls.find(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('scp') && s.includes('docker-compose.yaml')
+    })
+    expect(scpComposeCall).toBeDefined()
+
+    // No stdin write should contain a version@digest image reference for a new version
+    // (the committed compose content may contain the existing pinned digest, but not a new one)
+    const generatedComposeWrite = calls.find(c => c.stdinData.includes('fro-bot/dashboard:2026.06.47@'))
+    expect(generatedComposeWrite).toBeUndefined()
+  })
+
+  it('succeeds without version, digest, or contractVersion', async () => {
+    const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+// ─── Gap 2: validateContractVersion with contract_version alone ───────────────
+//
+// The fuse must trigger when ANY versioned-release input is non-empty:
+// version, digest, OR contract_version. Previously only version/digest were
+// checked, so a stale payload with only contract_version set would slip through.
+
+describe('validateContractVersion: contract_version alone triggers fuse', () => {
+  it('throws when contract_version is non-empty but wrong, with version and digest empty', () => {
+    // contract_version alone is a versioned-release input — wrong value must fail
+    expect(() => validateContractVersion('wrong-contract', '', '')).toThrow(/contract/)
+  })
+
+  it('throws when contract_version is non-empty but wrong (stale payload)', () => {
+    expect(() => validateContractVersion('dashboard-release-dispatch-v0', '', '')).toThrow(/contract/)
+  })
+
+  it('passes when contract_version alone equals RELEASE_CONTRACT_VERSION', () => {
+    // A dispatch with only contract_version set (no version/digest) is unusual but valid
+    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '', '')).not.toThrow()
+  })
+
+  it('deploy() rejects wrong contract_version alone before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '',
+        digest: '',
+        contractVersion: 'stale-contract-v0',
+      }),
+    ).rejects.toThrow(/contract/)
+
+    expect(calls).toHaveLength(0)
+  })
+})
+
+// ─── Gap 1: versioned deploy writes local compose path ───────────────────────
+//
+// After a successful versioned deploy, the local compose file at localComposePath
+// must be updated to reflect version@resolvedDigest. This is what the workflow's
+// `git add apps/dashboard/docker-compose.yaml` step reads for the audit commit.
+//
+// Tests use an injectable localComposePath (temp file) so the real
+// apps/dashboard/docker-compose.yaml is never mutated.
+
+describe('versioned deploy: writes local compose path after successful deploy', () => {
+  const SAMPLE_COMPOSE_FOR_WRITE = `services:
+  caddy:
+    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    restart: unless-stopped
+  dashboard:
+    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}
+    restart: unless-stopped
+`
+
+  it('writes version@resolvedDigest to localComposePath after successful versioned deploy', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'deploy-test-compose-'))
+    const tmpComposePath = join(tmpDir, 'docker-compose.yaml')
+    writeFileSync(tmpComposePath, SAMPLE_COMPOSE_FOR_WRITE, 'utf8')
+
+    try {
+      const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+      await deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        localComposePath: tmpComposePath,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      })
+
+      const written = readFileSync(tmpComposePath, 'utf8')
+      expect(written).toContain(`ghcr.io/fro-bot/dashboard:2026.06.47@${RESOLVED_DIGEST}`)
+      // Old version must be gone
+      expect(written).not.toContain('2026.06.15@sha256:')
+    } finally {
+      rmSync(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does NOT write local compose path on failed versioned deploy (digest mismatch)', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'deploy-test-compose-'))
+    const tmpComposePath = join(tmpDir, 'docker-compose.yaml')
+    writeFileSync(tmpComposePath, SAMPLE_COMPOSE_FOR_WRITE, 'utf8')
+
+    try {
+      const wrongDispatchedDigest = `sha256:${'d'.repeat(64)}`
+      const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+      await expect(
+        deploy({
+          env: VALID_ENV,
+          spawn: spawnFn,
+          resolve: resolvesOk,
+          fetch: fetchHealthzOk,
+          version: '2026.06.47',
+          digest: wrongDispatchedDigest, // mismatch → throws before deploy
+          contractVersion: RELEASE_CONTRACT_VERSION,
+          localComposePath: tmpComposePath,
+          probeAttempts: 1,
+          probeIntervalMs: 0,
+          sleep: async () => {},
+        }),
+      ).rejects.toThrow(/digest/)
+
+      // Local compose must be unchanged
+      const written = readFileSync(tmpComposePath, 'utf8')
+      expect(written).toBe(SAMPLE_COMPOSE_FOR_WRITE)
+    } finally {
+      rmSync(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does NOT write local compose path on no-version fallback deploy', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'deploy-test-compose-'))
+    const tmpComposePath = join(tmpDir, 'docker-compose.yaml')
+    writeFileSync(tmpComposePath, SAMPLE_COMPOSE_FOR_WRITE, 'utf8')
+
+    try {
+      const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
+
+      await deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        localComposePath: tmpComposePath,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      })
+
+      // No-version fallback must not mutate the local compose
+      const written = readFileSync(tmpComposePath, 'utf8')
+      expect(written).toBe(SAMPLE_COMPOSE_FOR_WRITE)
+    } finally {
+      rmSync(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does NOT write local compose path when caddy up fails (late deploy failure)', async () => {
+    // Verifies that the local compose write only happens after the full deploy
+    // succeeds. If caddy up (Phase 11) throws, the write must be skipped.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'deploy-test-compose-'))
+    const tmpComposePath = join(tmpDir, 'docker-compose.yaml')
+    writeFileSync(tmpComposePath, SAMPLE_COMPOSE_FOR_WRITE, 'utf8')
+
+    try {
+      // Replace the caddy up response (index 13) with a failing exit code.
+      const responses = makeVersionedHappyPathResponses()
+      responses[13] = makeSpawnResult('', 'caddy up failed', 1)
+      const {spawnFn} = makeFakeSpawn(responses)
+
+      await expect(
+        deploy({
+          env: VALID_ENV,
+          spawn: spawnFn,
+          resolve: resolvesOk,
+          fetch: fetchHealthzOk,
+          version: '2026.06.47',
+          digest: RESOLVED_DIGEST,
+          contractVersion: RELEASE_CONTRACT_VERSION,
+          localComposePath: tmpComposePath,
+          probeAttempts: 1,
+          probeIntervalMs: 0,
+          sleep: async () => {},
+        }),
+      ).rejects.toThrow()
+
+      // Local compose must be unchanged — write only happens after full success
+      const written = readFileSync(tmpComposePath, 'utf8')
+      expect(written).toBe(SAMPLE_COMPOSE_FOR_WRITE)
+    } finally {
+      rmSync(tmpDir, {recursive: true, force: true})
+    }
+  })
+})
+
+// ─── Explicit input mode validation ──────────────────────────────────────────
+//
+// Valid modes:
+//   a) all release inputs empty => no-version fallback
+//   b) version (CalVer) + contract_version === RELEASE_CONTRACT_VERSION + optional digest
+//
+// Invalid: digest without version, contract_version without version (even correct contract),
+//          malformed digest, malformed version.
+
+describe('explicit input mode validation', () => {
+  it('rejects digest-only (no version) before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '',
+        digest: FAKE_DIGEST,
+        contractVersion: '',
+      }),
+    ).rejects.toThrow(/contract|version|mode/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects correct contract_version alone (no version) before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '',
+        digest: '',
+        contractVersion: RELEASE_CONTRACT_VERSION,
+      }),
+    ).rejects.toThrow(/version|mode/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects malformed digest (not sha256:<64hex>) before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: 'sha256:tooshort',
+        contractVersion: RELEASE_CONTRACT_VERSION,
+      }),
+    ).rejects.toThrow(/digest/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects digest without sha256: prefix before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: 'a'.repeat(64),
+        contractVersion: RELEASE_CONTRACT_VERSION,
+      }),
+    ).rejects.toThrow(/digest/)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('accepts valid version with omitted digest (empty string)', async () => {
+    const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: '',
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects digest-only + correct contract (no version) before any SSH/spawn', async () => {
+    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '',
+        digest: FAKE_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+      }),
+    ).rejects.toThrow(/version|mode/)
+
+    expect(calls).toHaveLength(0)
+  })
+})
+
+// ─── RED: generateComposeContent digest validation ───────────────────────────
+//
+// generateComposeContent must validate the digest with DIGEST_RE and throw on
+// malformed input. It must also throw when more than one fro-bot/dashboard
+// image line is found (silent multi-service drift guard).
+
+describe('generateComposeContent: digest validation and duplicate guard', () => {
+  it('throws on malformed digest (not sha256:<64hex>)', () => {
+    const compose = `services:\n  dashboard:\n    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}\n`
+    expect(() => generateComposeContent(compose, '2026.06.47', 'sha256:tooshort')).toThrow(/digest/)
+  })
+
+  it('throws on digest without sha256: prefix', () => {
+    const compose = `services:\n  dashboard:\n    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}\n`
+    expect(() => generateComposeContent(compose, '2026.06.47', 'a'.repeat(64))).toThrow(/digest/)
+  })
+
+  it('throws on empty digest', () => {
+    const compose = `services:\n  dashboard:\n    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}\n`
+    expect(() => generateComposeContent(compose, '2026.06.47', '')).toThrow(/digest/)
+  })
+
+  it('throws when more than one fro-bot/dashboard image line is found', () => {
+    const compose = `services:
+  dashboard:
+    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}
+  dashboard2:
+    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}
+`
+    expect(() => generateComposeContent(compose, '2026.06.47', `sha256:${'b'.repeat(64)}`)).toThrow(
+      /fro-bot\/dashboard|multiple|more than one/,
+    )
+  })
+
+  it('accepts exactly one fro-bot/dashboard image line with valid digest', () => {
+    const compose = `services:\n  dashboard:\n    image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}\n`
+    const newDigest = `sha256:${'b'.repeat(64)}`
+    expect(() => generateComposeContent(compose, '2026.06.47', newDigest)).not.toThrow()
+  })
+})
+
+// ─── RED: resolveImageDigest fallback and error paths ────────────────────────
+//
+// resolveImageDigest must:
+// - parse "Digest: sha256:<hex>" fallback output when template format unavailable
+// - throw with a clear message on unparseable output
+
+describe('resolveImageDigest: fallback Digest: output and unparseable output', () => {
+  it('versioned deploy succeeds when imagetools returns "Digest: sha256:<hex>" fallback format', async () => {
+    // Simulate imagetools returning plain "Digest: sha256:<hex>" instead of template format
+    const fallbackOutput = `Name:      ghcr.io/fro-bot/dashboard:2026.06.47\nDigest: ${RESOLVED_DIGEST}\nManifest: application/vnd.oci.image.index.v1+json\n`
+    const responses = makeVersionedHappyPathResponses()
+    responses[0] = makeSpawnResult(fallbackOutput) // override imagetools inspect response
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('versioned deploy fails with clear message when imagetools output is unparseable', async () => {
+    const responses = makeVersionedHappyPathResponses()
+    responses[0] = makeSpawnResult('Error: manifest unknown') // unparseable — no sha256 digest
+
+    const {spawnFn} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        version: '2026.06.47',
+        digest: RESOLVED_DIGEST,
+        contractVersion: RELEASE_CONTRACT_VERSION,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/digest|imagetools|parse/)
+  })
+})
+
+// ─── RED: public probe final warning includes last error/status ───────────────
+//
+// When the public HTTPS probe fails, the final warning must include either the
+// last fetch error message or the last non-OK HTTP status code. This mirrors
+// the operator-health diagnostics pattern and helps diagnose DNS/routing/ACME.
+
+describe('public probe: final warning includes last error or status', () => {
+  it('warning includes last HTTP status when probe returns non-ok status', async () => {
+    const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.map(String).join(' '))
+    }
+
+    try {
+      await deploy({
+        env: {...VALID_ENV, GATEWAY_VPC_IP: ''}, // skip operator health check
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: async (_url: string, _opts?: RequestInit) => {
+          return new Response('Service Unavailable', {status: 503})
+        },
+        probeAttempts: 2,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      })
+    } finally {
+      console.warn = origWarn
+    }
+
+    // The final warning for /api/healthz must include the last HTTP status
+    const healthzWarning = warnMessages.find(m => m.includes('healthz') || m.includes('TLS') || m.includes('cert'))
+    expect(healthzWarning).toBeDefined()
+    expect(healthzWarning).toMatch(/503|status/)
+  })
+
+  it('warning includes last error message when probe throws', async () => {
+    const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
+    const warnMessages: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.map(String).join(' '))
+    }
+
+    try {
+      await deploy({
+        env: {...VALID_ENV, GATEWAY_VPC_IP: ''}, // skip operator health check
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: async (_url: string, _opts?: RequestInit) => {
+          throw new TypeError('ECONNREFUSED: connection refused')
+        },
+        probeAttempts: 2,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      })
+    } finally {
+      console.warn = origWarn
+    }
+
+    // The final warning for /api/healthz must include the last error message
+    const healthzWarning = warnMessages.find(m => m.includes('healthz') || m.includes('TLS') || m.includes('cert'))
+    expect(healthzWarning).toBeDefined()
+    expect(healthzWarning).toMatch(/ECONNREFUSED|connection refused|error/i)
+  })
+})
+
+// ─── RED: --wait-timeout 120 in compose up commands ──────────────────────────
+//
+// Both `docker compose up -d --no-build --wait dashboard` and
+// `docker compose up -d --no-build --wait caddy` must include `--wait-timeout 120`
+// to bound the wait and surface clear timeout errors.
+
+describe('docker compose up: --wait-timeout 120', () => {
+  it('dashboard compose up includes --wait-timeout 120', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const dashboardUpCall = calls.find(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('docker compose up') && s.includes('dashboard') && !s.includes('caddy')
+    })
+    expect(dashboardUpCall).toBeDefined()
+    expect(dashboardUpCall?.cmd.join(' ')).toContain('--wait-timeout 120')
+  })
+
+  it('caddy compose up includes --wait-timeout 120', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const caddyUpCall = calls.find(c => {
+      const s = c.cmd.join(' ')
+      return s.includes('docker compose up') && s.includes('caddy')
+    })
+    expect(caddyUpCall).toBeDefined()
+    expect(caddyUpCall?.cmd.join(' ')).toContain('--wait-timeout 120')
   })
 })

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -6,6 +6,20 @@ import {join} from 'node:path'
 
 import {validateDashboardHost} from './host'
 
+// ─── Release dispatch contract ────────────────────────────────────────────────
+
+/**
+ * Contract version fuse for versioned release dispatches.
+ *
+ * When any versioned-release input (version, digest, or contract_version) is
+ * non-empty, the dispatched contract_version must match this constant exactly.
+ * This prevents accidental or stale dispatch payloads from deploying.
+ *
+ * The value is intentionally stable — bump it only when the dispatch contract
+ * itself changes in a breaking way.
+ */
+export const RELEASE_CONTRACT_VERSION = 'dashboard-release-dispatch-v1'
+
 // ─── Remote paths ─────────────────────────────────────────────────────────────
 
 const REMOTE_DIR = '/opt/dashboard'
@@ -20,6 +34,9 @@ const DEFAULT_REMOTE_USER = 'root'
 // ─── Shell metacharacter deny-list ────────────────────────────────────────────
 // These characters are dangerous when interpolated into remote shell context.
 const SHELL_METACHAR_RE = /[\n\r`$|;&'"\\]/
+
+// CalVer: YYYY.MM.N — four-digit year, two-digit month, non-negative integer patch.
+const CALVER_RE = /^\d{4}\.\d{2}\.\d+$/
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -59,6 +76,34 @@ export interface DeployOpts {
   probeAttempts?: number
   /** Interval between probe attempts in ms (default: 5_000). */
   probeIntervalMs?: number
+  /**
+   * CalVer version to deploy (e.g. "2026.06.47").
+   * When set, the deploy resolves the image digest from GHCR, generates
+   * compose content pinned to version@resolvedDigest, and uploads it.
+   * When empty/absent, the committed docker-compose.yaml is the source of truth.
+   */
+  version?: string
+  /**
+   * Expected sha256 digest for the versioned image (e.g. "sha256:abc...").
+   * When set alongside version, the resolved digest must match this value exactly.
+   * When empty, the resolved digest is used without a cross-check.
+   */
+  digest?: string
+  /**
+   * Contract version fuse — must equal RELEASE_CONTRACT_VERSION when any
+   * versioned-release input (version, digest, or contractVersion) is non-empty.
+   */
+  contractVersion?: string
+  /**
+   * Local path to write the updated docker-compose.yaml after a successful
+   * versioned deploy. When omitted, no local file is written — callers that
+   * need the write (production entry point, tests asserting the write) must
+   * pass this explicitly.
+   *
+   * Only written on the versioned path (when version is set) and only after
+   * the full deploy completes successfully.
+   */
+  localComposePath?: string
 }
 
 /** Validated, typed environment required for deploy. */
@@ -78,6 +123,139 @@ export interface ValidatedEnv {
 }
 
 // ─── Exported helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Validates that a version string is a well-formed CalVer (YYYY.MM.N).
+ *
+ * Accepts: strings matching `^\d{4}\.\d{2}\.\d+$` (e.g. "2026.06.47").
+ * Rejects: "latest", semver, injection strings, empty strings, and anything
+ *   that does not match the CalVer pattern.
+ *
+ * @throws {Error} when the version is not a valid CalVer string.
+ */
+export function validateCalVer(version: string): void {
+  if (!version || !CALVER_RE.test(version)) {
+    throw new Error(
+      `Invalid version "${version}": must be a CalVer string matching YYYY.MM.N (e.g. 2026.06.47). ` +
+        `"latest", semver, and injection strings are not accepted.`,
+    )
+  }
+}
+
+/**
+ * Validates the release dispatch contract fuse.
+ *
+ * When any versioned-release input (version, digest, or contractVersion) is
+ * non-empty, contractVersion must match RELEASE_CONTRACT_VERSION exactly.
+ * When all inputs are empty (no-version fallback), no contract is required.
+ *
+ * @throws {Error} when versioned inputs are present but contract is missing or wrong.
+ */
+export function validateContractVersion(contractVersion: string, version: string, digest: string): void {
+  const hasVersionedInput = Boolean(version || digest || contractVersion)
+  if (!hasVersionedInput) return
+
+  if (!contractVersion || contractVersion !== RELEASE_CONTRACT_VERSION) {
+    throw new Error(
+      `Release dispatch contract mismatch. ` +
+        `Expected contract_version="${RELEASE_CONTRACT_VERSION}" but got "${contractVersion}". ` +
+        `Set contract_version to "${RELEASE_CONTRACT_VERSION}" when dispatching a versioned release.`,
+    )
+  }
+}
+
+// sha256 digest: exactly "sha256:" followed by 64 lowercase hex characters.
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
+
+/**
+ * Validates the explicit input mode for a deploy invocation.
+ *
+ * Valid modes:
+ *   a) All release inputs empty (version, digest, contractVersion) — no-version fallback.
+ *   b) version (CalVer) + contractVersion === RELEASE_CONTRACT_VERSION + optional digest.
+ *
+ * Invalid:
+ *   - digest without version (digest-only)
+ *   - contractVersion without version (contract-only, even if correct)
+ *   - malformed digest (must match ^sha256:[0-9a-f]{64}$)
+ *
+ * This is enforced before env validation and SSH so the error is surfaced early.
+ *
+ * @throws {Error} when the input combination is invalid.
+ */
+export function validateInputMode(version: string, digest: string, contractVersion: string): void {
+  const hasVersion = Boolean(version)
+  const hasDigest = Boolean(digest)
+  const hasContract = Boolean(contractVersion)
+
+  // Mode (a): all empty — no-version fallback, nothing to validate here.
+  if (!hasVersion && !hasDigest && !hasContract) return
+
+  // Mode (b) requires version. Reject digest-only and contract-only.
+  if (!hasVersion) {
+    throw new Error(
+      `Invalid deploy input mode: version is required when digest or contract_version is set. ` +
+        `Either omit all inputs (no-version fallback) or provide version + contract_version="${RELEASE_CONTRACT_VERSION}".`,
+    )
+  }
+
+  // Validate digest format when provided.
+  if (hasDigest && !DIGEST_RE.test(digest)) {
+    throw new Error(
+      `Invalid digest "${digest}": must match sha256:<64 hex chars> (e.g. sha256:abc...def). ` +
+        `Malformed digests are not accepted.`,
+    )
+  }
+}
+
+/**
+ * Generates docker-compose.yaml content with the image line replaced to pin
+ * the given version and digest.
+ *
+ * Replaces the `image: ghcr.io/fro-bot/dashboard:...` line with
+ * `image: ghcr.io/fro-bot/dashboard:<version>@<digest>`.
+ *
+ * @throws {Error} when digest is malformed (must match ^sha256:[0-9a-f]{64}$).
+ * @throws {Error} when no fro-bot/dashboard image line is found in the content.
+ * @throws {Error} when more than one fro-bot/dashboard image line is found (drift guard).
+ */
+export function generateComposeContent(originalContent: string, version: string, digest: string): string {
+  if (!digest || !DIGEST_RE.test(digest)) {
+    throw new Error(
+      `Invalid digest "${digest}": must match sha256:<64 hex chars> (e.g. sha256:abc...def). ` +
+        `Malformed digests are not accepted.`,
+    )
+  }
+
+  const lines = originalContent.split('\n')
+  let matchCount = 0
+
+  const newLines = lines.map(line => {
+    if (line.includes('fro-bot/dashboard')) {
+      matchCount++
+      // Preserve leading whitespace
+      const indent = line.match(/^(\s*)/)?.[1] ?? ''
+      return `${indent}image: ghcr.io/fro-bot/dashboard:${version}@${digest}`
+    }
+    return line
+  })
+
+  if (matchCount === 0) {
+    throw new Error(
+      'Could not find a fro-bot/dashboard image line in docker-compose.yaml. ' +
+        'Cannot generate versioned compose content.',
+    )
+  }
+
+  if (matchCount > 1) {
+    throw new Error(
+      `Found ${matchCount} fro-bot/dashboard image lines in docker-compose.yaml — expected exactly one. ` +
+        `Multiple matches risk silent multi-service drift. Inspect the compose file and ensure only one service uses this image.`,
+    )
+  }
+
+  return newLines.join('\n')
+}
 
 /**
  * Parses the sha256 digest from a docker-compose image line.
@@ -476,30 +654,81 @@ async function defaultResolve(host: string): Promise<void> {
   }
 }
 
+/**
+ * Resolves the top-level multi-arch digest for a versioned GHCR image.
+ *
+ * Uses `docker buildx imagetools inspect <image>:<version> --format '{{ .Manifest.Digest }}'`
+ * to retrieve the top-level index/manifest digest. Falls back to parsing
+ * plain `Digest: sha256:<hex>` output if the template format is unavailable.
+ *
+ * @throws {Error} when the digest cannot be resolved or parsed.
+ */
+async function resolveImageDigest(version: string, spawnFn: SpawnFn, deployEnv: DeployEnv): Promise<string> {
+  const imageRef = `ghcr.io/fro-bot/dashboard:${version}`
+  const {stdout} = await runCommand(
+    `Resolving image digest for ${imageRef}`,
+    ['docker', 'buildx', 'imagetools', 'inspect', imageRef, '--format', '{{ .Manifest.Digest }}'],
+    deployEnv,
+    spawnFn,
+  )
+
+  const trimmed = stdout.trim()
+
+  // Primary: template output is the digest directly (e.g. "sha256:abc...")
+  if (/^sha256:[0-9a-f]{64}$/.test(trimmed)) {
+    return trimmed
+  }
+
+  // Fallback: parse "Digest: sha256:<hex>" from plain output
+  const fallbackMatch = /Digest:\s*(sha256:[0-9a-f]{64})/.exec(trimmed)
+  if (fallbackMatch?.[1]) {
+    return fallbackMatch[1]
+  }
+
+  throw new Error(
+    `Could not parse image digest from imagetools inspect output for ${imageRef}.\n` +
+      `Output: ${trimmed.slice(0, 200)}`,
+  )
+}
+
 // ─── Main deploy orchestrator ─────────────────────────────────────────────────
 
 /**
  * Deploys the Dashboard stack to the remote droplet.
  *
+ * Two modes:
+ *
+ * **Versioned path** (version + contractVersion provided):
+ *   Pre-gate: validate CalVer, validate contract fuse (no secrets required).
+ *   Then: resolve digest via `docker buildx imagetools inspect`, cross-check
+ *   against dispatched digest (if provided), generate compose content pinned to
+ *   version@resolvedDigest, upload via SSH stdin.
+ *
+ * **No-version fallback** (no version):
+ *   Read digest from committed docker-compose.yaml; scp the committed file.
+ *
  * Order of operations:
- * 1. Validate env (throws before any SSH on failure)
- * 2. Validate host (SSH argv injection defense)
- * 3. Read expected digest from committed docker-compose.yaml (fail closed if not pinned)
+ * 1. Pre-gate: validate contract fuse + CalVer (no secrets, before environment gate)
+ * 2. Validate env (throws before any SSH on failure)
+ * 3. Validate host (SSH argv injection defense)
  * 4. DNS preflight
  * 5. ControlMaster SSH multiplexing setup (dual-tmpdir: key under os.tmpdir(), socket under /tmp)
- * 6. Remote prep: mkdir -p /opt/dashboard/config
- * 7. Materialize /opt/dashboard/.env via SSH stdin (includes DASHBOARD_GITHUB_APP_KEY_FILE path)
- * 8. scp docker-compose.yaml + config/Caddyfile
- * 9. Upload GitHub App private key via SSH stdin to /opt/dashboard/config/github-app.pem (0600)
- *    SECURITY: PEM bytes flow through stdin ONLY — never in argv, never in a local temp file
- * 10. chown 1000:1000 github-app.pem so the container's node user (UID 1000) can read it
- * 11. rm -f /opt/dashboard/docker-compose.override.yaml (idempotent legacy cleanup — old deploys
- *     wrote this file; Docker Compose auto-merges it if present, which would override the image pin)
- * 12. docker compose pull (pulls digest-pinned GHCR image from docker-compose.yaml)
- * 13. docker compose up -d --no-build --wait dashboard (app health gate first)
- * 14. Verify RepoDigests: assert running image includes digest from docker-compose.yaml (fail closed)
- * 15. docker compose up -d --no-build --wait caddy (public exposure after app healthy)
- * 16. Probe https://$DASHBOARD_DOMAIN/api/healthz — bounded retry; warning-only on ACME lag
+ * 6. Versioned: resolve digest via imagetools inspect + cross-check; generate compose content
+ *    No-version: read digest from committed docker-compose.yaml
+ * 7. Remote prep: mkdir -p /opt/dashboard/config
+ * 8. Materialize /opt/dashboard/.env via SSH stdin (includes DASHBOARD_GITHUB_APP_KEY_FILE path)
+ * 9. Versioned: upload generated compose via SSH stdin
+ *    No-version: scp committed docker-compose.yaml
+ *    Both: scp config/Caddyfile
+ * 10. Upload GitHub App private key via SSH stdin to /opt/dashboard/config/github-app.pem (0600)
+ *     SECURITY: PEM bytes flow through stdin ONLY — never in argv, never in a local temp file
+ * 11. chown 1000:1000 github-app.pem so the container's node user (UID 1000) can read it
+ * 12. rm -f /opt/dashboard/docker-compose.override.yaml (idempotent legacy cleanup)
+ * 13. docker compose pull (pulls digest-pinned GHCR image from docker-compose.yaml)
+ * 14. docker compose up -d --no-build --wait dashboard (app health gate first)
+ * 15. Verify RepoDigests: assert running image includes selected digest (fail closed)
+ * 16. docker compose up -d --no-build --wait caddy (public exposure after app healthy)
+ * 17. Probe https://$DASHBOARD_DOMAIN/api/healthz — bounded retry; warning-only on ACME lag
  */
 export async function deploy(opts: DeployOpts = {}): Promise<void> {
   const env = opts.env ?? (process.env as Record<string, string>)
@@ -509,14 +738,33 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
   const sleepFn = opts.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)))
   const probeAttempts = opts.probeAttempts ?? 10
   const probeIntervalMs = opts.probeIntervalMs ?? 5_000
+  const version = opts.version ?? ''
+  const dispatchedDigest = opts.digest ?? ''
+  const contractVersion = opts.contractVersion ?? ''
+  // localComposePath: when provided, the versioned deploy writes the generated
+  // compose content back here after success (for the workflow audit PR step).
+  // When undefined, the write is skipped — callers that need the write (production
+  // entry point, tests asserting the write) must pass this explicitly.
+  const localComposePath = opts.localComposePath
+
+  // ── Pre-gate: no-secret validation (runs before environment gate) ──────────
+  // These checks require no secrets and can run before the environment gate.
+
+  // Input mode: enforce valid combinations before contract/CalVer checks.
+  validateInputMode(version, dispatchedDigest, contractVersion)
+
+  // Contract fuse: if any versioned-release input is present, contract must match.
+  validateContractVersion(contractVersion, version, dispatchedDigest)
+
+  // CalVer validation: reject invalid version strings before any SSH/spawn.
+  if (version) {
+    validateCalVer(version)
+  }
 
   // Phase 1: Validate env — throws before any SSH on failure
   const validated = validateEnv(env)
 
   const host = validated.DASHBOARD_DOMAIN
-
-  // Phase 2: Read expected digest from committed docker-compose.yaml (fail closed)
-  const imageDigest = readComposeDigest()
 
   // Boundary-validate secret values before any SSH
   validateSecretValue(validated.DASHBOARD_OAUTH_CLIENT_SECRET, 'DASHBOARD_OAUTH_CLIENT_SECRET')
@@ -565,6 +813,40 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
     // %C expands to a hash of the connection tuple.
     const controlPath = join(controlTmpDir, 'cm-%C')
 
+    // Phase 2: Determine image digest and compose content
+    // - Versioned path: resolve digest from GHCR, compare to dispatched digest, generate compose
+    // - No-version fallback: read digest from committed docker-compose.yaml, scp the file
+    let imageDigest: string
+    let composeContentForUpload: string | null = null // null = use scp of committed file
+
+    if (version) {
+      // Versioned path: resolve top-level digest via imagetools inspect
+      const resolvedDigest = await resolveImageDigest(version, spawnFn, deployEnv)
+
+      // Cross-check: if a dispatched digest was provided, it must match the resolved digest
+      if (dispatchedDigest && resolvedDigest !== dispatchedDigest) {
+        throw new Error(
+          `Image digest mismatch for ghcr.io/fro-bot/dashboard:${version}.\n` +
+            `  Dispatched digest: ${dispatchedDigest}\n` +
+            `  Resolved digest:   ${resolvedDigest}\n` +
+            `The dispatched digest does not match the current GHCR image. ` +
+            `Re-dispatch with the correct digest or omit the digest field.`,
+        )
+      }
+
+      imageDigest = resolvedDigest
+
+      // Generate compose content with version@resolvedDigest.
+      // Always read from the committed file (source of truth for the template).
+      // localComposePath (if provided) is the write-back target after success.
+      const committedComposePath = join(import.meta.dir, '..', 'docker-compose.yaml')
+      const originalCompose = readFileSync(committedComposePath, 'utf8')
+      composeContentForUpload = generateComposeContent(originalCompose, version, resolvedDigest)
+    } else {
+      // No-version fallback: read digest from committed docker-compose.yaml
+      imageDigest = readComposeDigest()
+    }
+
     // Phase 4: Remote prep
     await runCommand(
       'Creating remote directories',
@@ -596,16 +878,31 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
       controlPath,
     )
 
-    // Phase 6: scp docker-compose.yaml and Caddyfile
-    const localCompose = join(import.meta.dir, '..', 'docker-compose.yaml')
+    // Phase 6: Upload docker-compose.yaml and Caddyfile
     const localCaddyfile = join(import.meta.dir, '..', 'config', 'Caddyfile')
 
-    await runCommand(
-      'Copying docker-compose.yaml',
-      scpCommand(localCompose, host, REMOTE_COMPOSE_PATH, keyPath, controlPath),
-      deployEnv,
-      spawnFn,
-    )
+    if (composeContentForUpload === null) {
+      // No-version fallback: scp the committed docker-compose.yaml
+      const committedComposePath = join(import.meta.dir, '..', 'docker-compose.yaml')
+      await runCommand(
+        'Copying docker-compose.yaml',
+        scpCommand(committedComposePath, host, REMOTE_COMPOSE_PATH, keyPath, controlPath),
+        deployEnv,
+        spawnFn,
+      )
+    } else {
+      // Versioned path: upload generated compose content via SSH stdin
+      await writeRemoteFile(
+        `Writing ${REMOTE_COMPOSE_PATH} (versioned: ${version}@${imageDigest.slice(0, 19)}...)`,
+        host,
+        REMOTE_COMPOSE_PATH,
+        composeContentForUpload,
+        deployEnv,
+        spawnFn,
+        keyPath,
+        controlPath,
+      )
+    }
 
     await runCommand(
       'Copying Caddyfile',
@@ -676,9 +973,15 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
 
     // Phase 9: Start dashboard only (Caddy NOT started — no public exposure yet).
     // --no-build enforces digest-pinned image; never builds from source on the droplet.
+    // --wait-timeout 120 bounds the health-check wait and surfaces clear timeout errors.
     await runCommand(
       'Starting dashboard (internal only)',
-      sshCommand(host, `cd ${REMOTE_DIR} && docker compose up -d --no-build --wait dashboard`, keyPath, controlPath),
+      sshCommand(
+        host,
+        `cd ${REMOTE_DIR} && docker compose up -d --no-build --wait --wait-timeout 120 dashboard`,
+        keyPath,
+        controlPath,
+      ),
       deployEnv,
       spawnFn,
     )
@@ -722,9 +1025,15 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
     console.warn('\u001B[1;32m✓\u001B[0m dashboard image digest verified')
 
     // Phase 11: Start Caddy — now safe to expose publicly (app is healthy + digest verified).
+    // --wait-timeout 120 bounds the health-check wait and surfaces clear timeout errors.
     await runCommand(
       'Starting Caddy (public exposure)',
-      sshCommand(host, `cd ${REMOTE_DIR} && docker compose up -d --no-build --wait caddy`, keyPath, controlPath),
+      sshCommand(
+        host,
+        `cd ${REMOTE_DIR} && docker compose up -d --no-build --wait --wait-timeout 120 caddy`,
+        keyPath,
+        controlPath,
+      ),
       deployEnv,
       spawnFn,
     )
@@ -792,17 +1101,20 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
 
     // Phase 12: Public HTTPS probe (warning-only — Caddy ACME cert may still be issuing)
     let probeOk = false
+    let lastProbeStatus = 0
+    let lastProbeError: string | undefined
     for (let attempt = 1; attempt <= probeAttempts; attempt++) {
       try {
         const response = await fetchFn(`https://${host}${HEALTH_PATH}`, {
           signal: AbortSignal.timeout(10_000),
         })
+        lastProbeStatus = response.status
         if (response.ok) {
           probeOk = true
           break
         }
-      } catch {
-        // Transient failure — retry
+      } catch (error) {
+        lastProbeError = error instanceof Error ? error.message : String(error)
       }
 
       if (attempt < probeAttempts) {
@@ -812,11 +1124,28 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
 
     if (probeOk) {
       console.warn(`\u001B[1;32m✓\u001B[0m Public HTTPS probe succeeded: https://${host}${HEALTH_PATH}`)
+    } else if (lastProbeError) {
+      console.warn(
+        `\u001B[1;33m[warn]\u001B[0m containers healthy; TLS cert may still be issuing — ` +
+          `verify at https://${host}${HEALTH_PATH}. ` +
+          `Last error: ${lastProbeError}`,
+      )
     } else {
       console.warn(
-        `\u001B[1;33m[warn]\u001B[0m containers healthy; TLS cert still issuing — ` +
-          `verify at https://${host}${HEALTH_PATH}`,
+        `\u001B[1;33m[warn]\u001B[0m containers healthy; TLS cert may still be issuing — ` +
+          `verify at https://${host}${HEALTH_PATH}. ` +
+          `Last HTTP status: ${lastProbeStatus}`,
       )
+    }
+
+    // Versioned path: write the generated compose content back to the local file.
+    // This is the audit record committed by the workflow's audit PR step.
+    // Only written after the full deploy completes successfully — never on failure.
+    // Only written when localComposePath is explicitly provided (production entry point passes it;
+    // tests that don't need the write omit it for isolation).
+    if (composeContentForUpload !== null && localComposePath !== undefined) {
+      writeFileSync(localComposePath, composeContentForUpload, 'utf8')
+      console.warn(`\u001B[1;32m✓\u001B[0m Updated local compose pin: ${localComposePath}`)
     }
 
     console.warn('\u001B[1;32m✓\u001B[0m Deploy complete.')
@@ -834,7 +1163,14 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
 if (import.meta.main) {
-  deploy().catch((error: unknown) => {
+  deploy({
+    version: process.env.DEPLOY_VERSION ?? '',
+    digest: process.env.DEPLOY_DIGEST ?? '',
+    contractVersion: process.env.DEPLOY_CONTRACT_VERSION ?? '',
+    // Pass the committed compose path explicitly so the versioned deploy writes
+    // the updated pin back for the workflow's audit PR step.
+    localComposePath: join(import.meta.dir, '..', 'docker-compose.yaml'),
+  }).catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : error)
     process.exit(1)
   })

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1220,3 +1220,364 @@ describe('deploy.yaml: deploy-dashboard is decoupled from deploy-gateway', () =>
     expect(text).not.toMatch(/needs\.deploy-gateway/)
   })
 })
+
+// ─── deploy-dashboard.yaml: dispatch/call inputs and job structure ────────────
+//
+// Verifies the workflow contract for the dashboard release dispatch:
+// - dispatch/call inputs version, digest, contract_version with defaults
+// - validate-inputs job exists and deploy-dashboard needs it
+// - deploy step forwards DEPLOY_VERSION, DEPLOY_DIGEST, DEPLOY_CONTRACT_VERSION
+// - no direct ${{ inputs.* }} interpolation inside run: script bodies
+// - audit path does not push to HEAD:main and uses a PR branch/gh pr create
+// - deploy router dashboard job skips audit pin commits on push but not workflow_dispatch
+
+describe('deploy-dashboard.yaml: dispatch/call inputs and job structure', () => {
+  const DEPLOY_DASHBOARD_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy-dashboard.yaml')
+
+  it('workflow_dispatch and workflow_call both declare version input with default empty string', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      on?: {
+        workflow_dispatch?: {inputs?: Record<string, {default?: unknown}>}
+        workflow_call?: {inputs?: Record<string, {default?: unknown}>}
+      }
+    }
+    expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty('version')
+    expect(parsed.on?.workflow_dispatch?.inputs?.version?.default).toBe('')
+    expect(parsed.on?.workflow_call?.inputs).toHaveProperty('version')
+    expect(parsed.on?.workflow_call?.inputs?.version?.default).toBe('')
+  })
+
+  it('workflow_dispatch and workflow_call both declare digest input with default empty string', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      on?: {
+        workflow_dispatch?: {inputs?: Record<string, {default?: unknown}>}
+        workflow_call?: {inputs?: Record<string, {default?: unknown}>}
+      }
+    }
+    expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty('digest')
+    expect(parsed.on?.workflow_dispatch?.inputs?.digest?.default).toBe('')
+    expect(parsed.on?.workflow_call?.inputs).toHaveProperty('digest')
+    expect(parsed.on?.workflow_call?.inputs?.digest?.default).toBe('')
+  })
+
+  it('workflow_dispatch and workflow_call both declare contract_version input with default empty string', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      on?: {
+        workflow_dispatch?: {inputs?: Record<string, {default?: unknown}>}
+        workflow_call?: {inputs?: Record<string, {default?: unknown}>}
+      }
+    }
+    expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty('contract_version')
+    expect(parsed.on?.workflow_dispatch?.inputs?.contract_version?.default).toBe('')
+    expect(parsed.on?.workflow_call?.inputs).toHaveProperty('contract_version')
+    expect(parsed.on?.workflow_call?.inputs?.contract_version?.default).toBe('')
+  })
+
+  it('validate-inputs job exists', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: Record<string, unknown>}
+    expect(parsed.jobs).toHaveProperty('validate-inputs')
+  })
+
+  it('deploy-dashboard job needs validate-inputs', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'deploy-dashboard'?: {needs?: string | string[]}}}
+    const needs = parsed.jobs?.['deploy-dashboard']?.needs ?? []
+    const needsArr = Array.isArray(needs) ? needs : [needs]
+    expect(needsArr).toContain('validate-inputs')
+  })
+
+  it('Deploy step env forwards DEPLOY_VERSION from inputs', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
+    }
+    const steps = parsed.jobs?.['deploy-dashboard']?.steps ?? []
+    const deployStep = steps.find(s => s.name === 'Deploy')
+    expect(deployStep).toBeDefined()
+    expect(deployStep?.env).toHaveProperty('DEPLOY_VERSION')
+    expect(deployStep?.env?.DEPLOY_VERSION).toContain('inputs.version')
+  })
+
+  it('Deploy step env forwards DEPLOY_DIGEST from inputs', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
+    }
+    const steps = parsed.jobs?.['deploy-dashboard']?.steps ?? []
+    const deployStep = steps.find(s => s.name === 'Deploy')
+    expect(deployStep).toBeDefined()
+    expect(deployStep?.env).toHaveProperty('DEPLOY_DIGEST')
+    expect(deployStep?.env?.DEPLOY_DIGEST).toContain('inputs.digest')
+  })
+
+  it('Deploy step env forwards DEPLOY_CONTRACT_VERSION from inputs', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
+    }
+    const steps = parsed.jobs?.['deploy-dashboard']?.steps ?? []
+    const deployStep = steps.find(s => s.name === 'Deploy')
+    expect(deployStep).toBeDefined()
+    expect(deployStep?.env).toHaveProperty('DEPLOY_CONTRACT_VERSION')
+    expect(deployStep?.env?.DEPLOY_CONTRACT_VERSION).toContain('inputs.contract_version')
+  })
+
+  it('no direct inputs.* interpolation inside run: script bodies', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: Record<string, {steps?: {run?: string; env?: unknown}[]}>}
+    // Pattern: ${{ inputs.* }} in run: body is a shell injection risk.
+    // Inputs must be passed via step env: and referenced as shell vars.
+    // Use non-global regex to avoid stateful lastIndex issues in loops.
+    const inputsInRunRe = /\$\{\{\s*inputs\./
+    const jobsWithViolations: string[] = []
+    for (const [jobId, job] of Object.entries(parsed.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if (typeof step.run !== 'string') continue
+        if (inputsInRunRe.test(step.run)) {
+          jobsWithViolations.push(jobId)
+          break
+        }
+      }
+    }
+    expect(jobsWithViolations).toEqual([])
+  })
+
+  it('audit path does not push directly to HEAD:main', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    // Direct push to HEAD:main is blocked by branch protection
+    expect(text).not.toContain('HEAD:main')
+  })
+
+  it('audit path uses gh pr create (PR-based write-back)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    expect(text).toContain('gh pr create')
+  })
+
+  it('workflow_call.secrets declares APPLICATION_ID as required', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {on?: {workflow_call?: {secrets?: Record<string, {required?: boolean}>}}}
+    const secrets = parsed.on?.workflow_call?.secrets ?? {}
+    expect(secrets).toHaveProperty('APPLICATION_ID')
+    expect(secrets.APPLICATION_ID?.required).toBe(true)
+  })
+
+  it('workflow_call.secrets declares APPLICATION_PRIVATE_KEY as required', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {on?: {workflow_call?: {secrets?: Record<string, {required?: boolean}>}}}
+    const secrets = parsed.on?.workflow_call?.secrets ?? {}
+    expect(secrets).toHaveProperty('APPLICATION_PRIVATE_KEY')
+    expect(secrets.APPLICATION_PRIVATE_KEY?.required).toBe(true)
+  })
+
+  it('does not use github.token anywhere (app token only)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    expect(text).not.toContain('github.token')
+  })
+
+  it('Get app token step has no if: condition (runs unconditionally)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; if?: unknown}[]}}
+    }
+    const steps = parsed.jobs?.['deploy-dashboard']?.steps ?? []
+    const getTokenStep = steps.find(s => s.name === 'Get app token')
+    expect(getTokenStep).toBeDefined()
+    expect(getTokenStep?.if).toBeUndefined()
+  })
+
+  it('has top-level permissions: contents: read (project convention — no GITHUB_TOKEN write)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {permissions?: {contents?: string}}
+    expect(parsed.permissions).toBeDefined()
+    expect(parsed.permissions?.contents).toBe('read')
+  })
+
+  it('deploy-dashboard job has no job-level permissions: block (no GITHUB_TOKEN write needed)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'deploy-dashboard'?: {permissions?: unknown}}}
+    expect(parsed.jobs?.['deploy-dashboard']?.permissions).toBeUndefined()
+  })
+})
+
+describe('deploy.yaml: dashboard job skips audit pin commits on push', () => {
+  const DEPLOY_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy.yaml')
+
+  it('deploy-dashboard if: skips commits whose message contains the audit pin prefix on push', async () => {
+    const text = await Bun.file(DEPLOY_WORKFLOW).text()
+    // The if: condition must exclude audit pin commits on push events
+    // by checking the head commit message does not contain the pin prefix
+    expect(text).toContain('chore(dashboard): pin image to')
+  })
+
+  it('deploy.yaml passes APPLICATION_ID to deploy-dashboard job', async () => {
+    const text = await Bun.file(DEPLOY_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {secrets?: Record<string, string>}}
+    }
+    const secrets = parsed.jobs?.['deploy-dashboard']?.secrets ?? {}
+    expect(secrets).toHaveProperty('APPLICATION_ID')
+    expect(secrets.APPLICATION_ID).toContain('APPLICATION_ID')
+  })
+
+  it('deploy.yaml passes APPLICATION_PRIVATE_KEY to deploy-dashboard job', async () => {
+    const text = await Bun.file(DEPLOY_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'deploy-dashboard'?: {secrets?: Record<string, string>}}
+    }
+    const secrets = parsed.jobs?.['deploy-dashboard']?.secrets ?? {}
+    expect(secrets).toHaveProperty('APPLICATION_PRIVATE_KEY')
+    expect(secrets.APPLICATION_PRIVATE_KEY).toContain('APPLICATION_PRIVATE_KEY')
+  })
+
+  it('deploy-dashboard job in deploy.yaml has no permissions: block (no GITHUB_TOKEN used)', async () => {
+    const text = await Bun.file(DEPLOY_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'deploy-dashboard'?: {permissions?: unknown}}}
+    expect(parsed.jobs?.['deploy-dashboard']?.permissions).toBeUndefined()
+  })
+})
+
+// ─── deploy-dashboard.yaml: pre-gate digest validation step ──────────────────
+//
+// A `Validate digest format` step must exist in the `validate-inputs` job,
+// before the `Validate input mode` step. It must:
+// - only run when inputs.digest != ''
+// - expose INPUT_DIGEST via env (not direct interpolation in run:)
+// - validate ^sha256:[0-9a-f]{64}$ and fail with a clear message on mismatch
+
+describe('deploy-dashboard.yaml: pre-gate digest validation step', () => {
+  const DEPLOY_DASHBOARD_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy-dashboard.yaml')
+
+  it('validate-inputs job has a "Validate digest format" step', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'validate-inputs'?: {steps?: {name?: string}[]}}}
+    const steps = parsed.jobs?.['validate-inputs']?.steps ?? []
+    const digestStep = steps.find(s => s.name === 'Validate digest format')
+    expect(digestStep).toBeDefined()
+  })
+
+  it('"Validate digest format" step has if: inputs.digest != \'\'', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'validate-inputs'?: {steps?: {name?: string; if?: unknown}[]}}
+    }
+    const steps = parsed.jobs?.['validate-inputs']?.steps ?? []
+    const digestStep = steps.find(s => s.name === 'Validate digest format')
+    expect(digestStep).toBeDefined()
+    // The if: condition must reference inputs.digest
+    expect(String(digestStep?.if ?? '')).toContain('inputs.digest')
+  })
+
+  it('"Validate digest format" step exposes INPUT_DIGEST via env (not direct interpolation)', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'validate-inputs'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
+    }
+    const steps = parsed.jobs?.['validate-inputs']?.steps ?? []
+    const digestStep = steps.find(s => s.name === 'Validate digest format')
+    expect(digestStep).toBeDefined()
+    expect(digestStep?.env).toHaveProperty('INPUT_DIGEST')
+    expect(digestStep?.env?.INPUT_DIGEST).toContain('inputs.digest')
+  })
+
+  it('"Validate digest format" step run: validates sha256:<64hex> pattern', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'validate-inputs'?: {steps?: {name?: string; run?: string}[]}}
+    }
+    const steps = parsed.jobs?.['validate-inputs']?.steps ?? []
+    const digestStep = steps.find(s => s.name === 'Validate digest format')
+    expect(digestStep).toBeDefined()
+    // Must contain the sha256 hex pattern
+    expect(digestStep?.run ?? '').toMatch(/sha256[^\d\n\ra-f\u2028\u2029]*[\da-f].*64|sha256:\[0-9a-f\]/)
+  })
+
+  it('"Validate digest format" step appears before "Validate input mode" step', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {
+      jobs?: {'validate-inputs'?: {steps?: {name?: string}[]}}
+    }
+    const steps = parsed.jobs?.['validate-inputs']?.steps ?? []
+    const digestIdx = steps.findIndex(s => s.name === 'Validate digest format')
+    const inputModeIdx = steps.findIndex(s => s.name === 'Validate input mode')
+    expect(digestIdx).toBeGreaterThan(-1)
+    expect(inputModeIdx).toBeGreaterThan(-1)
+    expect(digestIdx).toBeLessThan(inputModeIdx)
+  })
+})
+
+// ─── deploy-dashboard.yaml: audit step hardening ─────────────────────────────
+//
+// The audit PR step must:
+// - revalidate version with CalVer before constructing branch/commit strings
+// - use a unique branch per run: dashboard-pin-${version}-${GITHUB_RUN_ID}
+// - use `gh pr list --state open --head "${branch}"` (not just --head)
+// - NOT use `|| true` around push/pr create (audit failures must fail the step)
+
+describe('deploy-dashboard.yaml: audit step hardening', () => {
+  const DEPLOY_DASHBOARD_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy-dashboard.yaml')
+
+  it('audit PR step branch name includes github.run_id for uniqueness', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    // The branch must include run_id to avoid collision on re-runs
+    expect(text).toMatch(/run_id|GITHUB_RUN_ID/)
+    // And it must be in the context of the audit PR step (after "Open audit PR")
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    expect(afterAudit).toMatch(/run_id|GITHUB_RUN_ID/)
+  })
+
+  it('audit PR step uses --state open in gh pr list', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    expect(afterAudit).toContain('--state open')
+  })
+
+  it('audit PR step revalidates version with CalVer regex before branch construction', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    // Must contain a CalVer regex check (YYYY.MM.N pattern) — look for the bash =~ pattern
+    // The audit step must revalidate version before constructing branch/commit strings.
+    // We check for the presence of a numeric range pattern used in bash =~ checks.
+    expect(afterAudit).toContain('[0-9]')
+  })
+
+  it('audit PR step does NOT use || true around push or pr create', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    // || true around push or pr create silences audit failures — must not be present
+    expect(afterAudit).not.toMatch(/git push[^#\n]*\|\|\s*true/)
+    expect(afterAudit).not.toMatch(/gh pr create[^#\n]*\|\|\s*true/)
+  })
+})
+
+// ─── deploy-dashboard.yaml: job timeout-minutes ──────────────────────────────
+//
+// Both validate-inputs and deploy-dashboard jobs must have timeout-minutes set.
+// Conservative values: validate 5, deploy 30.
+
+describe('deploy-dashboard.yaml: job timeout-minutes', () => {
+  const DEPLOY_DASHBOARD_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy-dashboard.yaml')
+
+  it('validate-inputs job has timeout-minutes: 5', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'validate-inputs'?: {'timeout-minutes'?: number}}}
+    expect(parsed.jobs?.['validate-inputs']?.['timeout-minutes']).toBe(5)
+  })
+
+  it('deploy-dashboard job has timeout-minutes: 30', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const parsed = parseYaml(text) as {jobs?: {'deploy-dashboard'?: {'timeout-minutes'?: number}}}
+    expect(parsed.jobs?.['deploy-dashboard']?.['timeout-minutes']).toBe(30)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a versioned dashboard deploy path so a dashboard release can dispatch the existing gated deploy workflow with an explicit CalVer version, optional expected digest, and contract fuse.

The no-version path still deploys the committed compose pin.

## What changed

- Added `version`, `digest`, and `contract_version` inputs to `deploy-dashboard.yaml` for both manual dispatch and reusable workflow calls.
- Added pre-gate validation for version, digest, contract, and invalid input combinations before the `dashboard` environment approval gate.
- Resolve `ghcr.io/fro-bot/dashboard:<version>` independently with `docker buildx imagetools inspect`, cross-check the dispatched digest when provided, and deploy generated compose content pinned to `version@digest`.
- Keep the committed compose pin as the fallback source of truth when no version is provided.
- After a successful versioned deploy, open an App-authored audit PR with the updated compose pin instead of writing directly to `main`.
- Keep the workflow on the project token posture: top-level `permissions: contents: read`, no `github.token` path for dashboard deploy writes, and App token for checkout/audit PR creation.
- Harden deploy verification around malformed digest inputs, duplicate dashboard image lines, digest parser fallback, HTTPS probe diagnostics, and compose wait timeouts.

## Verification

- `bun test packages/cli/src/conventions.test.ts`
- `bun test apps/dashboard/src/deploy.test.ts apps/dashboard/docker-compose.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` — 0 errors, existing warnings only

Closes #688.
