### PR TITLE
feat(gateway): own workspace bash approval policy in deploy code

### DIFF
--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -226,6 +226,7 @@ After deploying a new daemon version, run these checks in order — each gate mu
 - If the gateway or workspace restarts while a prompt is open, the prompt is abandoned — the run does not resume.
 - Cloned repos live in the `workspace-repos` named volume at `/workspace/repos`. The volume persists repo contents across container recreation and daemon upgrades. Missing repos are re-cloned automatically on the next mention. **Never run `docker compose down -v`** — it destroys all cloned repos. Do not put secrets in repo contents — authorized runs may access the active workspace/repo surface. To fully clear a cloned repo, delete the volume and let the next mention re-clone it.
 - `WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot,models.dev` is required for the workspace to reach the LLM proxy and the OpenCode model catalog. Without `models.dev`, OpenCode cannot start and the mention loop fails entirely.
+- The workspace bash approval policy is owned by deploy code (`WORKSPACE_PERMISSION_POLICY` in `apps/gateway/src/deploy.ts`) and injected into `WORKSPACE_OPENCODE_CONFIG` at deploy time, overwriting any `permission` block the secret carries. Destructive commands — file deletion (`rm`, `rmdir`), force-push/hard-reset/clean, `sudo`, `chmod`/`chown`, exfil-shaped `curl`/`wget`, and package installs — route through the Discord Approve/Deny gate; ordinary commands run autonomously.
 
 ## ANNOUNCE/PRESENCE WEBHOOK
 

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -2524,9 +2524,14 @@ describe('buildGatewayEnvFileContents', () => {
     expect(configLine).toBeDefined()
     // The raw .env line must have $$ where the original had $
     expect(configLine).toContain('$$SECRET_VAL')
-    // Simulating docker-compose interpolation: replace $$ → $ to recover original
+    // Simulating docker-compose interpolation: replace $$ → $ to recover the config value
     const rawValue = configLine!.slice('WORKSPACE_OPENCODE_CONFIG='.length).replaceAll('$$', '$')
-    expect(rawValue).toBe(config)
+    const parsed = JSON.parse(rawValue) as Record<string, unknown>
+    // Provider and baseURL content must survive the permission injection and re-serialization
+    const options = ((parsed.provider as Record<string, unknown>).anthropic as Record<string, unknown>)
+      .options as Record<string, unknown>
+    expect(options.baseURL).toBe('https://cliproxy.fro.bot/v1')
+    expect(options.key).toBe('$SECRET_VAL')
   })
 
   test('config containing $ survives docker-compose interpolation: $$ round-trip', async () => {
@@ -2544,9 +2549,14 @@ describe('buildGatewayEnvFileContents', () => {
     expect(configLine).toBeDefined()
     // The raw .env line must have $$ where the original had $
     expect(configLine).toContain('$$')
-    // Simulating docker-compose interpolation: replace $$ → $ to recover original
+    // Simulating docker-compose interpolation: replace $$ → $ to recover the config value
     const rawValue = configLine!.slice('WORKSPACE_OPENCODE_CONFIG='.length).replaceAll('$$', '$')
-    expect(rawValue).toBe(config)
+    const parsed = JSON.parse(rawValue) as Record<string, unknown>
+    // Provider and baseURL content must survive the permission injection and re-serialization
+    const options = ((parsed.provider as Record<string, unknown>).anthropic as Record<string, unknown>)
+      .options as Record<string, unknown>
+    expect(options.baseURL).toBe('https://cliproxy.fro.bot/v1')
+    expect(options.key).toBe('value$with$dollars')
   })
 
   test('config with actual backslash payload round-trips intact', async () => {
@@ -2564,7 +2574,13 @@ describe('buildGatewayEnvFileContents', () => {
     expect(configLine).toContain('\\\\')
     // Recover: $$ → $ (docker-compose interpolation simulation); backslashes pass through unchanged
     const rawValue = configLine!.slice('WORKSPACE_OPENCODE_CONFIG='.length).replaceAll('$$', '$')
-    expect(rawValue).toBe(config)
+    const parsed = JSON.parse(rawValue) as Record<string, unknown>
+    // Provider and baseURL content must survive the permission injection and re-serialization
+    const options = ((parsed.provider as Record<string, unknown>).anthropic as Record<string, unknown>)
+      .options as Record<string, unknown>
+    expect(options.baseURL).toBe('https://cliproxy.fro.bot/v1')
+    // Backslash payload survives re-serialization (JSON.stringify preserves the value)
+    expect(options.path).toBe(String.raw`C:\Users\agent`)
   })
 
   test('SHELL_METACHAR_RE is NOT applied to config (would reject valid JSON)', async () => {
@@ -2893,6 +2909,139 @@ describe('buildGatewayEnvFileContents — CONFIG semantic validation', () => {
         config: '{"provider":{"openai":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}',
       }),
     ).not.toThrow()
+  })
+})
+
+// ─── buildGatewayEnvFileContents — permission policy injection ───────────────
+
+function extractParsedConfig(result: string): Record<string, unknown> {
+  const configLine = result.split('\n').find(l => l.startsWith('WORKSPACE_OPENCODE_CONFIG='))
+  if (!configLine) throw new Error('WORKSPACE_OPENCODE_CONFIG line not found')
+  const rawValue = configLine.slice('WORKSPACE_OPENCODE_CONFIG='.length).replaceAll('$$', '$')
+  return JSON.parse(rawValue) as Record<string, unknown>
+}
+
+describe('buildGatewayEnvFileContents — permission policy injection', () => {
+  const VALID_CONFIG = '{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}'
+
+  test('injected permission.bash catch-all "*" is the first key with value "allow"', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const permission = parsed.permission as Record<string, unknown>
+    const bash = permission.bash as Record<string, string>
+    expect(typeof bash).toBe('object')
+    expect(Object.keys(bash)[0]).toBe('*')
+    expect(bash['*']).toBe('allow')
+  })
+
+  test('injected permission.bash["rm *"] === "ask"', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const bash = (parsed.permission as Record<string, unknown>).bash as Record<string, string>
+    expect(bash['rm *']).toBe('ask')
+  })
+
+  test('injected permission.bash["sudo *"] === "ask"', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const bash = (parsed.permission as Record<string, unknown>).bash as Record<string, string>
+    expect(bash['sudo *']).toBe('ask')
+  })
+
+  test('injected permission.bash["curl *-X POST*"] === "ask"', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const bash = (parsed.permission as Record<string, unknown>).bash as Record<string, string>
+    expect(bash['curl *-X POST*']).toBe('ask')
+  })
+
+  test('injected permission.external_directory === "allow" and permission.doom_loop === "allow"', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const permission = parsed.permission as Record<string, unknown>
+    expect(permission.external_directory).toBe('allow')
+    expect(permission.doom_loop).toBe('allow')
+  })
+
+  test('secret permission block is overwritten by code policy (not the secret value)', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const configWithSecretPermission =
+      '{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}},"permission":{"bash":"allow","external_directory":"deny"}}'
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: configWithSecretPermission,
+    })
+    const parsed = extractParsedConfig(result)
+    const permission = parsed.permission as Record<string, unknown>
+    // bash must be the object form from code policy, not the string "allow" from the secret
+    expect(typeof permission.bash).toBe('object')
+    // external_directory must be "allow" from code policy, not "deny" from the secret
+    expect(permission.external_directory).toBe('allow')
+  })
+
+  test('config with no permission key still gets the injected policy', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    expect(parsed.permission).toBeDefined()
+    const permission = parsed.permission as Record<string, unknown>
+    expect(typeof permission.bash).toBe('object')
+  })
+
+  test('catch-all ordering invariant: Object.keys(permission.bash)[0] === "*" (last-match-wins load-bearing)', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const bash = (parsed.permission as Record<string, unknown>).bash as Record<string, string>
+    expect(Object.keys(bash)[0]).toBe('*')
+  })
+
+  test('provider and baseURL content survive the permission injection (re-serialization preserves existing fields)', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const provider = parsed.provider as Record<string, unknown>
+    const anthropic = provider.anthropic as Record<string, unknown>
+    const options = anthropic.options as Record<string, unknown>
+    expect(options.baseURL).toBe('https://cliproxy.fro.bot/v1')
   })
 })
 

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3043,6 +3043,34 @@ describe('buildGatewayEnvFileContents — permission policy injection', () => {
     const options = anthropic.options as Record<string, unknown>
     expect(options.baseURL).toBe('https://cliproxy.fro.bot/v1')
   })
