### PR TITLE
feat(dashboard): add versioned deploy flags

### DIFF
--- a/.changeset/dashboard-deploy-version-digest.md
+++ b/.changeset/dashboard-deploy-version-digest.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Add `--image-version` and `--digest` flags to `infra dashboard deploy` for versioned remote workflow dispatch.

--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -130,7 +130,7 @@ For rollback procedures, see [`docs/runbooks/dashboard-released-image-rollback.m
 | Command                                    | Purpose                                                                    |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
 | `infra dashboard status`                   | SSH `docker compose ps` → service/state/health rows (MCP-exposed)          |
-| `infra dashboard deploy`                   | Dispatch the Deploy Dashboard workflow (default) or `--local`              |
+| `infra dashboard deploy [--image-version <calver>] [--digest <sha256>]` | Dispatch the Deploy Dashboard workflow (default), optionally with explicit image inputs, or `--local`; image flags are remote-only and `--digest` requires `--image-version` |
 | `infra dashboard logs [service] [--tail N]`| Stream container logs via SSH (CI-guarded; emits a sensitive-data warning) |
 
 `infra status` includes a `dashboard` row (and a `dashboard` key under `--json`).

--- a/docs/plans/2026-06-26-001-feat-dashboard-deploy-version-flags-plan.md
+++ b/docs/plans/2026-06-26-001-feat-dashboard-deploy-version-flags-plan.md
@@ -1,0 +1,187 @@
+---
+title: "feat: Add dashboard deploy version flags"
+type: feat
+status: completed
+date: 2026-06-26
+---
+
+# feat: Add dashboard deploy version flags
+
+## Overview
+
+Add operator-facing `--image-version` and `--digest` flags to `infra dashboard deploy` so the CLI can dispatch the existing Dashboard deploy workflow's versioned release path. The workflow contract already exists; this plan wires the CLI to it without changing MCP exposure or deploy workflow behavior. The CLI flag is `--image-version` because goke reserves root `--version` before subcommand handlers see it.
+
+## Problem Frame
+
+The Dashboard deploy workflow accepts optional `version` and `digest` `workflow_dispatch` inputs, validates them before the environment gate, deploys the selected `ghcr.io/fro-bot/dashboard:<version>` image, and opens an audit PR when a versioned release runs. The CLI currently dispatches the same workflow with no inputs, so CLI and agent-assisted operators can only trigger the no-version fallback unless they drop down to raw `gh workflow run -f` commands.
+
+## Requirements Trace
+
+- R1. `infra dashboard deploy --image-version <YYYY.MM.N>` dispatches the Dashboard workflow with the `version` input.
+- R2. `infra dashboard deploy --image-version <YYYY.MM.N> --digest <sha256:...>` dispatches the workflow with both inputs so the workflow cross-checks the resolved digest.
+- R3. `infra dashboard deploy` with no release flags preserves the current no-version fallback behavior.
+- R4. Invalid CalVer, invalid digest, and digest-without-version fail locally before spawning `gh`.
+- R5. `--local` deploy mode remains unchanged and does not accept remote workflow dispatch flags.
+- R6. `dashboard deploy` remains CLI-only and is not added to the MCP allowlist.
+- R7. Because this changes the published CLI surface, include a patch changeset.
+
+## Scope Boundaries
+
+- Do not modify `.github/workflows/deploy-dashboard.yaml`; it already owns authoritative validation and deployment behavior.
+- Do not add `deploy.yaml` aggregate passthrough inputs.
+- Do not expose `dashboard deploy` over MCP.
+- Do not add `GITHUB_TOKEN`, `GH_TOKEN`, `actions: write`, or a self-dispatch workflow step.
+- Do not change local dashboard deploy semantics beyond rejecting remote-only release flags when `--local` is set.
+
+### Deferred to Separate Tasks
+
+- Package tarball smoke coverage for newly published CLI flags: separate CI/tooling hardening task. It is valuable, but it touches CI/build pipeline policy and is outside this CLI-only follow-up.
+- Authenticated browser/API verification for operator routes: separate operational check; not required for CLI dispatch flags.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/cli/src/commands/dashboard/deploy.ts` registers `dashboard deploy` with goke/Zod options, dry-run output, and remote `gh workflow run` dispatch.
+- `packages/cli/src/commands/dashboard/deploy.test.ts` runs the real CLI entry point in dry-run mode and asserts planned command output.
+- `packages/cli/src/__snapshots__/cli.test.ts.snap` snapshots CLI help output; new flags require snapshot refresh.
+- `apps/dashboard/AGENTS.md` documents dashboard CLI usage and should mention the new flags.
+- `.github/workflows/deploy-dashboard.yaml` declares optional `version` and `digest` inputs and validates them before environment approval.
+- `packages/cli/AGENTS.md` requires goke schema-based options, non-interactive CLI surfaces, and keeps mutating deploy commands out of MCP.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/fro-bot-schedule-session-bloat-no-op-2026-06-14.md`: do not introduce self-dispatch jobs or broaden `GITHUB_TOKEN` permissions to solve dispatch ergonomics.
+- `docs/solutions/workflow-issues/aggregate-deploy-concurrency-cancels-gated-deploys-2026-06-25.md`: keep deploy concurrency at per-app workflows; do not reintroduce aggregate fan-out coupling.
+- `docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md`: digest-pinned deploys need validation and explicit wiring through every entry point.
+- `docs/solutions/integration-issues/gateway-caddy-announce-ingress-self-404-2026-06-04.md`: when adding deploy inputs, ensure every entry point forwards them deliberately; missing one hop creates silent drift.
+
+## Key Technical Decisions
+
+- Use CLI-side validation as fast-fail UX, not as the security boundary. The workflow remains authoritative because operators can still dispatch from GitHub UI or raw `gh`.
+- Build the `gh workflow run` argv conditionally with `-f version=<value>` and `-f digest=<value>` only when values are present. Do not send empty inputs.
+- Reject `--digest` without `--image-version` locally to mirror the workflow input-mode gate.
+- Reject `--image-version` or `--digest` with `--local` because these flags target GitHub Actions dispatch, not the local Bun deploy path.
+- Keep the command out of `MCP_ALLOWLIST`; environment-gated deploy mutation remains CLI-only.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should `--digest` be mandatory when `--image-version` is set? No. The confirmed scope keeps digest optional so the workflow can resolve the digest itself; provided digest is a cross-check.
+- Should the aggregate deploy workflow gain passthrough inputs? No. Confirmed scope is direct `deploy-dashboard.yaml` dispatch from CLI only.
+- Should MCP expose versioned dashboard deploy? No. Confirmed out of scope.
+
+### Deferred to Implementation
+
+- Exact error wording for invalid option combinations: match existing terse CLI style while naming the offending flags.
+
+## Implementation Units
+
+- [x] **Unit 1: Add dashboard deploy release flags**
+
+**Goal:** Extend `infra dashboard deploy` remote mode with validated `--image-version` and `--digest` options that forward to GitHub Actions inputs.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/cli/src/commands/dashboard/deploy.ts`
+- Test: `packages/cli/src/commands/dashboard/deploy.test.ts`
+
+**Approach:**
+- Add Zod-backed string options for `--image-version <version>` and `--digest <digest>` with help text matching the workflow vocabulary.
+- Validate CalVer and digest shape before spawning `gh`.
+- Validate `--digest` requires `--image-version`.
+- Validate release flags are remote-only and rejected when `--local` is set.
+- Refactor remote command construction into a small helper if it keeps dry-run output and spawn argv identical.
+
+**Execution note:** Implement test-first for the new CLI behavior.
+
+**Patterns to follow:**
+- `packages/cli/src/commands/dashboard/deploy.ts` existing dry-run and `Bun.spawn` shape.
+- `packages/cli/src/commands/gateway/deploy.ts` conditional flag argv construction.
+- `.agents/skills/goke/SKILL.md` option schema and help-text rules.
+
+**Test scenarios:**
+- Happy path: no flags dry-run prints the existing `gh workflow run "Deploy Dashboard" --repo marcusrbrown/infra` command and no `-f` inputs.
+- Happy path: `--image-version 2026.06.50 --dry-run` prints `-f version=2026.06.50` and no digest input.
+- Happy path: `--image-version 2026.06.50 --digest sha256:<64 hex> --dry-run` prints both `-f` inputs.
+- Error path: `--digest sha256:<64 hex> --dry-run` exits non-zero with a digest-requires-version message and does not dispatch.
+- Error path: invalid versions such as `latest` or `v1.2.3` are rejected before dispatch.
+- Error path: malformed digests such as `sha256:bad` or `md5:<64 hex>` are rejected before dispatch.
+- Error path: `--local --image-version 2026.06.50 --dry-run` is rejected as a remote-only flag combination.
+
+**Verification:**
+- Dashboard deploy command tests pass and prove dry-run argv mirrors the spawn argv shape.
+
+- [x] **Unit 2: Refresh CLI docs and package metadata**
+
+**Goal:** Keep help snapshots, operator docs, and release metadata in sync with the new CLI surface.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/cli/src/__snapshots__/cli.test.ts.snap`
+- Modify: `apps/dashboard/AGENTS.md`
+- Create: `.changeset/dashboard-deploy-version-digest.md`
+
+**Approach:**
+- Refresh the CLI snapshot after adding the flags.
+- Update the dashboard CLI command table to mention `--image-version` and `--digest` for versioned workflow dispatch.
+- Add a patch changeset because this changes the published `@marcusrbrown/infra` CLI surface.
+- Leave `packages/cli/src/commands/mcp.ts` unchanged.
+
+**Execution note:** Snapshot update follows the implementation test change; do not hand-edit snapshot output unless the test runner cannot update it.
+
+**Patterns to follow:**
+- Existing `.changeset/*.md` one-line patch entries.
+- Existing `apps/dashboard/AGENTS.md` CLI command table wording.
+
+**Test scenarios:**
+- Happy path: root CLI help snapshot includes the new dashboard deploy options.
+- Integration: no MCP allowlist change occurs; `dashboard deploy` remains absent from MCP.
+
+**Verification:**
+- CLI snapshot tests pass.
+- Grep confirms no `dashboard deploy` MCP allowlist addition.
+
+## System-Wide Impact
+
+- **Interaction graph:** CLI `dashboard deploy` → `gh workflow run Deploy Dashboard` → existing workflow pre-gate validation → dashboard environment approval → deploy/audit PR. Only the CLI entry point changes.
+- **Error propagation:** CLI validation failures should exit before `gh`; workflow validation remains the second gate for non-CLI dispatches.
+- **State lifecycle risks:** No local state mutation. Versioned dispatch can create an audit PR via existing workflow behavior.
+- **API surface parity:** GitHub UI/raw `gh` and CLI now have equivalent access to `version` and `digest` inputs; MCP intentionally remains read-only for dashboard deploy.
+- **Unchanged invariants:** No `GITHUB_TOKEN` dispatch shim, no aggregate deploy concurrency changes, no deploy workflow contract changes.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| CLI and workflow validation drift | Keep workflow authoritative; CLI regex mirrors workflow contract and tests cover representative invalid values. |
+| Accidental empty-string inputs sent to GitHub Actions | Build `-f` argv only for non-empty values. |
+| Local deploy semantics become ambiguous | Reject release flags with `--local` rather than silently ignoring them. |
+| Published package drift | Add changeset now; defer tarball smoke CI to separate approved tooling work. |
+
+## Documentation / Operational Notes
+
+- `infra dashboard deploy --image-version 2026.06.50` triggers the versioned release path and requires dashboard environment approval.
+- Adding `--digest sha256:<64 hex>` makes the workflow fail if GHCR resolves the tag to a different digest.
+- Omit both flags to use the committed compose pin.
+
+## Sources & References
+
+- `packages/cli/src/commands/dashboard/deploy.ts`
+- `packages/cli/src/commands/dashboard/deploy.test.ts`
+- `packages/cli/src/__snapshots__/cli.test.ts.snap`
+- `apps/dashboard/AGENTS.md`
+- `.github/workflows/deploy-dashboard.yaml`
+- `packages/cli/AGENTS.md`
+- `.agents/skills/goke/SKILL.md`
+- `docs/solutions/workflow-issues/fro-bot-schedule-session-bloat-no-op-2026-06-14.md`
+- `docs/solutions/workflow-issues/aggregate-deploy-concurrency-cancels-gated-deploys-2026-06-25.md`
+- `docs/solutions/best-practices/off-droplet-docker-image-build-gateway-deploy-2026-06-04.md`
+- `docs/solutions/integration-issues/gateway-caddy-announce-ingress-self-404-2026-06-04.md`

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -160,6 +160,8 @@ Commands:
 
     --local                            Run local deployment with Bun using apps/dashboard instead of triggering GitHub Actions. (default: false)
     --dry-run                          Validate deploy prerequisites and print planned actions without executing local deploy or dispatching workflow. (default: false)
+    --image-version <version>          CalVer version to deploy (e.g. 2026.06.47). Remote-only. Triggers the versioned release path and requires dashboard environment approval. Must match YYYY.MM.N. Forwarded as -f version=<value> to gh workflow run.
+    --digest <digest>                  Expected sha256 digest (e.g. sha256:abc...def). Remote-only. Requires --image-version. When set, the workflow fails if GHCR resolves the tag to a different digest. Must match sha256:<64 hex chars>.
 
 
   dashboard logs [service]             Stream logs from a dashboard service via SSH and docker compose.

--- a/packages/cli/src/commands/dashboard/deploy.test.ts
+++ b/packages/cli/src/commands/dashboard/deploy.test.ts
@@ -124,8 +124,6 @@ describe('getDashboardDeployEnv', () => {
 
     expect(env.DASHBOARD_SSH_KEY).toBe('ssh-ed25519 AAAA...')
     expect('SSH_AUTH_SOCK' in env).toBe(false)
-    expect(env.DASHBOARD_SSH_KEY).toBe('ssh-ed25519 AAAA...')
-    expect('SSH_AUTH_SOCK' in env).toBe(false)
   })
 
   it('forwards all DASHBOARD_* vars from process.env (not a selective subset)', () => {
@@ -191,7 +189,9 @@ describe('deploy command', () => {
 
     expect(exitCode).toBe(0)
     expect(stdout).toContain('Dry run')
-    expect(stdout).toContain('Deploy Dashboard')
+    expect(stdout).toContain('gh workflow run "Deploy Dashboard" --repo marcusrbrown/infra')
+    expect(stdout).not.toContain('-f version=')
+    expect(stdout).not.toContain('-f digest=')
   })
 
   it('dry-run local mode prints planned bun command without executing', async () => {
@@ -211,5 +211,306 @@ describe('deploy command', () => {
     expect(exitCode).toBe(0)
     expect(stdout).toContain('Dry run')
     expect(stdout).toContain('apps/dashboard')
+  })
+
+  it('dry-run remote with --image-version prints -f version= in planned command', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--image-version', '2026.06.50', '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Deploy Dashboard')
+    expect(stdout).toContain('-f version=2026.06.50')
+    expect(stdout).not.toContain('-f digest=')
+  })
+
+  it('dry-run remote with --image-version and --digest prints both -f entries in planned command', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`
+    const proc = Bun.spawn(
+      [
+        'bun',
+        'run',
+        'packages/cli/src/cli.ts',
+        'dashboard',
+        'deploy',
+        '--image-version',
+        '2026.06.50',
+        '--digest',
+        digest,
+        '--dry-run',
+      ],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Deploy Dashboard')
+    expect(stdout).toContain('-f version=2026.06.50')
+    expect(stdout).toContain(`-f digest=${digest}`)
+  })
+
+  it('rejects --digest without --image-version with a non-zero exit and helpful message', async () => {
+    const digest = `sha256:${'b'.repeat(64)}`
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--digest', digest, '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('--digest requires --image-version')
+  })
+
+  it('rejects --image-version without a value', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--image-version', '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('image-version')
+  })
+
+  it('rejects --digest without a value', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--digest', '--dry-run'], {
+      cwd: repoRoot,
+      env: {...process.env, NO_COLOR: '1'},
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('digest')
+  })
+
+  it('rejects an invalid CalVer image version before dispatching', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--image-version', 'latest', '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('Invalid version')
+  })
+
+  it('rejects a semver image version string before dispatching', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--image-version', 'v1.2.3', '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('Invalid version')
+  })
+
+  it('rejects a malformed digest (too short) before dispatching', async () => {
+    const proc = Bun.spawn(
+      [
+        'bun',
+        'run',
+        'packages/cli/src/cli.ts',
+        'dashboard',
+        'deploy',
+        '--image-version',
+        '2026.06.50',
+        '--digest',
+        'sha256:bad',
+        '--dry-run',
+      ],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('Invalid digest')
+  })
+
+  it('rejects digest without image-version before checking digest shape', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--digest', 'sha256:bad', '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('--digest requires --image-version')
+  })
+
+  it('rejects a non-sha256 digest algorithm before dispatching', async () => {
+    const proc = Bun.spawn(
+      [
+        'bun',
+        'run',
+        'packages/cli/src/cli.ts',
+        'dashboard',
+        'deploy',
+        '--image-version',
+        '2026.06.50',
+        '--digest',
+        `md5:${'c'.repeat(64)}`,
+        '--dry-run',
+      ],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('Invalid digest')
+  })
+
+  it('rejects --image-version with --local as a remote-only flag combination', async () => {
+    const proc = Bun.spawn(
+      [
+        'bun',
+        'run',
+        'packages/cli/src/cli.ts',
+        'dashboard',
+        'deploy',
+        '--local',
+        '--image-version',
+        '2026.06.50',
+        '--dry-run',
+      ],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('--local')
+    expect(stderr).toContain('--image-version')
+  })
+
+  it('rejects --digest with --local as a remote-only flag combination', async () => {
+    const digest = `sha256:${'d'.repeat(64)}`
+    const proc = Bun.spawn(
+      ['bun', 'run', 'packages/cli/src/cli.ts', 'dashboard', 'deploy', '--local', '--digest', digest, '--dry-run'],
+      {
+        cwd: repoRoot,
+        env: {...process.env, NO_COLOR: '1'},
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('--local')
+    expect(stderr).toContain('--digest')
   })
 })

--- a/packages/cli/src/commands/dashboard/deploy.ts
+++ b/packages/cli/src/commands/dashboard/deploy.ts
@@ -11,7 +11,61 @@ const REPO = 'marcusrbrown/infra'
 const WORKFLOW_NAME = 'Deploy Dashboard'
 const WORKFLOW_URL = 'https://github.com/marcusrbrown/infra/actions/workflows/deploy-dashboard.yaml'
 
+// Mirrors the workflow's validate-inputs step regexes exactly.
+const CALVER_RE = /^\d{4}\.\d{2}\.\d+$/
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/
+
 type CliInstance = ReturnType<typeof goke>
+
+// ─── Validation helpers ───────────────────────────────────────────────────────
+
+function validateReleaseFlags(options: {imageVersion?: string; digest?: string; local: boolean}): void {
+  const {imageVersion, digest, local} = options
+
+  if (local && (imageVersion !== undefined || digest !== undefined)) {
+    throw new Error(
+      '--image-version and --digest are remote-only flags and cannot be used with --local. ' +
+        'Remove --local to dispatch the GitHub Actions workflow with release flags.',
+    )
+  }
+
+  if (imageVersion !== undefined && !CALVER_RE.test(imageVersion)) {
+    throw new Error(
+      `Invalid version ${JSON.stringify(imageVersion)}: must match YYYY.MM.N (e.g. 2026.06.47). ` +
+        "Rejected: 'latest', semver, and injection strings are not accepted.",
+    )
+  }
+
+  if (digest !== undefined && imageVersion === undefined) {
+    throw new Error(
+      '--digest requires --image-version. Either omit all release flags (no-version fallback) or provide --image-version (+ optional --digest).',
+    )
+  }
+
+  if (digest !== undefined && !DIGEST_RE.test(digest)) {
+    throw new Error(
+      `Invalid digest ${JSON.stringify(digest)}: must match sha256:<64 hex chars> (e.g. sha256:abc...def). ` +
+        'Rejected: malformed digests are not accepted.',
+    )
+  }
+}
+
+// ─── Remote argv builder ──────────────────────────────────────────────────────
+
+function buildRemoteArgv(options: {imageVersion?: string; digest?: string}): string[] {
+  const argv = ['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO]
+  if (options.imageVersion !== undefined) {
+    argv.push('-f', `version=${options.imageVersion}`)
+  }
+  if (options.digest !== undefined) {
+    argv.push('-f', `digest=${options.digest}`)
+  }
+  return argv
+}
+
+function formatArgv(argv: string[]): string {
+  return argv.map(arg => (/^[\w./:=@-]+$/.test(arg) ? arg : JSON.stringify(arg))).join(' ')
+}
 
 // ─── Env helpers ─────────────────────────────────────────────────────────────
 
@@ -78,13 +132,37 @@ export function registerDashboardDeploy(cli: CliInstance): void {
           'Validate deploy prerequisites and print planned actions without executing local deploy or dispatching workflow.',
         ),
     )
+    .option(
+      '--image-version <version>',
+      z
+        .string()
+        .optional()
+        .describe(
+          'CalVer version to deploy (e.g. 2026.06.47). Remote-only. Triggers the versioned release path and requires dashboard environment approval. Must match YYYY.MM.N. Forwarded as -f version=<value> to gh workflow run.',
+        ),
+    )
+    .option(
+      '--digest <digest>',
+      z
+        .string()
+        .optional()
+        .describe(
+          'Expected sha256 digest (e.g. sha256:abc...def). Remote-only. Requires --image-version. When set, the workflow fails if GHCR resolves the tag to a different digest. Must match sha256:<64 hex chars>.',
+        ),
+    )
     .example('# Trigger remote GitHub Actions deploy (default mode)')
     .example('infra dashboard deploy')
+    .example('# Deploy a specific CalVer release via GitHub Actions')
+    .example('infra dashboard deploy --image-version 2026.06.47')
+    .example('# Deploy a specific release with digest cross-check')
+    .example('infra dashboard deploy --image-version 2026.06.47 --digest sha256:<64 hex>')
     .example('# Validate local deploy preconditions and planned command')
     .example('infra dashboard deploy --local --dry-run')
     .example('# Run local deploy with explicit SSH agent context')
     .example('infra dashboard deploy --local')
     .action(async options => {
+      validateReleaseFlags({imageVersion: options.imageVersion, digest: options.digest, local: options.local})
+
       if (options.local) {
         const command = ['bun', 'run', '--cwd', 'apps/dashboard', 'deploy']
 
@@ -112,14 +190,16 @@ export function registerDashboardDeploy(cli: CliInstance): void {
 
       validateDashboardRemotePreconditions()
 
+      const remoteArgv = buildRemoteArgv({imageVersion: options.imageVersion, digest: options.digest})
+
       if (options.dryRun) {
         console.log('Dry run: remote dashboard deploy')
-        console.log(`- command: gh workflow run "${WORKFLOW_NAME}" --repo ${REPO}`)
+        console.log(`- command: ${formatArgv(remoteArgv)}`)
         console.log(`- workflow URL: ${WORKFLOW_URL}`)
         return
       }
 
-      const child = Bun.spawn(['gh', 'workflow', 'run', WORKFLOW_NAME, '--repo', REPO], {
+      const child = Bun.spawn(remoteArgv, {
         stdout: 'inherit',
         stderr: 'inherit',
       })


### PR DESCRIPTION
## Summary

- Adds `infra dashboard deploy --image-version <calver>` and optional `--digest <sha256>` for versioned Dashboard workflow dispatch.
- Validates CalVer, digest shape, digest-without-version, missing flag values, and remote-only flag combinations before spawning `gh`.
- Keeps the deploy workflow and MCP allowlist unchanged; updates CLI help snapshots, dashboard operator docs, plan status, and adds a patch changeset.

## Testing

- `bun test packages/cli/src/commands/dashboard/deploy.test.ts`
- `bun test packages/cli/src/cli.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` (pre-existing warnings only)
- `bun test --recursive` (`2295 pass`, `0 fail`)
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Expected healthy signal: CI passes and the release workflow publishes the next patch for `@marcusrbrown/infra`.
- Post-release validation: run `bunx @marcusrbrown/infra@latest dashboard deploy --image-version 2026.06.N --dry-run` and confirm the planned command includes `-f version=2026.06.N`.
- Failure signals: CI failure, release failure, missing npm package version, or dry-run output omitting the workflow input flags.
- Runtime monitoring: no live dashboard service monitoring is required until an operator intentionally dispatches a dashboard deploy.
- Owner/window: validate after merge and package release complete.
