### PR TITLE
feat(broker): set the harness integrate trust allowlist

### DIFF
--- a/apps/broker/AGENTS.md
+++ b/apps/broker/AGENTS.md
@@ -111,7 +111,7 @@ Secrets and the `BROKER_AUD` variable are scoped to the `broker` GitHub Environm
 
 Each `POST /v1/mint` request:
 1. Verifies the OIDC JWT (RS256, GitHub issuer, broker-minted audience, `exp`/`nbf`/`jti` replay check).
-2. Evaluates claims against `BROKER_TRUST_POLICY` (`repository_id`, `repository_owner_id`, `workflow_ref`, `ref`, `ref_type`, `ref_protected`, `event_name`, `runner_environment`, `repository_visibility`).
+2. Evaluates claims against `BROKER_TRUST_POLICY` (`repository_id`, `repository_owner_id`, `job_workflow_ref`, `ref`, `ref_type`, `ref_protected`, `event_name`, `runner_environment`, `repository_visibility`).
 3. Mints a `ghact-<run_id>-<random>` key via cliproxy management API (GET-modify-write + read-back, single-flight lock).
 4. Records the entry in the in-memory live set with a 30-minute TTL.
 5. Returns the OpenCode `auth.json` payload (same shape as `apps/cliproxy/AGENTS.md`).
@@ -182,8 +182,8 @@ Do not edit the `.env` on the droplet directly — the next deploy overwrites it
 
 ## NOTES
 