+
+  test('size cap fires after permission injection for a config that passes the input-length check', async () => {
+    const {buildGatewayEnvFileContents} = await import('./deploy')
+    // Build a valid config (passes provider/baseURL guard and the input-length check)
+    // whose serialized length after policy injection exceeds 16384 bytes.
+    const padding = 'x'.repeat(16_000)
+    const config = `{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1","pad":"${padding}"}}}}`
+    expect(config.length).toBeLessThanOrEqual(16_384) // passes the input-length check
+    expect(() =>
+      buildGatewayEnvFileContents({
+        objectStoreHosts: 'host.example.com',
+        model: 'anthropic/claude-sonnet-4-6',
+        config,
+      }),
+    ).toThrow(/too large after permission policy injection/)
+  })
+
+  test('injected permission.bash deep-equals WORKSPACE_PERMISSION_POLICY.bash (all destructive categories)', async () => {
+    const {buildGatewayEnvFileContents, WORKSPACE_PERMISSION_POLICY} = await import('./deploy')
+    const result = buildGatewayEnvFileContents({
+      objectStoreHosts: 'host.example.com',
+      model: 'anthropic/claude-sonnet-4-6',
+      config: VALID_CONFIG,
+    })
+    const parsed = extractParsedConfig(result)
+    const bash = (parsed.permission as Record<string, unknown>).bash
+    expect(bash).toEqual(WORKSPACE_PERMISSION_POLICY.bash)
+  })
 })
 
 // ─── main() — negative integration tests (validation aborts before SSH) ───────

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -291,6 +291,46 @@ export function resolveUpstreamPin(jsonPath?: string): UpstreamPin {
 const MODEL_ALLOWLIST_RE = /^[\w.-]+\/[\w.-]+$/
 
 /**
+ * Authoritative OpenCode permission policy for the gateway workspace.
+ *
+ * Deploy code owns this policy so the autonomous-shell approval boundary is
+ * auditable in git rather than hidden in an opaque secret. It is injected into
+ * WORKSPACE_OPENCODE_CONFIG at deploy time, overwriting any `permission` block
+ * the secret carries.
+ *
+ * OpenCode evaluates bash patterns with last-matching-rule-wins, so the `"*"`
+ * catch-all is listed first and destructive patterns follow. `"ask"` routes a
+ * command through the Discord Approve/Deny gate; `"allow"` runs it autonomously.
+ * This is a human-in-the-loop tripwire layered on top of the container and
+ * mitmproxy egress boundary — not a hard sandbox.
+ */
+export const WORKSPACE_PERMISSION_POLICY = {
+  external_directory: 'allow',
+  doom_loop: 'allow',
+  bash: {
+    '*': 'allow',
+    'rm *': 'ask',
+    'rmdir *': 'ask',
+    'git push *--force*': 'ask',
+    'git push *-f*': 'ask',
+    'git reset --hard*': 'ask',
+    'git clean *-f*': 'ask',
+    'sudo *': 'ask',
+    'chmod *': 'ask',
+    'chown *': 'ask',
+    'curl *-X POST*': 'ask',
+    'curl *-d *': 'ask',
+    'curl *-T *': 'ask',
+    'wget *--post-data*': 'ask',
+    'wget *--post-file*': 'ask',
+    'apt install*': 'ask',
+    'apt-get install*': 'ask',
+    'pip install*': 'ask',
+    'npm install -g*': 'ask',
+  },
+} as const
+
+/**
  * Returns the operator listener state based on the presence of all three operator inputs.
  *
  * - 'enabled':  all three vars (GATEWAY_OPERATOR_BIND_HOST, GATEWAY_OPERATOR_BIND_PORT,
@@ -896,11 +936,26 @@ export function buildGatewayEnvFileContents(opts: {
     )
   }
 
+  // Inject the code-owned permission policy, overwriting any `permission` block the secret carries.
+  // Casting to Record<string, unknown> is safe — we already verified parsed is a plain object above.
+  ;(configObj as Record<string, unknown>).permission = WORKSPACE_PERMISSION_POLICY
+
+  // Re-serialize after injection. JSON.stringify never emits embedded newlines for non-newline
+  // input values, so a second newline check on the output is not needed.
+  const serializedConfig = JSON.stringify(configObj)
+
+  // Guard the final serialized string against the size cap — the injected policy adds bytes.
+  if (serializedConfig.length > 16_384) {
+    throw new Error(
+      `WORKSPACE_OPENCODE_CONFIG is too large after permission policy injection (${serializedConfig.length} bytes; max 16384). Reduce the config size before deploying.`,
+    )
+  }
+
   // Escape $ → $$ so docker-compose interpolation does not expand $VAR sequences.
   // docker-compose converts $$ → $ when passing the value to the container.
   // Note: String.replaceAll('$', '$$') does NOT work — '$$' in a string replacement
   // is a special pattern meaning "insert a literal $", so it's a no-op. Use split/join.
-  const escapedConfig = config.split('$').join('$$')
+  const escapedConfig = serializedConfig.split('$').join('$$')
 
   // Validate readyTimeoutMs if provided — must be a safe positive integer within bounds.
   // validateReadyTimeout handles string input; here we guard the numeric form directly.

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -304,15 +304,16 @@ const MODEL_ALLOWLIST_RE = /^[\w.-]+\/[\w.-]+$/
  * This is a human-in-the-loop tripwire layered on top of the container and
  * mitmproxy egress boundary — not a hard sandbox.
  */
-export const WORKSPACE_PERMISSION_POLICY = {
+export const WORKSPACE_PERMISSION_POLICY = Object.freeze({
   external_directory: 'allow',
   doom_loop: 'allow',
-  bash: {
+  bash: Object.freeze({
     '*': 'allow',
     'rm *': 'ask',
     'rmdir *': 'ask',
     'git push *--force*': 'ask',
     'git push *-f*': 'ask',
+    'git push +*': 'ask',
     'git reset --hard*': 'ask',
     'git clean *-f*': 'ask',
     'sudo *': 'ask',
@@ -327,8 +328,9 @@ export const WORKSPACE_PERMISSION_POLICY = {
     'apt-get install*': 'ask',
     'pip install*': 'ask',
     'npm install -g*': 'ask',
-  },
-} as const
+    'npm i -g*': 'ask',
+  }),
+} as const)
 
 /**
  * Returns the operator listener state based on the presence of all three operator inputs.
@@ -937,11 +939,9 @@ export function buildGatewayEnvFileContents(opts: {
   }
 
   // Inject the code-owned permission policy, overwriting any `permission` block the secret carries.
-  // Casting to Record<string, unknown> is safe — we already verified parsed is a plain object above.
   ;(configObj as Record<string, unknown>).permission = WORKSPACE_PERMISSION_POLICY
 
-  // Re-serialize after injection. JSON.stringify never emits embedded newlines for non-newline
-  // input values, so a second newline check on the output is not needed.
+  // Re-serialize after injection.
   const serializedConfig = JSON.stringify(configObj)
 
   // Guard the final serialized string against the size cap — the injected policy adds bytes.


### PR DESCRIPTION
## Problem

The gateway workspace runs autonomous OpenCode sessions triggered by authorized Discord mentions. The bash approval boundary — which commands run autonomously vs. which require a human Approve/Deny click — lived entirely in the `WORKSPACE_OPENCODE_CONFIG` secret's `permission` block. That block only set `external_directory` and `doom_loop`, so every bash command fell back to OpenCode's default of `allow` and ran with no approval prompt. The approval path existed but was never exercised, and the security boundary was hidden in an opaque secret where it could silently drift.

## Change

Deploy code now owns the workspace bash approval policy. `buildGatewayEnvFileContents` injects an authoritative `WORKSPACE_PERMISSION_POLICY` into the workspace config at deploy time, overwriting any `permission` block the secret carries. The policy is auditable in git and cannot silently regress through a secret edit.

The policy is a denylist tripwire: `"*": "allow"` keeps ordinary commands autonomous, and destructive commands route through the Discord Approve/Deny gate via OpenCode's `"ask"` action — file deletion (`rm`, `rmdir`), force-push including `+refspec` form, hard-reset, clean, `sudo`, `chmod`/`chown`, exfil-shaped `curl`/`wget`, and global/package installs (`npm i -g`, `pip install`, `apt`).

The catch-all `"*"` is listed first because OpenCode evaluates bash patterns last-matching-rule-wins. This is a human-in-the-loop tripwire layered on top of the real boundary (container isolation + mitmproxy egress allowlist + authorized-Discord-users), not a hard sandbox — glob-on-command-string is not airtight against adversarial obfuscation, by design.

## Implementation notes

- Injection happens after the existing provider/baseURL egress validation, then re-serializes and re-checks the 16384-byte size cap on the injected output before `$`→`$$` escaping.
- The policy constant is `Object.freeze`-d (outer + nested `bash`) so it cannot be mutated at runtime.
- Force-push refspec coverage (`git push +*`) and the `npm i -g` shorthand were confirmed against OpenCode's wildcard matcher, which escapes regex metacharacters before substitution (`git push +*` → `^git push \+.*$`), so `+` is literal and ordinary `git push` is not over-matched.

## Verification

- 574 tests pass (`apps/gateway/src/deploy.test.ts`), tsc clean, lint at baseline.
- Tests assert: catch-all-first ordering invariant, secret-permission overwrite, no-permission-key injection, post-injection size-cap guard, and the injected bash policy deep-equals the source constant (all destructive categories).
- Provider/baseURL egress content survives the injection and re-serialization.

The end-to-end deny smoke (mention a destructive command → Discord Approve/Deny embed → Deny → clean failed run) runs after this deploys.
