### PR TITLE
fix(dashboard): remove release dispatch fuse

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -1,4 +1,4 @@
-# Dispatch input contract (dashboard-release-dispatch-v1):
+# Dispatch input contract:
 #
 #   version          CalVer string (YYYY.MM.N, e.g. 2026.06.47). Optional.
 #                    When set, the deploy resolves the GHCR image digest,
@@ -10,13 +10,9 @@
 #                    When set alongside `version`, the resolved digest must
 #                    match this value exactly — mismatch fails hard.
 #
-#   contract_version Contract fuse. Must equal "dashboard-release-dispatch-v1"
-#                    when any versioned-release input (version, digest, OR
-#                    contract_version itself) is non-empty. Prevents stale or
-#                    accidental dispatch payloads from deploying.
-#
-# No-version fallback: omit all three inputs (or leave empty). The committed
+# No-version fallback: omit both inputs (or leave empty). The committed
 # docker-compose.yaml digest is the source of truth; no audit PR is opened.
+#
 
 name: Deploy Dashboard
 
@@ -35,11 +31,6 @@ on:
         required: false
         type: string
         default: ''
-      contract_version:
-        description: 'Contract fuse — must be "dashboard-release-dispatch-v1" when version, digest, or contract_version is set.'
-        required: false
-        type: string
-        default: ''
   workflow_call:
     inputs:
       version:
@@ -49,11 +40,6 @@ on:
         default: ''
       digest:
         description: Expected sha256 digest (e.g. sha256:abc...). Leave empty to skip cross-check.
-        required: false
-        type: string
-        default: ''
-      contract_version:
-        description: 'Contract fuse — must be "dashboard-release-dispatch-v1" when version, digest, or contract_version is set.'
         required: false
         type: string
         default: ''
@@ -127,25 +113,11 @@ jobs:
             exit 1
           fi
 
-      - name: Validate contract fuse
-        if: inputs.version != '' || inputs.digest != '' || inputs.contract_version != ''
-        env:
-          INPUT_CONTRACT_VERSION: ${{ inputs.contract_version }}
-        run: |
-          contract="${INPUT_CONTRACT_VERSION}"
-          expected="dashboard-release-dispatch-v1"
-          if [[ "$contract" != "$expected" ]]; then
-            echo "Release dispatch contract mismatch."
-            printf 'Expected contract_version=%q but got %q.\n' "$expected" "$contract"
-            printf 'Set contract_version to %q when dispatching a versioned release.\n' "$expected"
-            exit 1
-          fi
-
       - name: Validate input mode
-        if: inputs.version == '' && (inputs.digest != '' || inputs.contract_version != '')
+        if: inputs.version == '' && inputs.digest != ''
         run: |
-          echo "Invalid deploy input mode: version is required when digest or contract_version is set."
-          echo "Either omit all inputs (no-version fallback) or provide version + contract_version=dashboard-release-dispatch-v1."
+          echo "Invalid deploy input mode: version is required when digest is set."
+          echo "Either omit all inputs (no-version fallback) or provide version (+ optional digest)."
           exit 1
 
   deploy-dashboard:
@@ -217,7 +189,6 @@ jobs:
           GATEWAY_VPC_IP: ${{ secrets.GATEWAY_VPC_IP }}
           DEPLOY_VERSION: ${{ inputs.version }}
           DEPLOY_DIGEST: ${{ inputs.digest }}
-          DEPLOY_CONTRACT_VERSION: ${{ inputs.contract_version }}
         run: bun run --cwd apps/dashboard deploy
 
       - name: Open audit PR for compose pin

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -10,9 +10,7 @@ import {
   deploy,
   generateComposeContent,
   parseComposeImageDigest,
-  RELEASE_CONTRACT_VERSION,
   validateCalVer,
-  validateContractVersion,
   validateEnv,
   validateGatewayVpcIp,
   validateSecretValue,
@@ -1535,49 +1533,6 @@ describe('validateCalVer', () => {
   })
 })
 
