### PR TITLE
fix(release): patch get-github-info to fix flaky changelog GraphQL fetch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,5 +71,5 @@ jobs:
           setupGitUser: false
           commit: 'chore(changesets): version packages'
           title: 'chore(🦋📦): version packages'
-          version: npm run version-changesets
+          version: bun run version-changesets
           publish: bunx changeset publish

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "packages/cli": {
       "name": "@marcusrbrown/infra",
-      "version": "0.13.10",
+      "version": "0.13.12",
       "bin": {
         "infra": "./dist/cli.js",
       },
@@ -88,6 +88,9 @@
         "zod": "^4.3.6",
       },
     },
+  },
+  "patchedDependencies": {
+    "@changesets/get-github-info@0.6.0": "patches/@changesets%2Fget-github-info@0.6.0.patch",
   },
   "packages": {
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "prettier": "3.8.4",
     "simple-git-hooks": "2.13.1",
     "typescript": "6.0.3"
+  },
+  "patchedDependencies": {
+    "@changesets/get-github-info@0.6.0": "patches/@changesets%2Fget-github-info@0.6.0.patch"
   }
 }

--- a/patches/@changesets%2Fget-github-info@0.6.0.patch
+++ b/patches/@changesets%2Fget-github-info@0.6.0.patch
@@ -1,0 +1,90 @@
+diff --git a/dist/changesets-get-github-info.cjs.js b/dist/changesets-get-github-info.cjs.js
+index a74df59f8a5988f458a3476087399f5e6dfe4818..e6d349a6230c1c5e215899e2bf9718e18e2923f3 100644
+--- a/dist/changesets-get-github-info.cjs.js
++++ b/dist/changesets-get-github-info.cjs.js
+@@ -167,15 +167,31 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
+ 
+     repos[repo].push(data);
+   });
+-  const data = await fetch__default["default"]("https://api.github.com/graphql", {
+-    method: "POST",
+-    headers: {
+-      Authorization: `Token ${process.env.GITHUB_TOKEN}`
+-    },
+-    body: JSON.stringify({
+-      query: makeQuery(repos)
+-    })
+-  }).then(x => x.json());
++  const data = await (async () => {
++    let lastErr;
++    for (let attempt = 0; attempt < 4; attempt++) {
++      try {
++        const res = await fetch__default["default"]("https://api.github.com/graphql", {
++          method: "POST",
++          headers: {
++            Authorization: `Token ${process.env.GITHUB_TOKEN}`
++          },
++          body: JSON.stringify({
++            query: makeQuery(repos)
++          }),
++          compress: false
++        });
++        return await res.json();
++      } catch (err) {
++        lastErr = err;
++        if (attempt < 3) {
++          await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** attempt));
++          continue;
++        }
++      }
++    }
++    throw lastErr;
++  })();
+ 
+   if (data.errors) {
+     throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data.errors, null, 2)}`);
+diff --git a/dist/changesets-get-github-info.esm.js b/dist/changesets-get-github-info.esm.js
+index 27e5c972ab1202ff16f5124b471f4bbcc46be2b5..82d29ae6f23520c58cd842bc6bb626f011c6e0fa 100644
+--- a/dist/changesets-get-github-info.esm.js
++++ b/dist/changesets-get-github-info.esm.js
+@@ -158,15 +158,31 @@ const GHDataLoader = new DataLoader(async requests => {
+ 
+     repos[repo].push(data);
+   });
+-  const data = await fetch("https://api.github.com/graphql", {
+-    method: "POST",
+-    headers: {
+-      Authorization: `Token ${process.env.GITHUB_TOKEN}`
+-    },
+-    body: JSON.stringify({
+-      query: makeQuery(repos)
+-    })
+-  }).then(x => x.json());
++  const data = await (async () => {
++    let lastErr;
++    for (let attempt = 0; attempt < 4; attempt++) {
++      try {
++        const res = await fetch("https://api.github.com/graphql", {
++          method: "POST",
++          headers: {
++            Authorization: `Token ${process.env.GITHUB_TOKEN}`
++          },
++          body: JSON.stringify({
++            query: makeQuery(repos)
++          }),
++          compress: false
++        });
++        return await res.json();
++      } catch (err) {
++        lastErr = err;
++        if (attempt < 3) {
++          await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** attempt));
++          continue;
++        }
++      }
++    }
++    throw lastErr;
++  })();
+ 
+   if (data.errors) {
+     throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data.errors, null, 2)}`);


### PR DESCRIPTION
## Problem

The Release pipeline fails whenever a changeset is pending. `changeset version` generates changelog entries by linking each changeset's commit to its PR through a single GitHub GraphQL call in `@changesets/get-github-info`. That call uses `node-fetch@2`, which requests a gzipped response. In GitHub Actions the response stream is intermittently truncated before the gzip stream completes, so zlib raises:

```
FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
  errno: 'ERR_STREAM_PREMATURE_CLOSE'
  at Gunzip.<anonymous> (node-fetch/lib/index.js:217:52)
```

The failure is **runtime-independent** — it reproduces under both Bun and Node 24 (an earlier attempt to run the step under Node did not fix it). It only triggers when a changeset is pending, because that's the only time the changelog GraphQL call runs.

## Fix

Patch `@changesets/get-github-info` via `bun patch`:

- Add `compress: false` to the fetch options so `node-fetch` requests identity (uncompressed) encoding. This removes the gzip-decompression path that throws.
- Wrap the fetch + JSON parse in a bounded exponential-backoff retry (4 attempts, 1s/2s/4s) as a safety net for any other transient transport error.

The patch is applied to both the CJS and ESM dist entries and auto-applies on `bun install` via `patchedDependencies`. The changelog's PR/author links are preserved.

The version step is also restored to `bun run version-changesets` for repo consistency (running it under Node was not the fix).

## Verification

- With the patch live, `bun run version-changesets` exits 0 and the generated `packages/cli/CHANGELOG.md` entry retains the `[#707](…)` PR link — proof the patched GraphQL call ran successfully and produced enriched output.
- The patch auto-applies under `bun install --frozen-lockfile` (CI install mode), confirmed in a clean clone.
- Convention tests pass.