-- **Trust policy placeholders**: `BROKER_TRUST_POLICY` in `apps/broker/src/policy.ts` has placeholder values for `repository_id`, `repository_owner_id`, and `workflow_ref`. These must be replaced with the real `fro-bot/agent` numeric IDs and workflow path before the broker is deployed. Obtain them with `gh api repos/fro-bot/agent --jq .id` and `gh api orgs/fro-bot --jq .id`. Tracked in `fro-bot/agent#1060`.
-- **Cross-repo handoff**: once the broker ships, update `fro-bot/agent#1060` with a `@fro-bot` mention so the consuming-side integration (OIDC token request, broker call, `auth.json` injection) is picked up there.
+- **Trust policy**: `BROKER_TRUST_POLICY` in `apps/broker/src/policy.ts` pins the `fro-bot/agent` harness integrate identity — `repository_id` `1126485011`, `repository_owner_id` `80104189`, and `job_workflow_ref` `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`. The broker pins `job_workflow_ref` (the reusable integrate file that requests the token), not `workflow_ref` (which is the `harness-release` caller). `repository_visibility` is `public` (fro-bot/agent is a public repo). Values sourced from `fro-bot/agent#1081` and verified against the live GitHub API. If the integrate workflow file, ref, or repo identity changes, update the policy and redeploy.
+- **Cross-repo integration**: the consuming side (OIDC token request at audience `https://broker.fro.bot`, broker call, `auth.json` injection) lands in `fro-bot/agent` via `harness-integrate.yaml` — see `fro-bot/agent#1081`. The mint fails closed until this policy matches the integrate workflow's OIDC claims.
 - **Broker→cliproxy reachability**: the broker runs on its own separate DigitalOcean droplet (not co-located with cliproxy). It reaches cliproxy over the public internet via `https://cliproxy.fro.bot`. The hairpin concern (DO droplets don't NAT-loopback) does not apply here — that only affects same-host container-to-container calls.
 - **Pre-first-deploy checklist**: create the `broker` GitHub Environment (reviewer + main-only) before merging the deploy workflow; add `broker`-scoped secrets after the environment is gated; pin broker FQDN host keys in both `.github/known_hosts` and `packages/cli/src/resources/known_hosts` (byte-identical).
 - **First deploy**: budget for a live contract cascade (host-key domain pin, SSH identity, paths-filter glob, ControlMaster). After the first deploy, author a `docs/solutions/` compound doc capturing cascade waves and any mint/revoke surprises.

--- a/apps/broker/src/policy.test.ts
+++ b/apps/broker/src/policy.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for the BROKER_TRUST_POLICY allowlist and evaluateClaims function.
  *
- * The policy pins specific claim values. The exact fro-bot/agent numeric IDs
- * and workflow path are placeholders here — filled at integration time (#1060).
+ * The policy pins specific claim values sourced from fro-bot/agent#1081.
  * These tests verify the evaluation logic against the policy structure.
  */
 import {describe, expect, test} from 'bun:test'
@@ -19,13 +18,13 @@ function validClaims(): Record<string, string> {
     repository: BROKER_TRUST_POLICY.repository,
     repository_id: BROKER_TRUST_POLICY.repository_id,
     repository_owner_id: BROKER_TRUST_POLICY.repository_owner_id,
-    workflow_ref: BROKER_TRUST_POLICY.workflow_ref,
+    job_workflow_ref: BROKER_TRUST_POLICY.job_workflow_ref,
     ref: BROKER_TRUST_POLICY.allowed_refs[0] ?? 'refs/heads/main',
     ref_type: 'branch',
     ref_protected: 'true',
     event_name: 'workflow_dispatch',
     runner_environment: 'github-hosted',
-    repository_visibility: 'private',
+    repository_visibility: 'public',
   }
 }
 
@@ -44,17 +43,18 @@ describe('evaluateClaims — happy path', () => {
 // Forgeable-name trap
 // ---------------------------------------------------------------------------
 
-describe('evaluateClaims — workflow_ref vs workflow name', () => {
-  test('workflow_ref path differs from policy → deny', () => {
+describe('evaluateClaims — job_workflow_ref vs workflow name', () => {
+  test('job_workflow_ref path differs from policy → deny', () => {
     const claims = {
       ...validClaims(),
-      // Same repo, same workflow name in the path, but different file path
-      workflow_ref: `fro-bot/agent/.github/workflows/other-workflow.yaml@refs/heads/main`,
+      // Same repo, but a different workflow file path (e.g. the harness-release
+      // caller rather than the pinned harness-integrate file).
+      job_workflow_ref: `fro-bot/agent/.github/workflows/harness-release.yaml@refs/heads/main`,
     }
     const result = evaluateClaims(claims, BROKER_TRUST_POLICY)
     expect(result.ok).toBe(false)
     if (!result.ok) {
-      expect(result.reason).toMatch(/workflow_ref/i)
+      expect(result.reason).toMatch(/job_workflow_ref/i)
     }
   })
 })
@@ -133,7 +133,7 @@ describe('evaluateClaims — missing claims', () => {
   const requiredClaims = [
     'repository_id',
     'repository_owner_id',
-    'workflow_ref',
+    'job_workflow_ref',
     'ref',
     'ref_type',
     'ref_protected',
@@ -197,8 +197,8 @@ describe('evaluateClaims — environment and visibility', () => {
     }
   })
 
-  test('repository_visibility: public → deny', () => {
-    const claims = {...validClaims(), repository_visibility: 'public'}
+  test('repository_visibility: private → deny', () => {
+    const claims = {...validClaims(), repository_visibility: 'private'}
     const result = evaluateClaims(claims, BROKER_TRUST_POLICY)
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -240,7 +240,7 @@ describe('BROKER_TRUST_POLICY structure', () => {
     expect(BROKER_TRUST_POLICY.runner_environment).toBe('github-hosted')
   })
 
-  test('policy requires private repository', () => {
-    expect(BROKER_TRUST_POLICY.repository_visibility).toBe('private')
+  test('policy requires public repository', () => {
+    expect(BROKER_TRUST_POLICY.repository_visibility).toBe('public')
   })
 })

--- a/apps/broker/src/policy.ts
+++ b/apps/broker/src/policy.ts
@@ -5,11 +5,11 @@
  * claim values that a GitHub Actions OIDC token must satisfy before the broker
  * will mint a cliproxy credential.
  *
- * The exact fro-bot/agent numeric IDs and workflow path are filled at
- * integration time (cross-repo, tracked in fro-bot/agent#1060). The
- * placeholder values below MUST be replaced with real values before the broker
- * is deployed. They are intentionally non-numeric strings so a type-check or
- * test will catch an unset placeholder.
+ * The fro-bot/agent numeric IDs and the integrate workflow ref were supplied
+ * at integration time (cross-repo, fro-bot/agent#1081). The broker pins
+ * job_workflow_ref (the reusable integrate file), not workflow_ref (which is
+ * the harness-release caller), because the integrate job runs as a reusable
+ * workflow.
  *
  * Pattern: apps/gateway/src/deploy.ts WORKSPACE_PERMISSION_POLICY
  */
@@ -23,20 +23,21 @@ export interface BrokerTrustPolicy {
   readonly repository: string
   /**
    * Numeric GitHub repository ID. Survives renames; prevents typosquat.
-   * PLACEHOLDER — replace with the real fro-bot/agent repository_id.
    */
   readonly repository_id: string
   /**
    * Numeric GitHub owner (org/user) ID. Survives renames.
-   * PLACEHOLDER — replace with the real fro-bot org repository_owner_id.
    */
   readonly repository_owner_id: string
   /**
-   * Exact workflow_ref value: "owner/repo/.github/workflows/<file>@<ref>".
-   * Pin this, never the forgeable `workflow` name claim.
-   * PLACEHOLDER — replace with the real integrate workflow path and ref.
+   * Exact job_workflow_ref value: "owner/repo/.github/workflows/<file>@<ref>".
+   * Pins the reusable workflow file that requested the token (authorizes any
+   * job in that file), never the forgeable `workflow` name claim. The integrate
+   * job runs in a reusable workflow called by harness-release.yaml, so the
+   * token's `workflow_ref` is the caller (harness-release) while
+   * `job_workflow_ref` is the integrate file — the correct claim to pin.
    */
-  readonly workflow_ref: string
+  readonly job_workflow_ref: string
   /** Allowed ref values (e.g. refs/heads/main). */
   readonly allowed_refs: readonly string[]
   /** ref_type must be "branch". */
@@ -59,26 +60,23 @@ export interface BrokerTrustPolicy {
 // ---------------------------------------------------------------------------
 
 /**
- * The broker trust policy.
- *
- * IMPORTANT: repository_id, repository_owner_id, and workflow_ref are
- * PLACEHOLDERS. Replace them with the real fro-bot/agent values before
- * deploying. See fro-bot/agent#1060.
+ * The broker trust policy for the fro-bot/agent harness integrate job.
+ * Values sourced from fro-bot/agent#1081 and verified against the live
+ * GitHub API.
  */
 export const BROKER_TRUST_POLICY: BrokerTrustPolicy = Object.freeze({
   repository: 'fro-bot/agent',
 
-  // PLACEHOLDER: replace with the real numeric repository ID from
-  // `gh api repos/fro-bot/agent --jq .id`
-  repository_id: 'PLACEHOLDER_REPOSITORY_ID',
+  // Numeric repository ID (gh api repos/fro-bot/agent --jq .id).
+  repository_id: '1126485011',
 
-  // PLACEHOLDER: replace with the real numeric owner ID from
-  // `gh api orgs/fro-bot --jq .id` (or `gh api users/fro-bot --jq .id`)
-  repository_owner_id: 'PLACEHOLDER_REPOSITORY_OWNER_ID',
+  // Numeric owner ID for the fro-bot org (gh api users/fro-bot --jq .id).
+  repository_owner_id: '80104189',
 
-  // PLACEHOLDER: replace with the exact workflow_ref for the integrate
-  // workflow, e.g. "fro-bot/agent/.github/workflows/integrate.yaml@refs/heads/main"
-  workflow_ref: 'PLACEHOLDER_WORKFLOW_REF',
+  // The reusable integrate workflow file that requests the OIDC token.
+  // Pinning job_workflow_ref authorizes any job in this file; harness-integrate
+  // documents a one-job invariant so minting authority is not silently shared.
+  job_workflow_ref: 'fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main',
 
   allowed_refs: Object.freeze(['refs/heads/main']),
 
@@ -92,7 +90,8 @@ export const BROKER_TRUST_POLICY: BrokerTrustPolicy = Object.freeze({
 
   runner_environment: 'github-hosted',
 
-  repository_visibility: 'private',
+  // fro-bot/agent is a public repository.
+  repository_visibility: 'public',
 } as const)
 
 // ---------------------------------------------------------------------------
@@ -137,10 +136,10 @@ export function evaluateClaims(claims: Record<string, string | undefined>, polic
       return null
     },
     () => {
-      const v = claims.workflow_ref
-      if (v === undefined) return {ok: false, reason: 'missing required claim: workflow_ref'}
-      if (v !== policy.workflow_ref)
-        return {ok: false, reason: `workflow_ref mismatch: got ${v}, expected ${policy.workflow_ref}`}
+      const v = claims.job_workflow_ref
+      if (v === undefined) return {ok: false, reason: 'missing required claim: job_workflow_ref'}
+      if (v !== policy.job_workflow_ref)
+        return {ok: false, reason: `job_workflow_ref mismatch: got ${v}, expected ${policy.job_workflow_ref}`}
       return null
     },
     () => {


### PR DESCRIPTION
Set the broker's trust allowlist to the real `fro-bot/agent` harness integrate identity, replacing the placeholders it shipped with. The broker fails closed until this matches the integrate workflow's OIDC claims, so it needs to be deployed before the harness integration (`fro-bot/agent#1081`) goes live.

## Values

From `fro-bot/agent#1081`, verified against the live GitHub API:

- `repository_id`: `1126485011`
- `repository_owner_id`: `80104189`
- `job_workflow_ref`: `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`

## Two structural fixes beyond the value swap

Dropping the three values into the old policy shape would have made the broker reject the legitimate token. Two claims had to change:

- **Pin `job_workflow_ref`, not `workflow_ref`.** The integrate job runs in a reusable workflow (`harness-integrate.yaml`) called by `harness-release.yaml`. For a reusable workflow the token's `workflow_ref` is the *caller* (harness-release) while `job_workflow_ref` is the file that requested the token. Pinning the integrate path against `workflow_ref` would never match. This is the claim the harness side deliberately pins.
- **`repository_visibility` is `public`.** `fro-bot/agent` is a public repo; the policy previously pinned `private`, which would reject.

The other defensive claim checks — `ref` (`refs/heads/main`), `ref_type`, `ref_protected`, `event_name` (excludes `pull_request`/`pull_request_target`), `runner_environment` (`github-hosted`) — are retained. They're consistent with the integrate token (which requests via `workflow_dispatch`/`push` on protected `main`) and add defense in depth.

## Verification

Full broker suite green (210 tests), type-check and lint clean. Policy tests updated to the real values and the `job_workflow_ref` / `public` shape, including the deny cases (wrong workflow file, wrong repo id/owner, `private` visibility, `pull_request`).

After this merges, the broker is redeployed so the live allowlist matches before any real harness dispatch mints.
