### PR TITLE
docs(solutions): release GraphQL flake and gateway bash approval fixes

### DIFF
--- a/docs/solutions/integration-issues/gateway-bash-approval-default-allow-2026-06-28.md
+++ b/docs/solutions/integration-issues/gateway-bash-approval-default-allow-2026-06-28.md
@@ -1,0 +1,110 @@
+---
+title: 'Gateway bash approval gate never fired (OpenCode default-allow); deploy code now owns the policy'
+date: 2026-06-28
+category: docs/solutions/integration-issues/
+module: apps/gateway
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - Discord Approve/Deny embed never appeared for bash tool calls
+  - Workspace OpenCode executed bash with no permission.asked event
+  - Deny-flow smoke test was un-exercisable in production
+root_cause: missing_permission
+resolution_type: code_fix
+severity: high
+related_components:
+  - development_workflow
+tags:
+  - gateway
+  - opencode
+  - permission
+  - approval
+  - bash
+  - discord
+  - security-boundary
+  - fro-bot
+---
+
+# Gateway bash approval gate never fired (OpenCode default-allow); deploy code now owns the policy
+
+## Problem
+
+The Fro Bot gateway runs autonomous OpenCode sessions in a sandboxed workspace, triggered by authorized Discord mentions. Destructive bash commands are supposed to route through a Discord Approve/Deny embed, but the gate never fired — every bash command ran autonomously with no prompt, leaving the human approval path un-exercisable.
+
+## Symptoms
+
+- A prompt asking the agent to run a write/delete shell command completed with `Succeeded`; no approval embed was posted.
+- Workspace OpenCode executed `tool="bash"` to `state="completed"` and `/permission?session=…` returned `[]` — no `permission.asked` event was ever emitted.
+- The deny-flow smoke test (mention destructive command → Approve/Deny → Deny → clean failed run) could not be run because there was nothing to deny.
+
+## What Didn't Work
+
+- **Assuming the approval UI had regressed in a daemon bump.** It hadn't. The gateway forwards whatever `permission.asked` events OpenCode emits; the workspace simply never emitted one for bash, so there was no event to render. The regression hypothesis was discarded after confirming the workspace OpenCode config.
+- **The "deny-by-default" framing from the original follow-up note.** A blanket `"bash": "ask"` would make *every* shell command in *every* autonomous run post an Approve/Deny embed and block up to the run deadline — that destroys the gateway's whole purpose (autonomous execution). The real fix is a pattern policy, not a blanket gate.
+
+## Solution
+
+Two parts: the right policy shape, and moving ownership of that policy into reviewed deploy code.
+
+### Root cause
+
+The workspace OpenCode permission config (carried in the `WORKSPACE_OPENCODE_CONFIG` secret) only set `external_directory` and `doom_loop`. Every other tool — including `bash` — fell back to OpenCode's default of `allow`, so bash ran with no `permission.asked` and no Discord gate. This is the *same* config that an earlier fix added to stop headless runs from hanging on unanswered `external_directory` prompts (see Related) — that fix made runs complete by allowing everything, which is exactly what left bash ungated.
+
+### Policy shape — denylist tripwire
+
+`bash` accepts a pattern→action object. Use `"*": "allow"` (keep ordinary commands autonomous) with destructive commands set to `"ask"` (route through the Discord gate). The catch-all `"*"` **must be the first key**: OpenCode's bash matcher is last-matching-rule-wins, so a trailing `"*": "allow"` would override every destructive rule.
+
+```ts
+export const WORKSPACE_PERMISSION_POLICY = Object.freeze({
+  external_directory: 'allow',
+  doom_loop: 'allow',
+  bash: Object.freeze({
+    '*': 'allow',
+    'rm *': 'ask',
+    'rmdir *': 'ask',
+    'git push *--force*': 'ask',
+    'git push *-f*': 'ask',
+    'git push +*': 'ask',
+    'git reset --hard*': 'ask',
+    'git clean *-f*': 'ask',
+    'sudo *': 'ask',
+    'chmod *': 'ask',
+    'chown *': 'ask',
+    'curl *-X POST*': 'ask',
+    'curl *-d *': 'ask',
+    'curl *-T *': 'ask',
+    'wget *--post-data*': 'ask',
+    'wget *--post-file*': 'ask',
+    'apt install*': 'ask',
+    'apt-get install*': 'ask',
+    'pip install*': 'ask',
+    'npm install -g*': 'ask',
+    'npm i -g*': 'ask',
+  }),
+} as const)
+```
+
+### Ownership — deploy code, not the secret
+
+`buildGatewayEnvFileContents` (`apps/gateway/src/deploy.ts`) now overwrites `parsed.permission` with `WORKSPACE_PERMISSION_POLICY` after the existing baseURL-egress validation, re-serializes the config, re-checks the size cap on the injected output, then applies the `$`→`$$` escaping. The secret's `permission` block is irrelevant — code wins. The boundary is auditable in git and cannot silently regress through a secret edit.
+
+## Why This Works
+
+OpenCode's wildcard matcher anchors patterns (`^…$`) and escapes regex metacharacters before substituting `*`→`.*`, so `git push +*` compiles to `^git push \+.*$` — `+` is literal and ordinary `git push` is not over-matched. The bash tool parses the shell line into command *nodes* and matches each node's text, so chaining (`x && rm y`) is split and `rm y` is matched on its own — pattern sprawl chasing `&&`/`;`/`$()` evasion is unnecessary. Setting a command to `"ask"` makes OpenCode publish `permission.asked` and block awaiting a decision, which the gateway renders as the Approve/Deny embed.
+
+This is a **human-in-the-loop tripwire**, not a hard sandbox — glob-on-command-string does not survive adversarial obfuscation (renamed binaries, env indirection, interpreter escapes). The real isolation boundary remains container isolation + mitmproxy egress allowlist + authorized-Discord-users; the permission policy is defense-in-depth.
+
+Production verification — gateway logs for the deny smoke showed the full chain that was previously impossible:
+`approvals: permission requested` (permission:bash) → `run-core: permission.asked forwarded` → `confirmReply … reply:reject` (the Deny click) → `run-core: permission.replied forwarded` → `session.idle received — stream complete` (clean finish, no hang). The deployed `.env` carried all patterns with `permission.bash` first key `"*"`, confirming the catch-all-first ordering survived the inject → serialize → compose-interpolation round-trip.
+
+## Prevention
+
+- **Own security boundaries in reviewed code, not opaque secrets.** A policy that lives only in a single-line JSON secret can silently sit wrong (here: bash at default-allow) with no diff to catch it. Inject it from a tracked constant so the boundary shows up in review.
+- **Know the default.** In OpenCode, only `external_directory` and `doom_loop` default to `ask`; everything else (including `bash`, `edit`) defaults to `allow`. A `permission` block that lists only those two leaves all tools ungated.
+- **Catch-all-first is load-bearing.** Last-match-wins means `"*": "allow"` must precede destructive rules. A test asserts `Object.keys(permission.bash)[0] === "*"`.
+- **A change that makes runs *complete* may be disabling a gate.** The prior fix allowed everything to stop hangs; that is the inverse of gating destructive actions. When relaxing permissions to fix one symptom, check what gate you're removing.
+
+## Related Issues
+
+- `docs/solutions/integration-issues/gateway-mention-loop-permission-and-empty-workspace-2026-06-05.md` — the direct parent: added `{"external_directory":"allow","doom_loop":"allow"}` to stop headless hangs, which is the config that left bash at default-allow. Its Fix 1 config guidance is now superseded by the code-owned policy here.
+- `docs/solutions/integration-issues/gateway-operator-repos-unmounted-and-keyless-bindings-2026-06-24.md` — adjacent gateway fail-closed gating / denylist precedent.

