### PR TITLE
fix(broker): force-recreate the container on deploy

### DIFF
--- a/apps/broker/AGENTS.md
+++ b/apps/broker/AGENTS.md
@@ -24,7 +24,7 @@ OIDC-authenticated credential broker at `broker.fro.bot`. Docker Compose stack (
 2. **Build** (`buildBundle`): runs `bun build src/main.ts --target bun --outfile dist/main.js` (cwd `apps/broker/`). Produces a self-contained ~300KB bundle with `jose` inlined via Web Crypto. Aborts on non-zero exit — no remote mutation happens if the build fails.
 3. **Upload**: `docker-compose.yaml`, `config/Caddyfile`, and `dist/main.js` are SCP'd to `/opt/broker/` on the droplet (`dist/main.js` → `/opt/broker/dist/main.js`).
 4. **Secrets**: the broker `.env` file (`BROKER_HOST`, `CLIPROXY_MANAGEMENT_URL`, `CLIPROXY_MANAGEMENT_KEY`, `BROKER_AUD`) is written via SSH stdin — never in argv.
-5. **Restart**: `docker compose pull && docker compose up -d --wait --wait-timeout 90` from `/opt/broker/`.
+5. **Restart**: `docker compose pull && docker compose up -d --force-recreate --wait --wait-timeout 90` from `/opt/broker/`. `--force-recreate` is required because `dist/main.js` is bind-mounted (`ro`) into the broker container and loaded into memory at process start — a bundle-only change leaves the compose spec, image, and env byte-identical, so without `--force-recreate` compose would see no config change and skip recreating the container, leaving the old process running the stale bundle. Named volumes (`caddy_data`, `caddy_config`) persist across recreation, so Let's Encrypt certs are unaffected.
 6. **Health gate**: GET `https://<BROKER_HOST>/healthz` confirms the stack is serving.
 
 All SSH calls in a single deploy share one ControlPath socket (avoids UFW rate-limit at 6 connections/30s).

--- a/apps/broker/src/deploy.test.ts
+++ b/apps/broker/src/deploy.test.ts
@@ -508,6 +508,57 @@ describe('deploy (broker)', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // deploy — compose-up command forces recreation of the running stack
+  // ---------------------------------------------------------------------------
+  //
+  // Regression test: the broker container bind-mounts dist/main.js and loads it
+  // into memory at process start. `docker compose up -d` alone does not restart
+  // a container when only the bind-mounted file content changes (compose spec,
+  // image, and env are otherwise identical) — the running process keeps
+  // executing the stale bundle. `--force-recreate` guarantees the container
+  // (and therefore the bun process) always restarts and reloads the freshly
+  // uploaded bundle.
+
+  describe('deploy — compose-up forces recreation', () => {
+    it('runs docker compose up with --force-recreate', async () => {
+      setValidEnv()
+
+      const mockFetch: FetchFn = async () => new Response(JSON.stringify([]), {status: 200})
+
+      const sshCommands: string[][] = []
+
+      const mockSpawn = (cmd: string[], _opts: unknown) => {
+        if (cmd[0] === 'bun' && cmd.includes('build')) {
+          // Bundle build succeeds.
+          return {
+            stdin: {write: () => {}, end: () => {}},
+            stdout: emptyStream(),
+            stderr: emptyStream(),
+            exited: Promise.resolve(0),
+          }
+        }
+        sshCommands.push(cmd)
+        return {
+          stdin: {write: () => {}, end: () => {}},
+          stdout: emptyStream(),
+          stderr: emptyStream(),
+          exited: Promise.resolve(0),
+        }
+      }
+
+      await deploy({fetch: mockFetch, spawn: mockSpawn as unknown as typeof Bun.spawn})
+
+      const composeUpCommand = sshCommands.map(cmd => cmd.join(' ')).find(cmd => cmd.includes('docker compose up'))
+
+      expect(composeUpCommand).toBeDefined()
+      expect(composeUpCommand).toContain('--force-recreate')
+      expect(composeUpCommand).toContain(
+        'docker compose pull && docker compose up -d --force-recreate --wait --wait-timeout 90',
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // deploy — single controlPath threaded through all SSH/SCP calls
   // ---------------------------------------------------------------------------
 

--- a/apps/broker/src/deploy.ts
+++ b/apps/broker/src/deploy.ts
@@ -422,7 +422,7 @@ export async function deploy(deps: DeployDeps = {}): Promise<void> {
     'Updating Docker Compose stack',
     sshCommand(
       host,
-      `cd ${REMOTE_DIR} && docker compose pull && docker compose up -d --wait --wait-timeout 90`,
+      `cd ${REMOTE_DIR} && docker compose pull && docker compose up -d --force-recreate --wait --wait-timeout 90`,
       controlPath,
     ),
     env,


### PR DESCRIPTION
The broker runs a bind-mounted bundle (`./dist/main.js:/app/main.js:ro`) that `bun main.js` loads into memory at container start. When a deploy changes only the bundle content — the common case, since the compose spec, image, and env are usually identical — `docker compose up -d` sees no config change and does not recreate the broker container. The old process keeps executing the previous bundle, so a deploy uploads new code to disk while the live broker runs stale code.

This bit in production: after the trust-allowlist was un-placeholdered and redeployed, the broker kept serving the previous bundle and returned 403 to a legitimate mint whose token was actually correct (the audit log showed the token carrying the right repository_id but the policy still comparing against the old placeholder).

## Fix

Add `--force-recreate` to the compose-up so the process always re-execs the freshly-uploaded bundle:

```
docker compose pull && docker compose up -d --force-recreate --wait --wait-timeout 90
```

Force-recreate on the whole stack covers both a bundle change (broker must restart) and a Caddyfile change (caddy must reload). The named volumes (`caddy_data`, `caddy_config`) persist across recreation, so Let's Encrypt certificates are not affected — only `down -v` would remove them, and that stays banned.

## Verification

211 broker tests pass (one new: asserts the deploy's compose-up command includes `--force-recreate`), type-check and lint clean.