-// ─── validateContractVersion ──────────────────────────────────────────────────
-
-describe('validateContractVersion', () => {
-  it('passes when contract matches the expected constant and version is set', () => {
-    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '2026.06.15', '')).not.toThrow()
-  })
-
-  it('passes when contract matches and digest is set', () => {
-    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '', `sha256:${'a'.repeat(64)}`)).not.toThrow()
-  })
-
-  it('passes when contract matches and both version and digest are set', () => {
-    expect(() =>
-      validateContractVersion(RELEASE_CONTRACT_VERSION, '2026.06.15', `sha256:${'a'.repeat(64)}`),
-    ).not.toThrow()
-  })
-
-  it('passes when all inputs are empty (no-version fallback — contract not required)', () => {
-    expect(() => validateContractVersion('', '', '')).not.toThrow()
-  })
-
-  it('throws when version is set but contract is empty', () => {
-    expect(() => validateContractVersion('', '2026.06.15', '')).toThrow(/contract/)
-  })
-
-  it('throws when digest is set but contract is empty', () => {
-    expect(() => validateContractVersion('', '', `sha256:${'a'.repeat(64)}`)).toThrow(/contract/)
-  })
-
-  it('throws when contract is wrong (version set)', () => {
-    expect(() => validateContractVersion('wrong-contract', '2026.06.15', '')).toThrow(/contract/)
-  })
-
-  it('throws when contract is wrong (digest set)', () => {
-    expect(() => validateContractVersion('wrong-contract', '', `sha256:${'a'.repeat(64)}`)).toThrow(/contract/)
-  })
-
-  it('RELEASE_CONTRACT_VERSION is a stable non-empty string', () => {
-    expect(typeof RELEASE_CONTRACT_VERSION).toBe('string')
-    expect(RELEASE_CONTRACT_VERSION.length).toBeGreaterThan(0)
-  })
-})
-
 // ─── generateComposeContent ───────────────────────────────────────────────────
 
 describe('generateComposeContent', () => {
@@ -1613,7 +1568,7 @@ describe('generateComposeContent', () => {
 
 // ─── versioned deploy path ────────────────────────────────────────────────────
 //
-// When version + contractVersion are provided:
+// When version is provided:
 // - resolves digest via `docker buildx imagetools inspect`
 // - compares resolved digest to dispatched digest (if provided)
 // - generates compose content with version@resolvedDigest
@@ -1677,43 +1632,8 @@ describe('versioned deploy path', () => {
         resolve: resolvesOk,
         fetch: fetchHealthzOk,
         version: 'latest',
-        contractVersion: RELEASE_CONTRACT_VERSION,
       }),
     ).rejects.toThrow(/version/)
-
-    expect(calls).toHaveLength(0)
-  })
-
-  it('rejects missing contract when version is set, before any SSH/spawn', async () => {
-    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
-
-    await expect(
-      deploy({
-        env: VALID_ENV,
-        spawn: spawnFn,
-        resolve: resolvesOk,
-        fetch: fetchHealthzOk,
-        version: '2026.06.47',
-        contractVersion: '',
-      }),
-    ).rejects.toThrow(/contract/)
-
-    expect(calls).toHaveLength(0)
-  })
-
-  it('rejects wrong contract when version is set, before any SSH/spawn', async () => {
-    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
-
-    await expect(
-      deploy({
-        env: VALID_ENV,
-        spawn: spawnFn,
-        resolve: resolvesOk,
-        fetch: fetchHealthzOk,
-        version: '2026.06.47',
-        contractVersion: 'wrong-contract-v99',
-      }),
-    ).rejects.toThrow(/contract/)
 
     expect(calls).toHaveLength(0)
   })
@@ -1730,7 +1650,6 @@ describe('versioned deploy path', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: wrongDispatchedDigest,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -1738,7 +1657,7 @@ describe('versioned deploy path', () => {
     ).rejects.toThrow(/digest/)
   })
 
-  it('completes successfully with valid version + matching digest + correct contract', async () => {
+  it('completes successfully with valid version + matching digest', async () => {
     const {spawnFn} = makeFakeSpawn(makeVersionedHappyPathResponses())
 
     await expect(
@@ -1749,7 +1668,6 @@ describe('versioned deploy path', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -1767,7 +1685,6 @@ describe('versioned deploy path', () => {
       fetch: fetchHealthzOk,
       version: '2026.06.47',
       digest: RESOLVED_DIGEST,
-      contractVersion: RELEASE_CONTRACT_VERSION,
       probeAttempts: 1,
       probeIntervalMs: 0,
       sleep: async () => {},
@@ -1792,7 +1709,6 @@ describe('versioned deploy path', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -1816,7 +1732,6 @@ describe('versioned deploy path', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -1834,7 +1749,6 @@ describe('versioned deploy path', () => {
       fetch: fetchHealthzOk,
       version: '2026.06.47',
       digest: RESOLVED_DIGEST,
-      contractVersion: RELEASE_CONTRACT_VERSION,
       probeAttempts: 1,
       probeIntervalMs: 0,
       sleep: async () => {},
@@ -1857,7 +1771,6 @@ describe('versioned deploy path', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: '',
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -1916,7 +1829,7 @@ describe('no-version fallback', () => {
     expect(generatedComposeWrite).toBeUndefined()
   })
 
-  it('succeeds without version, digest, or contractVersion', async () => {
+  it('succeeds without version or digest', async () => {
     const {spawnFn} = makeFakeSpawn(makeHappyPathResponses())
 
     await expect(
@@ -1930,46 +1843,6 @@ describe('no-version fallback', () => {
         sleep: async () => {},
       }),
     ).resolves.toBeUndefined()
-  })
-})
-
-// ─── Gap 2: validateContractVersion with contract_version alone ───────────────
-//
-// The fuse must trigger when ANY versioned-release input is non-empty:
-// version, digest, OR contract_version. Previously only version/digest were
-// checked, so a stale payload with only contract_version set would slip through.
-
-describe('validateContractVersion: contract_version alone triggers fuse', () => {
-  it('throws when contract_version is non-empty but wrong, with version and digest empty', () => {
-    // contract_version alone is a versioned-release input — wrong value must fail
-    expect(() => validateContractVersion('wrong-contract', '', '')).toThrow(/contract/)
-  })
-
-  it('throws when contract_version is non-empty but wrong (stale payload)', () => {
-    expect(() => validateContractVersion('dashboard-release-dispatch-v0', '', '')).toThrow(/contract/)
-  })
-
-  it('passes when contract_version alone equals RELEASE_CONTRACT_VERSION', () => {
-    // A dispatch with only contract_version set (no version/digest) is unusual but valid
-    expect(() => validateContractVersion(RELEASE_CONTRACT_VERSION, '', '')).not.toThrow()
-  })
-
-  it('deploy() rejects wrong contract_version alone before any SSH/spawn', async () => {
-    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
-
-    await expect(
-      deploy({
-        env: VALID_ENV,
-        spawn: spawnFn,
-        resolve: resolvesOk,
-        fetch: fetchHealthzOk,
-        version: '',
-        digest: '',
-        contractVersion: 'stale-contract-v0',
-      }),
-    ).rejects.toThrow(/contract/)
-
-    expect(calls).toHaveLength(0)
   })
 })
 
@@ -2007,7 +1880,6 @@ describe('versioned deploy: writes local compose path after successful deploy', 
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         localComposePath: tmpComposePath,
         probeAttempts: 1,
         probeIntervalMs: 0,
@@ -2040,7 +1912,6 @@ describe('versioned deploy: writes local compose path after successful deploy', 
           fetch: fetchHealthzOk,
           version: '2026.06.47',
           digest: wrongDispatchedDigest, // mismatch → throws before deploy
-          contractVersion: RELEASE_CONTRACT_VERSION,
           localComposePath: tmpComposePath,
           probeAttempts: 1,
           probeIntervalMs: 0,
@@ -2104,7 +1975,6 @@ describe('versioned deploy: writes local compose path after successful deploy', 
           fetch: fetchHealthzOk,
           version: '2026.06.47',
           digest: RESOLVED_DIGEST,
-          contractVersion: RELEASE_CONTRACT_VERSION,
           localComposePath: tmpComposePath,
           probeAttempts: 1,
           probeIntervalMs: 0,
@@ -2125,10 +1995,9 @@ describe('versioned deploy: writes local compose path after successful deploy', 
 //
 // Valid modes:
 //   a) all release inputs empty => no-version fallback
-//   b) version (CalVer) + contract_version === RELEASE_CONTRACT_VERSION + optional digest
+//   b) version (CalVer) + optional digest
 //
-// Invalid: digest without version, contract_version without version (even correct contract),
-//          malformed digest, malformed version.
+// Invalid: digest without version, malformed digest, malformed version.
 
 describe('explicit input mode validation', () => {
   it('rejects digest-only (no version) before any SSH/spawn', async () => {
@@ -2142,25 +2011,6 @@ describe('explicit input mode validation', () => {
         fetch: fetchHealthzOk,
         version: '',
         digest: FAKE_DIGEST,
-        contractVersion: '',
-      }),
-    ).rejects.toThrow(/contract|version|mode/)
-
-    expect(calls).toHaveLength(0)
-  })
-
-  it('rejects correct contract_version alone (no version) before any SSH/spawn', async () => {
-    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
-
-    await expect(
-      deploy({
-        env: VALID_ENV,
-        spawn: spawnFn,
-        resolve: resolvesOk,
-        fetch: fetchHealthzOk,
-        version: '',
-        digest: '',
-        contractVersion: RELEASE_CONTRACT_VERSION,
       }),
     ).rejects.toThrow(/version|mode/)
 
@@ -2178,7 +2028,6 @@ describe('explicit input mode validation', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: 'sha256:tooshort',
-        contractVersion: RELEASE_CONTRACT_VERSION,
       }),
     ).rejects.toThrow(/digest/)
 
@@ -2196,7 +2045,6 @@ describe('explicit input mode validation', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: 'a'.repeat(64),
-        contractVersion: RELEASE_CONTRACT_VERSION,
       }),
     ).rejects.toThrow(/digest/)
 
@@ -2214,30 +2062,11 @@ describe('explicit input mode validation', () => {
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: '',
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
       }),
     ).resolves.toBeUndefined()
-  })
-
-  it('rejects digest-only + correct contract (no version) before any SSH/spawn', async () => {
-    const {spawnFn, calls} = makeFakeSpawn([makeSpawnResult()])
-
-    await expect(
-      deploy({
-        env: VALID_ENV,
-        spawn: spawnFn,
-        resolve: resolvesOk,
-        fetch: fetchHealthzOk,
-        version: '',
-        digest: FAKE_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
-      }),
-    ).rejects.toThrow(/version|mode/)
-
-    expect(calls).toHaveLength(0)
   })
 })
 
@@ -2305,7 +2134,6 @@ describe('resolveImageDigest: fallback Digest: output and unparseable output', (
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},
@@ -2327,7 +2155,6 @@ describe('resolveImageDigest: fallback Digest: output and unparseable output', (
         fetch: fetchHealthzOk,
         version: '2026.06.47',
         digest: RESOLVED_DIGEST,
-        contractVersion: RELEASE_CONTRACT_VERSION,
         probeAttempts: 1,
         probeIntervalMs: 0,
         sleep: async () => {},

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -6,20 +6,6 @@ import {join} from 'node:path'
 
 import {validateDashboardHost} from './host'
 
-// ─── Release dispatch contract ────────────────────────────────────────────────
-
-/**
- * Contract version fuse for versioned release dispatches.
- *
- * When any versioned-release input (version, digest, or contract_version) is
- * non-empty, the dispatched contract_version must match this constant exactly.
- * This prevents accidental or stale dispatch payloads from deploying.
- *
- * The value is intentionally stable — bump it only when the dispatch contract
- * itself changes in a breaking way.
- */
-export const RELEASE_CONTRACT_VERSION = 'dashboard-release-dispatch-v1'
-
 // ─── Remote paths ─────────────────────────────────────────────────────────────
 
 const REMOTE_DIR = '/opt/dashboard'
@@ -90,11 +76,6 @@ export interface DeployOpts {
    */
   digest?: string
   /**
-   * Contract version fuse — must equal RELEASE_CONTRACT_VERSION when any
-   * versioned-release input (version, digest, or contractVersion) is non-empty.
-   */
-  contractVersion?: string
-  /**
    * Local path to write the updated docker-compose.yaml after a successful
    * versioned deploy. When omitted, no local file is written — callers that
    * need the write (production entry point, tests asserting the write) must
@@ -142,28 +123,6 @@ export function validateCalVer(version: string): void {
   }
 }
 
-/**
- * Validates the release dispatch contract fuse.
- *
- * When any versioned-release input (version, digest, or contractVersion) is
- * non-empty, contractVersion must match RELEASE_CONTRACT_VERSION exactly.
- * When all inputs are empty (no-version fallback), no contract is required.
- *
- * @throws {Error} when versioned inputs are present but contract is missing or wrong.
- */
-export function validateContractVersion(contractVersion: string, version: string, digest: string): void {
-  const hasVersionedInput = Boolean(version || digest || contractVersion)
-  if (!hasVersionedInput) return
-
-  if (!contractVersion || contractVersion !== RELEASE_CONTRACT_VERSION) {
-    throw new Error(
-      `Release dispatch contract mismatch. ` +
-        `Expected contract_version="${RELEASE_CONTRACT_VERSION}" but got "${contractVersion}". ` +
-        `Set contract_version to "${RELEASE_CONTRACT_VERSION}" when dispatching a versioned release.`,
-    )
-  }
-}
-
 // sha256 digest: exactly "sha256:" followed by 64 lowercase hex characters.
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
 
@@ -171,31 +130,29 @@ const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
  * Validates the explicit input mode for a deploy invocation.
  *
  * Valid modes:
- *   a) All release inputs empty (version, digest, contractVersion) — no-version fallback.
- *   b) version (CalVer) + contractVersion === RELEASE_CONTRACT_VERSION + optional digest.
+ *   a) All release inputs empty (version, digest) — no-version fallback.
+ *   b) version (CalVer) + optional digest.
  *
  * Invalid:
  *   - digest without version (digest-only)
- *   - contractVersion without version (contract-only, even if correct)
  *   - malformed digest (must match ^sha256:[0-9a-f]{64}$)
  *
  * This is enforced before env validation and SSH so the error is surfaced early.
  *
  * @throws {Error} when the input combination is invalid.
  */
-export function validateInputMode(version: string, digest: string, contractVersion: string): void {
+export function validateInputMode(version: string, digest: string): void {
   const hasVersion = Boolean(version)
   const hasDigest = Boolean(digest)
-  const hasContract = Boolean(contractVersion)
 
   // Mode (a): all empty — no-version fallback, nothing to validate here.
-  if (!hasVersion && !hasDigest && !hasContract) return
+  if (!hasVersion && !hasDigest) return
 
-  // Mode (b) requires version. Reject digest-only and contract-only.
+  // Mode (b) requires version. Reject digest-only.
   if (!hasVersion) {
     throw new Error(
-      `Invalid deploy input mode: version is required when digest or contract_version is set. ` +
-        `Either omit all inputs (no-version fallback) or provide version + contract_version="${RELEASE_CONTRACT_VERSION}".`,
+      `Invalid deploy input mode: version is required when digest is set. ` +
+        `Either omit all inputs (no-version fallback) or provide version with an optional digest.`,
     )
   }
 
@@ -698,8 +655,8 @@ async function resolveImageDigest(version: string, spawnFn: SpawnFn, deployEnv: 
  *
  * Two modes:
  *
- * **Versioned path** (version + contractVersion provided):
- *   Pre-gate: validate CalVer, validate contract fuse (no secrets required).
+ * **Versioned path** (version provided):
+ *   Pre-gate: validate CalVer and digest shape (no secrets required).
  *   Then: resolve digest via `docker buildx imagetools inspect`, cross-check
  *   against dispatched digest (if provided), generate compose content pinned to
  *   version@resolvedDigest, upload via SSH stdin.
@@ -708,7 +665,7 @@ async function resolveImageDigest(version: string, spawnFn: SpawnFn, deployEnv: 
  *   Read digest from committed docker-compose.yaml; scp the committed file.
  *
  * Order of operations:
- * 1. Pre-gate: validate contract fuse + CalVer (no secrets, before environment gate)
+ * 1. Pre-gate: validate input mode, digest shape, and CalVer
  * 2. Validate env (throws before any SSH on failure)
  * 3. Validate host (SSH argv injection defense)
  * 4. DNS preflight
@@ -740,7 +697,6 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
   const probeIntervalMs = opts.probeIntervalMs ?? 5_000
   const version = opts.version ?? ''
   const dispatchedDigest = opts.digest ?? ''
-  const contractVersion = opts.contractVersion ?? ''
   // localComposePath: when provided, the versioned deploy writes the generated
   // compose content back here after success (for the workflow audit PR step).
   // When undefined, the write is skipped — callers that need the write (production
@@ -750,11 +706,8 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
   // ── Pre-gate: no-secret validation (runs before environment gate) ──────────
   // These checks require no secrets and can run before the environment gate.
 
-  // Input mode: enforce valid combinations before contract/CalVer checks.
-  validateInputMode(version, dispatchedDigest, contractVersion)
-
-  // Contract fuse: if any versioned-release input is present, contract must match.
-  validateContractVersion(contractVersion, version, dispatchedDigest)
+  // Input mode: enforce valid combinations before CalVer checks.
+  validateInputMode(version, dispatchedDigest)
 
   // CalVer validation: reject invalid version strings before any SSH/spawn.
   if (version) {
@@ -1166,7 +1119,6 @@ if (import.meta.main) {
   deploy({
     version: process.env.DEPLOY_VERSION ?? '',
     digest: process.env.DEPLOY_DIGEST ?? '',
-    contractVersion: process.env.DEPLOY_CONTRACT_VERSION ?? '',
     // Pass the committed compose path explicitly so the versioned deploy writes
     // the updated pin back for the workflow's audit PR step.
     localComposePath: join(import.meta.dir, '..', 'docker-compose.yaml'),

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1224,9 +1224,9 @@ describe('deploy.yaml: deploy-dashboard is decoupled from deploy-gateway', () =>
 // ─── deploy-dashboard.yaml: dispatch/call inputs and job structure ────────────
 //
 // Verifies the workflow contract for the dashboard release dispatch:
-// - dispatch/call inputs version, digest, contract_version with defaults
+// - dispatch/call inputs version and digest with defaults
 // - validate-inputs job exists and deploy-dashboard needs it
-// - deploy step forwards DEPLOY_VERSION, DEPLOY_DIGEST, DEPLOY_CONTRACT_VERSION
+// - deploy step forwards DEPLOY_VERSION, DEPLOY_DIGEST
 // - no direct ${{ inputs.* }} interpolation inside run: script bodies
 // - audit path does not push to HEAD:main and uses a PR branch/gh pr create
 // - deploy router dashboard job skips audit pin commits on push but not workflow_dispatch
@@ -1262,18 +1262,22 @@ describe('deploy-dashboard.yaml: dispatch/call inputs and job structure', () => 
     expect(parsed.on?.workflow_call?.inputs?.digest?.default).toBe('')
   })
 
-  it('workflow_dispatch and workflow_call both declare contract_version input with default empty string', async () => {
+  it('does not declare or forward the removed release fuse input', async () => {
     const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const removedInputName = ['contract', 'version'].join('_')
+    const removedEnvName = ['DEPLOY', 'CONTRACT', 'VERSION'].join('_')
     const parsed = parseYaml(text) as {
       on?: {
-        workflow_dispatch?: {inputs?: Record<string, {default?: unknown}>}
-        workflow_call?: {inputs?: Record<string, {default?: unknown}>}
+        workflow_dispatch?: {inputs?: Record<string, unknown>}
+        workflow_call?: {inputs?: Record<string, unknown>}
       }
+      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
     }
-    expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty('contract_version')
-    expect(parsed.on?.workflow_dispatch?.inputs?.contract_version?.default).toBe('')
-    expect(parsed.on?.workflow_call?.inputs).toHaveProperty('contract_version')
-    expect(parsed.on?.workflow_call?.inputs?.contract_version?.default).toBe('')
+    const deployStep = parsed.jobs?.['deploy-dashboard']?.steps?.find(step => step.name === 'Deploy')
+
+    expect(parsed.on?.workflow_dispatch?.inputs).not.toHaveProperty(removedInputName)
+    expect(parsed.on?.workflow_call?.inputs).not.toHaveProperty(removedInputName)
+    expect(deployStep?.env).not.toHaveProperty(removedEnvName)
   })
 
   it('validate-inputs job exists', async () => {
@@ -1312,18 +1316,6 @@ describe('deploy-dashboard.yaml: dispatch/call inputs and job structure', () => 
     expect(deployStep).toBeDefined()
     expect(deployStep?.env).toHaveProperty('DEPLOY_DIGEST')
     expect(deployStep?.env?.DEPLOY_DIGEST).toContain('inputs.digest')
-  })
-
-  it('Deploy step env forwards DEPLOY_CONTRACT_VERSION from inputs', async () => {
-    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
-    const parsed = parseYaml(text) as {
-      jobs?: {'deploy-dashboard'?: {steps?: {name?: string; env?: Record<string, string>}[]}}
-    }
-    const steps = parsed.jobs?.['deploy-dashboard']?.steps ?? []
-    const deployStep = steps.find(s => s.name === 'Deploy')
-    expect(deployStep).toBeDefined()
-    expect(deployStep?.env).toHaveProperty('DEPLOY_CONTRACT_VERSION')
-    expect(deployStep?.env?.DEPLOY_CONTRACT_VERSION).toContain('inputs.contract_version')
   })
 
   it('no direct inputs.* interpolation inside run: script bodies', async () => {


### PR DESCRIPTION
## Summary

Removes the dashboard release dispatch fuse so versioned deploys use the simpler input surface:

- `version` for the CalVer release to deploy
- optional `digest` for GHCR digest cross-checking

The deploy workflow no longer declares, forwards, validates, or documents the removed fuse input. The TypeScript deploy entry point now validates only the actual deploy inputs: version and optional digest.

## Verification

- `grep -R -n -E 'contract_version|RELEASE_CONTRACT_VERSION|DEPLOY_CONTRACT_VERSION|contractVersion|validateContractVersion|dashboard-release-dispatch-v1' .github/workflows/deploy-dashboard.yaml apps/dashboard/src/deploy.ts apps/dashboard/src/deploy.test.ts packages/cli/src/conventions.test.ts` returns no matches
- `bun test packages/cli/src/conventions.test.ts apps/dashboard/src/deploy.test.ts apps/dashboard/docker-compose.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