--- a/docs/solutions/integration-issues/gateway-mention-loop-permission-and-empty-workspace-2026-06-05.md
+++ b/docs/solutions/integration-issues/gateway-mention-loop-permission-and-empty-workspace-2026-06-05.md
@@ -1,6 +1,7 @@
 ---
 title: Gateway mention loop hangs on tool-using prompts (unanswered permission.asked + empty workspace)
 date: 2026-06-05
+last_updated: 2026-06-28
 category: docs/solutions/integration-issues/
 module: apps/gateway
 problem_type: integration_issue
@@ -55,6 +56,8 @@ Add a `permission` block to `WORKSPACE_OPENCODE_CONFIG` (a single-line JSON secr
 ```
 
 Update the GitHub secret via stdin and the local `.env`, then redeploy the gateway. The workspace must restart for the new permission config to load.
+
+> **Superseded (2026-06-28):** the `permission` block is no longer owned by the secret. Deploy code injects an authoritative policy (`WORKSPACE_PERMISSION_POLICY` in `apps/gateway/src/deploy.ts`) that overwrites whatever `permission` the secret carries. Allowing only `external_directory`/`doom_loop` (as above) left `bash` at OpenCode's default `allow`, so destructive commands never hit the Discord Approve/Deny gate. See `docs/solutions/integration-issues/gateway-bash-approval-default-allow-2026-06-28.md`.
 
 ### Fix 2 — the cloned repo does not survive deploys
 

--- a/docs/solutions/workflow-issues/release-changeset-graphql-premature-close-2026-06-28.md
+++ b/docs/solutions/workflow-issues/release-changeset-graphql-premature-close-2026-06-28.md
@@ -1,0 +1,105 @@
+---
+title: 'Release pipeline flakes on changeset changelog GraphQL fetch (ERR_STREAM_PREMATURE_CLOSE)'
+date: 2026-06-28
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: development_workflow
+symptoms:
+  - "Release job fails in changeset version with FetchError: Premature close"
+  - "errno ERR_STREAM_PREMATURE_CLOSE thrown at Gunzip in node-fetch/lib/index.js"
+  - Fails only when a changeset is pending; release runs with nothing to version pass
+root_cause: config_error
+resolution_type: dependency_update
+severity: high
+tags:
+  - changesets
+  - release-pipeline
+  - node-fetch
+  - graphql
+  - gzip
+  - bun-patch
+  - github-actions
+related_components:
+  - tooling
+---
+
+# Release pipeline flakes on changeset changelog GraphQL fetch (ERR_STREAM_PREMATURE_CLOSE)
+
+## Problem
+
+The GitHub Actions Release job (`changesets/action` → `changeset version`) intermittently failed during changelog generation, blocking every release that carried a pending changeset. Three identical failures landed across a ~5.5-hour window while GitHub reported "All Systems Operational".
+
+## Symptoms
+
+- `changeset version` aborts with:
+  ```
+  The following error was encountered while generating changelog entries
+  We have escaped applying the changesets, and no files should have been affected
+  🦋  error FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
+      at Gunzip.<anonymous> (node_modules/.bun/node-fetch@2.7.0/node_modules/node-fetch/lib/index.js:217:52)
+    errno: 'ERR_STREAM_PREMATURE_CLOSE', code: 'ERR_STREAM_PREMATURE_CLOSE'
+  ```
+- Fails **only when a changeset is pending** — release runs with nothing to version pass cleanly (no changelog GraphQL call happens).
+
+## What Didn't Work
+
+- **"It's transient, just rerun it."** Wrong — it failed three times across hours with GitHub fully operational. Rerunning is not a fix; the third identical failure disproved the transient framing.
+- **Switching the version step from Bun to Node** (`bun run version-changesets` → `npm run version-changesets`). The original hypothesis was that `node-fetch@2` mishandles the gzipped response specifically under the Bun runtime. One post-switch release succeeded, but the very next changeset-bearing release failed with the **identical** `ERR_STREAM_PREMATURE_CLOSE` and the same `node_modules/.bun/node-fetch@2.7.0` stack — this time under `/opt/hostedtoolcache/node/24.17.0/x64/bin/npm`. The failure is **runtime-independent**; the single success was luck (n=2). This change was reverted.
+
+## Solution
+
+Patch the offending dependency with `bun patch` to (1) request an uncompressed response and (2) retry transient transport errors.
+
+`@changesets/get-github-info` makes a single, unretried `node-fetch@2` POST to `https://api.github.com/graphql` to associate each changeset's commit with its PR. node-fetch requests a gzipped response by default; GitHub Actions intermittently truncates that stream before zlib finishes, so `Gunzip` throws.
+
+```bash
+bun patch '@changesets/get-github-info@0.6.0'
+# edit both dist entries (CJS + ESM), then:
+bun patch --commit 'node_modules/@changesets/get-github-info'
+```
+
+The patch wraps the fetch in both dist entries (`changesets-get-github-info.cjs.js`, `changesets-get-github-info.esm.js`) with `compress: false` plus a bounded retry:
+
+```js
+const data = await (async () => {
+  let lastErr;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const res = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers: { Authorization: `Token ${process.env.GITHUB_TOKEN}` },
+        body: JSON.stringify({ query: makeQuery(repos) }),
+        compress: false,
+      });
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < 3) {
+        await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** attempt));
+        continue;
+      }
+    }
+  }
+  throw lastErr;
+})();
+```
+
+`bun patch --commit` writes `patches/@changesets%2Fget-github-info@0.6.0.patch` and wires `patchedDependencies` into `package.json`. The patch auto-applies under `bun install --frozen-lockfile` (CI install mode). PR/author links in the generated changelog are preserved.
+
+## Why This Works
+
+`compress: false` makes node-fetch send `Accept-Encoding: identity`, so the response is never gzipped and the `Gunzip` decompression path that throws is removed entirely — this is the actual fix. The retry is a safety net for any other transient transport error. The cause is below the application/query/token layer (the exact GraphQL query returns valid data via `gh api graphql`, and `changeset version` runs clean locally), so neither a token change, a query change, nor a runtime swap addresses it.
+
+Verification: with the patch live, `bun run version-changesets` exits 0 and the generated `packages/cli/CHANGELOG.md` entry retains its `([#NNN](…))` PR link — proof the patched GraphQL call ran successfully — and the patch re-applies in a clean `bun install --frozen-lockfile` clone.
+
+## Prevention
+
+- **A reproducible CI failure is not transient.** If GitHub status is green and the same error recurs, stop rerunning and reproduce the exact failing call locally before forming a fix.
+- **Don't anchor a transport bug on the runtime without isolating it.** The same `node-fetch@2` gzip stack failed under both Bun and Node 24. Confirm runtime-independence before claiming "switch runtimes" as the fix.
+- **Renovate footgun:** a Renovate bump of `@changesets/get-github-info` off `0.6.0` drops the patch (the patch is version-pinned). Re-run `bun patch` against the new version on bump, or the flake returns. The `@svitejs/changesets-changelog-github-compact` plugin's dep range is `^0.6.0`.
+- Alternative durable fix if PR links are ever dispensable: swap the changelog generator to the no-network `@changesets/changelog-git`, which deletes the failure class entirely (loses auto PR/author links).
+
+## Related Issues
+
+- `docs/solutions/workflow-issues/renovate-changesets-monorepo-targeting-2026-04-15.md` — adjacent changesets/release-pipeline configuration.


### PR DESCRIPTION
## What

Two new `docs/solutions/` entries capturing root causes solved this cycle, plus a superseded-config note on a related prior doc.

### New

- **`workflow-issues/release-changeset-graphql-premature-close-2026-06-28.md`** — the Release pipeline's intermittent `ERR_STREAM_PREMATURE_CLOSE` during `changeset version`. Root cause: `@changesets/get-github-info` makes a single unretried `node-fetch@2` GraphQL POST that requests gzip; GitHub Actions truncates the stream. Runtime-independent (failed under both Bun and Node — the earlier `npm run` switch was a wrong fix and is documented as such). Fixed via `bun patch` adding `compress: false` + retry. Includes the Renovate re-patch footgun.

- **`integration-issues/gateway-bash-approval-default-allow-2026-06-28.md`** — the gateway's Discord Approve/Deny gate never firing for bash. Root cause: the workspace OpenCode `permission` config only set `external_directory`/`doom_loop`, leaving bash at OpenCode's default `allow`. Fixed by owning the policy in deploy code (`WORKSPACE_PERMISSION_POLICY`) as a catch-all-first denylist tripwire. Documents the matcher semantics, the container/mitmproxy boundary characterization, and the production deny-smoke log chain.

### Updated

- **`integration-issues/gateway-mention-loop-permission-and-empty-workspace-2026-06-05.md`** — added a superseded-config note forward-pointing to the new code-owned policy. That doc's Fix 1 added the very `external_directory`/`doom_loop`-only block that left bash ungated, so it needed the pointer.

## Notes

Docs only — no `packages/cli/src/` change, so no changeset.
