### PR TITLE
fix(release): run changeset version under Node to fix GraphQL fetch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,5 +71,5 @@ jobs:
           setupGitUser: false
           commit: 'chore(changesets): version packages'
           title: 'chore(🦋📦): version packages'
-          version: bun run version-changesets
+          version: npm run version-changesets
           publish: bunx changeset publish


### PR DESCRIPTION
## Problem

The Release pipeline has failed three times in a row (runs [28301379375](https://github.com/marcusrbrown/infra/actions/runs/28301379375), [28308404228](https://github.com/marcusrbrown/infra/actions/runs/28308404228) ×2) with:

```
FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
  errno: 'ERR_STREAM_PREMATURE_CLOSE'
  at Gunzip.<anonymous> (node-fetch/lib/index.js:217:52)
```

All three failures happened while GitHub reported "All Systems Operational", so this is reproducible, not a transient blip.

## Root cause

`changeset version` generates changelog entries by associating each pending changeset's commit with its PR through a GitHub GraphQL call. That call runs through `@changesets/get-github-info`, which imports `node-fetch@2` and talks to `node:http`/`node:zlib` directly instead of the runtime's native `fetch`. Under Bun the gzip-decompress (`Gunzip`) stream closes prematurely and the fetch aborts.

The call only happens when a changeset is pending, which is why earlier release runs with nothing to version passed — they never hit the GraphQL path. The current pending changeset (cliproxy `7.2.43`) triggers it every time.

## Fix

Run the version step under Node (`npm run version-changesets`) instead of Bun (`bun run version-changesets`). Node 24 is already set up on the runner, the script and installed dependencies are unchanged, and Node's `node:http`/`zlib` path handles the gzip stream correctly. The `publish` step does not touch the changelog GraphQL path and is left on Bun.

## Verification

Reproduced locally against this branch with Bun-installed `node_modules`:

- `npm run version-changesets` exits 0 and applies the changeset.
- The generated `packages/cli/CHANGELOG.md` entry contains the `[#707](…)` PR link — proof the GraphQL PR-association ran successfully, which is the exact call that dies under Bun.
- `bun run version-changesets` continues to fail with the same `ERR_STREAM_PREMATURE_CLOSE` it fails with in CI.

Convention tests (`packages/cli/src/conventions.test.ts`) pass.
