### PR TITLE
fix(broker): make minted keys self-describing so restart is safe

### DIFF
--- a/apps/broker/src/main.ts
+++ b/apps/broker/src/main.ts
@@ -76,7 +76,7 @@ const rateLimiter = createRateLimiter()
 const serverDeps = {
   verifyOidcToken: (token: string) => verifyOidcToken(token, {audience: BROKER_AUD}),
   evaluateClaims: (claims: Record<string, string | undefined>) => evaluateClaims(claims, BROKER_TRUST_POLICY),
-  mintKey: (runId: string) => mintKey(runId, mintDeps),
+  mintKey: (runId: string, expiresAt: number) => mintKey(runId, expiresAt, mintDeps),
   recordMint,
   isReady,
   rateLimiter,

--- a/apps/broker/src/mint.test.ts
+++ b/apps/broker/src/mint.test.ts
@@ -8,7 +8,7 @@
 import type {FetchFn} from './mint'
 
 import {describe, expect, mock, test} from 'bun:test'
-import {listApiKeys, mintKey, revokeKey} from './mint'
+import {listApiKeys, mintKey, parseKeyExpiry, revokeKey} from './mint'
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -16,6 +16,9 @@ import {listApiKeys, mintKey, revokeKey} from './mint'
 
 const TEST_URL = 'https://cliproxy.example.test'
 const TEST_KEY = 'test-management-key'
+
+/** A representative future expiry (epoch ms) for tests that don't care about the exact value. */
+const TEST_EXPIRY = Date.now() + 30 * 60 * 1000
 
 /** Build a minimal deps object with a custom fetch mock. */
 function makeDeps(fetchFn: FetchFn) {
@@ -77,7 +80,7 @@ describe('mintKey — happy path', () => {
     const existingKeys = ['existing-key-1', 'existing-key-2']
     const store = [...existingKeys]
 
-    const key = await mintKey('run-123', makeDeps(makeStoreFetch(store)))
+    const key = await mintKey('run-123', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
 
     // Key has the greppable prefix
     expect(key).toMatch(/^ghact-run-123-/)
@@ -97,7 +100,7 @@ describe('mintKey — happy path', () => {
   test('GET-back confirms the new key is present before returning', async () => {
     const store: string[] = []
 
-    const key = await mintKey('run-456', makeDeps(makeStoreFetch(store)))
+    const key = await mintKey('run-456', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
 
     expect(store).toContain(key)
     expect(key).toMatch(/^ghact-run-456-/)
@@ -114,7 +117,7 @@ describe('mintKey — preserves existing keys', () => {
     const existingKeys = Array.from({length: N}, (_, i) => `key-${i}`)
     const store = [...existingKeys]
 
-    const key = await mintKey('run-preserve', makeDeps(makeStoreFetch(store)))
+    const key = await mintKey('run-preserve', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
 
     expect(store).toHaveLength(N + 1)
     expect(store).toContain(key)
@@ -126,7 +129,7 @@ describe('mintKey — preserves existing keys', () => {
   test('works when existing api-keys list is empty', async () => {
     const store: string[] = []
 
-    const key = await mintKey('run-empty', makeDeps(makeStoreFetch(store)))
+    const key = await mintKey('run-empty', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
 
     expect(store).toHaveLength(1)
     expect(store[0]).toBe(key)
@@ -157,7 +160,7 @@ describe('mintKey — GET-back mismatch retry', () => {
       throw new Error(`Unexpected fetch: ${method} ${urlStr}`)
     })
 
-    await expect(mintKey('run-mismatch', makeDeps(fetchMock))).rejects.toThrow(
+    await expect(mintKey('run-mismatch', TEST_EXPIRY, makeDeps(fetchMock))).rejects.toThrow(
       /read-back.*not found|not found.*read-back|key not present|mismatch/i,
     )
   })
@@ -191,7 +194,7 @@ describe('mintKey — GET-back mismatch retry', () => {
       throw new Error(`Unexpected fetch: ${method} ${urlStr}`)
     })
 
-    const key = await mintKey('run-retry', makeDeps(fetchMock))
+    const key = await mintKey('run-retry', TEST_EXPIRY, makeDeps(fetchMock))
 
     expect(key).toMatch(/^ghact-run-retry-/)
     expect(store).toContain(key)
@@ -211,7 +214,7 @@ describe('mintKey — HTTP errors throw immediately', () => {
       return errorResponse(401, 'Unauthorized')
     })
 
-    await expect(mintKey('run-401', makeDeps(fetchMock))).rejects.toThrow(/401/)
+    await expect(mintKey('run-401', TEST_EXPIRY, makeDeps(fetchMock))).rejects.toThrow(/401/)
 
     // Only one call — no retry on auth failure
     expect(callCount).toBe(1)
@@ -225,7 +228,7 @@ describe('mintKey — HTTP errors throw immediately', () => {
       return errorResponse(403, 'Forbidden')
     })
 
-    await expect(mintKey('run-403', makeDeps(fetchMock))).rejects.toThrow(/403/)
+    await expect(mintKey('run-403', TEST_EXPIRY, makeDeps(fetchMock))).rejects.toThrow(/403/)
 
     expect(callCount).toBe(1)
   })
@@ -238,7 +241,7 @@ describe('mintKey — HTTP errors throw immediately', () => {
       return errorResponse(500, 'Internal Server Error')
     })
 
-    await expect(mintKey('run-500', makeDeps(fetchMock))).rejects.toThrow(/500/)
+    await expect(mintKey('run-500', TEST_EXPIRY, makeDeps(fetchMock))).rejects.toThrow(/500/)
 
     expect(callCount).toBe(1)
   })
@@ -289,8 +292,8 @@ describe('mintKey — unique prefix per run', () => {
     const store1: string[] = []
     const store2: string[] = []
 
-    const key1 = await mintKey('run-aaa', makeDeps(makeStoreFetch(store1)))
-    const key2 = await mintKey('run-bbb', makeDeps(makeStoreFetch(store2)))
+    const key1 = await mintKey('run-aaa', TEST_EXPIRY, makeDeps(makeStoreFetch(store1)))
+    const key2 = await mintKey('run-bbb', TEST_EXPIRY, makeDeps(makeStoreFetch(store2)))
 
     expect(key1).toMatch(/^ghact-run-aaa-/)
     expect(key2).toMatch(/^ghact-run-bbb-/)
@@ -301,8 +304,8 @@ describe('mintKey — unique prefix per run', () => {
     const store1: string[] = []
     const store2: string[] = []
 
-    const key1 = await mintKey('run-same', makeDeps(makeStoreFetch(store1)))
-    const key2 = await mintKey('run-same', makeDeps(makeStoreFetch(store2)))
+    const key1 = await mintKey('run-same', TEST_EXPIRY, makeDeps(makeStoreFetch(store1)))
+    const key2 = await mintKey('run-same', TEST_EXPIRY, makeDeps(makeStoreFetch(store2)))
 
     expect(key1).toMatch(/^ghact-run-same-/)
     expect(key2).toMatch(/^ghact-run-same-/)
@@ -346,7 +349,10 @@ describe('mintKey — single-flight lock (concurrency)', () => {
     const deps = makeDeps(fetchMock)
 
     // Fire both mints concurrently
-    const [key1, key2] = await Promise.all([mintKey('run-concurrent-1', deps), mintKey('run-concurrent-2', deps)])
+    const [key1, key2] = await Promise.all([
+      mintKey('run-concurrent-1', TEST_EXPIRY, deps),
+      mintKey('run-concurrent-2', TEST_EXPIRY, deps),
+    ])
 
     // Both keys must be present in the final store
     expect(sharedStore).toContain(key1)
@@ -396,11 +402,11 @@ describe('mintKey — single-flight lock (concurrency)', () => {
     const deps = makeDeps(fetchMock)
 
     // First mint to get a key to revoke
-    const keyToRevoke = await mintKey('run-serial-1', deps)
+    const keyToRevoke = await mintKey('run-serial-1', TEST_EXPIRY, deps)
     expect(sharedStore).toContain(keyToRevoke)
 
     // Now run a mint and a revoke concurrently
-    const [key2] = await Promise.all([mintKey('run-serial-2', deps), revokeKey(keyToRevoke, deps)])
+    const [key2] = await Promise.all([mintKey('run-serial-2', TEST_EXPIRY, deps), revokeKey(keyToRevoke, deps)])
 
     // The new key must be present
     expect(sharedStore).toContain(key2)
@@ -446,7 +452,10 @@ describe('listApiKeys — exported helper', () => {
     const deps = makeDeps(fetchMock)
 
     // Fire a mint and a listApiKeys concurrently
-    const [mintedKey, listedKeys] = await Promise.all([mintKey('run-list-concurrent', deps), listApiKeys(deps)])
+    const [mintedKey, listedKeys] = await Promise.all([
+      mintKey('run-list-concurrent', TEST_EXPIRY, deps),
+      listApiKeys(deps),
+    ])
 
     // The listed keys should include the pre-existing key
     expect(listedKeys).toContain('pre-existing')
@@ -462,21 +471,21 @@ describe('listApiKeys — exported helper', () => {
 describe('mintKey — CSPRNG suffix', () => {
   test('minted key suffix is hex-encoded (no Math.random base36 chars like z)', async () => {
     const store: string[] = []
-    const key = await mintKey('run-csprng', makeDeps(makeStoreFetch(store)))
+    const key = await mintKey('run-csprng', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
 
-    // Format: ghact-<runId>-<hex>
-    expect(key).toMatch(/^ghact-run-csprng-[0-9a-f]+$/)
+    // Format: ghact-<runId>-<expiresAtEpochMs>-<hex>
+    expect(key).toMatch(/^ghact-run-csprng-\d+-[0-9a-f]+$/)
   })
 
   test('two mints for the same runId produce different hex suffixes', async () => {
     const store1: string[] = []
     const store2: string[] = []
 
-    const key1 = await mintKey('run-same-id', makeDeps(makeStoreFetch(store1)))
-    const key2 = await mintKey('run-same-id', makeDeps(makeStoreFetch(store2)))
+    const key1 = await mintKey('run-same-id', TEST_EXPIRY, makeDeps(makeStoreFetch(store1)))
+    const key2 = await mintKey('run-same-id', TEST_EXPIRY, makeDeps(makeStoreFetch(store2)))
 
-    expect(key1).toMatch(/^ghact-run-same-id-[0-9a-f]+$/)
-    expect(key2).toMatch(/^ghact-run-same-id-[0-9a-f]+$/)
+    expect(key1).toMatch(/^ghact-run-same-id-\d+-[0-9a-f]+$/)
+    expect(key2).toMatch(/^ghact-run-same-id-\d+-[0-9a-f]+$/)
     expect(key1).not.toBe(key2)
   })
 
@@ -484,7 +493,7 @@ describe('mintKey — CSPRNG suffix', () => {
     const keys = new Set<string>()
     for (let i = 0; i < 100; i++) {
       const store: string[] = []
-      const key = await mintKey('run-collision', makeDeps(makeStoreFetch(store)))
+      const key = await mintKey('run-collision', TEST_EXPIRY, makeDeps(makeStoreFetch(store)))
       keys.add(key)
     }
     // All 100 keys must be unique
@@ -504,7 +513,7 @@ describe('mintKey — no secret leakage in errors', () => {
 
     let thrownError: Error | undefined
     try {
-      await mintKey('run-leak-check', makeDeps(fetchMock))
+      await mintKey('run-leak-check', TEST_EXPIRY, makeDeps(fetchMock))
     } catch (error) {
       thrownError = error instanceof Error ? error : new Error(String(error))
     }
@@ -512,5 +521,54 @@ describe('mintKey — no secret leakage in errors', () => {
     expect(thrownError).toBeDefined()
     // The management key value must not appear in the error message
     expect(thrownError?.message).not.toContain(TEST_KEY)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mintKey — embedded expiry matches the caller-supplied value
+// ---------------------------------------------------------------------------
+
+describe('mintKey — embedded expiry matches caller-supplied value', () => {
+  test('the generated key embeds exactly the expiresAt passed to mintKey', async () => {
+    const store: string[] = []
+    const expiresAt = Date.now() + 45 * 60 * 1000
+
+    const key = await mintKey('run-expiry-match', expiresAt, makeDeps(makeStoreFetch(store)))
+
+    expect(parseKeyExpiry(key)).toBe(expiresAt)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseKeyExpiry — pure unit tests
+// ---------------------------------------------------------------------------
+
+describe('parseKeyExpiry', () => {
+  test('returns the embedded expiry for a well-formed ghact- key', () => {
+    expect(parseKeyExpiry('ghact-run123-1750000000000-abcd1234')).toBe(1750000000000)
+  })
+
+  test('returns null for a non-ghact- key', () => {
+    expect(parseKeyExpiry('sk-ant-durable-key-abc123')).toBeNull()
+  })
+
+  test('returns null for a ghact- key with a non-numeric expiry segment (legacy format)', () => {
+    // Legacy/malformed: ghact-<runId>-<hex> with no numeric expiry segment.
+    expect(parseKeyExpiry('ghact-run123-abcd1234')).toBeNull()
+  })
+
+  test('returns null for a ghact- key missing the random suffix entirely', () => {
+    expect(parseKeyExpiry('ghact-run123-1750000000000')).toBeNull()
+  })
+
+  test('parses correctly when runId itself contains hyphens and digits', () => {
+    // runId = "run-42-abc-99"; anchors on the LAST two segments.
+    const key = 'ghact-run-42-abc-99-1750000000000-deadbeef'
+    expect(parseKeyExpiry(key)).toBe(1750000000000)
+  })
+
+  test('returns null when the hex suffix contains non-hex characters', () => {
+    // 'z' is not a valid hex digit — this must NOT best-effort parse.
+    expect(parseKeyExpiry('ghact-run123-1750000000000-zzzz')).toBeNull()
   })
 })

--- a/apps/broker/src/mint.ts
+++ b/apps/broker/src/mint.ts
@@ -5,6 +5,13 @@
  * management API using a single-flight lock to prevent lost-update races on
  * the shared `api-keys` array.
  *
+ * Key names are self-describing: `ghact-<runId>-<expiresAtEpochMs>-<hexrand>`.
+ * The embedded expiry makes key-lifecycle decisions time-based instead of
+ * dependent on in-memory live-set membership — the sweeper's `reconcile` can
+ * parse a key's expiry straight from its name after a broker restart, when
+ * the live set is empty but a run may still be legitimately in-flight.
+ * See `parseKeyExpiry`.
+ *
  * Single-instance invariant: the lock is valid because there is exactly one
  * broker instance (single droplet, no horizontal scaling). If the broker is
  * ever scaled out, this in-process lock is insufficient and a distributed lock
@@ -84,15 +91,53 @@ const KEY_PREFIX = 'ghact-'
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a unique broker key for the given run.
- * Format: `ghact-<runId>-<random>` — greppable prefix, CSPRNG hex suffix for uniqueness.
+ * Generate a unique, self-describing broker key for the given run.
+ *
+ * Format: `ghact-<runId>-<expiresAtEpochMs>-<hexrand>` — greppable prefix,
+ * embedded expiry as the second-to-last hyphen segment, CSPRNG hex suffix as
+ * the last segment. The runId may itself contain hyphens/digits; parsing
+ * (see `parseKeyExpiry`) anchors on the last two segments, so this is safe.
+ *
  * Uses crypto.getRandomValues for a cryptographically secure random suffix.
  */
-function generateKey(runId: string): string {
+function generateKey(runId: string, expiresAt: number): string {
   const bytes = new Uint8Array(8)
   crypto.getRandomValues(bytes)
   const random = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
-  return `${KEY_PREFIX}${runId}-${random}`
+  return `${KEY_PREFIX}${runId}-${expiresAt}-${random}`
+}
+
+/**
+ * Regex anchoring on the LAST TWO hyphen-delimited segments of a `ghact-`
+ * key: an all-digit expiry (epoch ms) followed by an all-hex random suffix.
+ * Everything between the `ghact-` prefix and those two segments is the
+ * runId, which may itself contain hyphens or digits — greedy backtracking
+ * on the runId capture group resolves the ambiguity correctly.
+ */
+const KEY_EXPIRY_PATTERN = /^ghact-.+-(\d+)-[0-9a-f]+$/
+
+/**
+ * Parses the embedded expiry (epoch ms) out of a broker-minted key name.
+ *
+ * Returns the expiry as a number for a well-formed `ghact-<runId>-<epochMs>-<hex>`
+ * key. Returns `null` for a non-`ghact-` key OR a malformed/legacy `ghact-`
+ * key that has no numeric expiry segment (e.g. the pre-fix format
+ * `ghact-<runId>-<hex>`). This is a strict parse — never best-effort — so
+ * callers can safely treat `null` as "cannot prove this key's expiry" and
+ * refuse to revoke it.
+ */
+export function parseKeyExpiry(key: string): number | null {
+  if (!key.startsWith(KEY_PREFIX)) {
+    return null
+  }
+
+  const match = KEY_EXPIRY_PATTERN.exec(key)
+  if (!match) {
+    return null
+  }
+
+  const expiry = Number(match[1])
+  return Number.isSafeInteger(expiry) ? expiry : null
 }
 
 /**
@@ -153,8 +198,11 @@ async function putApiKeys(baseUrl: string, managementKey: string, keys: string[]
 /**
  * Mint a short-lived cliproxy key for the given run.
  *
- * Generates a key with the format `ghact-<runId>-<random>`, then — holding
- * the single-flight lock — performs:
+ * Generates a key with the format `ghact-<runId>-<expiresAtEpochMs>-<hexrand>`
+ * — the caller computes `expiresAt` ONCE and passes it in, so the embedded
+ * expiry always matches whatever the caller records elsewhere (e.g. the
+ * live-set entry in server.ts). Then — holding the single-flight lock —
+ * performs:
  *   1. GET /v0/management/api-keys (read current list)
  *   2. Append the new key (preserving ALL existing keys)
  *   3. PUT the full array back
@@ -166,9 +214,9 @@ async function putApiKeys(baseUrl: string, managementKey: string, keys: string[]
  *
  * Returns the minted key string. Never logs the key value or the management key.
  */
-export async function mintKey(runId: string, deps: MintDeps): Promise<string> {
+export async function mintKey(runId: string, expiresAt: number, deps: MintDeps): Promise<string> {
   const {managementUrl, managementKey, fetch: fetchFn = globalThis.fetch} = deps
-  const key = generateKey(runId)
+  const key = generateKey(runId, expiresAt)
 
   return withLock(async () => {
     // Step 1: GET current list (strict parse — throws on malformed)

--- a/apps/broker/src/server.ts
+++ b/apps/broker/src/server.ts
@@ -46,8 +46,8 @@ export interface ServerDeps {
   verifyOidcToken: (token: string) => Promise<VerifyResult>
   /** Evaluates verified claims against the trust policy. */
   evaluateClaims: (claims: Record<string, string | undefined>) => EvaluateResult
-  /** Mints a cliproxy key for the given run ID. */
-  mintKey: (runId: string) => Promise<string>
+  /** Mints a cliproxy key for the given run ID, expiring at the given epoch ms. */
+  mintKey: (runId: string, expiresAt: number) => Promise<string>
   /** Records a minted entry in the live set. */
   recordMint: (entry: LiveEntry) => void
   /** Returns true when the startup reconcile has completed. */
@@ -211,10 +211,13 @@ async function handleMint(req: Request, deps: ServerDeps): Promise<Response> {
     return jsonResponse(403, {error: 'claims do not satisfy trust policy'})
   }
 
-  // 6. Mint the key. On failure, return a generic 5xx with no secret bytes.
+  // 6. Mint the key. expiresAt is computed ONCE and passed to mintKey so the
+  //    embedded key-name expiry and the live-set record always agree.
+  //    On failure, return a generic 5xx with no secret bytes.
+  const expiresAt = now + DEFAULT_KEY_TTL_MS
   let mintedKey: string
   try {
-    mintedKey = await mintKey(runId ?? 'unknown')
+    mintedKey = await mintKey(runId ?? 'unknown', expiresAt)
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'mint failed'
     auditError({ts, srcIp, jti, repositoryId, workflowRef, reason}, auditLogger)
@@ -222,12 +225,12 @@ async function handleMint(req: Request, deps: ServerDeps): Promise<Response> {
     return jsonResponse(500, {error: 'internal error — mint failed'})
   }
 
-  // 7. Record in live set. expiresAt is now + DEFAULT_KEY_TTL_MS.
+  // 7. Record in live set with the SAME expiresAt passed to mintKey.
   recordMint({
     key: mintedKey,
     runId: runId ?? 'unknown',
     jti: jti ?? 'unknown',
-    expiresAt: now + DEFAULT_KEY_TTL_MS,
+    expiresAt,
   })
 
   // 8. Audit the successful mint. Never log the minted key value.

--- a/apps/broker/src/sweeper.test.ts
+++ b/apps/broker/src/sweeper.test.ts
@@ -28,6 +28,11 @@ function makeEntry(key: string, expiresAt: number, runId = 'run-1', jti = 'jti-1
   return {key, runId, jti, expiresAt}
 }
 
+/** Build a well-formed, self-describing `ghact-<runId>-<expiresAt>-<hex>` key for tests. */
+function ghactKey(runId: string, expiresAt: number, suffix = 'abcd1234'): string {
+  return `ghact-${runId}-${expiresAt}-${suffix}`
+}
+
 // ---------------------------------------------------------------------------
 // sweepExpired — happy path: entry past TTL is swept
 // ---------------------------------------------------------------------------
@@ -176,42 +181,18 @@ describe('sweepExpired — integration: crashed run', () => {
 })
 
 // ---------------------------------------------------------------------------
-// reconcile — integration: restart recovery
+// reconcile — integration: restart recovery (TIME-BASED, not live-set-based)
 // ---------------------------------------------------------------------------
 
 describe('reconcile — integration: restart recovery', () => {
-  test('revokes a ghact- key present in cliproxy but absent from live set', async () => {
-    const staleKey = 'ghact-run-stale-abc'
+  test('KEEPS an active post-restart key: live-set empty, key expiry is in the future', async () => {
+    const now = 1_000_000
+    const activeKey = ghactKey('run123', now + 60_000)
 
     const revokeKey = mock(async (_key: string, _deps: unknown) => {})
     const removeKey = mock((_key: string) => {})
-    // Live set is empty (broker restarted)
+    // Live set is empty (broker restarted) — must NOT be consulted for this decision.
     const listLive = mock(() => [] as LiveEntry[])
-    // cliproxy still has the stale key
-    const listApiKeys = mock(async () => [staleKey])
-
-    const deps: SweeperDeps = {
-      revokeKey,
-      removeKey,
-      listLive,
-      listApiKeys,
-      markReady: mock(() => {}),
-      mintDeps: makeMintDeps(),
-    }
-
-    await reconcile(deps)
-
-    expect(revokeKey).toHaveBeenCalledTimes(1)
-    expect(revokeKey.mock.calls[0]?.[0]).toBe(staleKey)
-  })
-
-  test('does not revoke a ghact- key that IS in the live set (active run)', async () => {
-    const activeKey = 'ghact-run-active-abc'
-    const activeEntry = makeEntry(activeKey, Date.now() + 60_000)
-
-    const revokeKey = mock(async (_key: string, _deps: unknown) => {})
-    const removeKey = mock((_key: string) => {})
-    const listLive = mock(() => [activeEntry])
     const listApiKeys = mock(async () => [activeKey])
 
     const deps: SweeperDeps = {
@@ -223,9 +204,122 @@ describe('reconcile — integration: restart recovery', () => {
       mintDeps: makeMintDeps(),
     }
 
-    await reconcile(deps)
+    await reconcile(now, deps)
 
     expect(revokeKey).not.toHaveBeenCalled()
+  })
+
+  test('REVOKES an expired post-restart key: live-set empty, key expiry is in the past', async () => {
+    const now = 1_000_000
+    const expiredKey = ghactKey('run123', now - 60_000)
+
+    const revokeKey = mock(async (_key: string, _deps: unknown) => {})
+    const removeKey = mock((_key: string) => {})
+    const listLive = mock(() => [] as LiveEntry[])
+    const listApiKeys = mock(async () => [expiredKey])
+
+    const deps: SweeperDeps = {
+      revokeKey,
+      removeKey,
+      listLive,
+      listApiKeys,
+      markReady: mock(() => {}),
+      mintDeps: makeMintDeps(),
+    }
+
+    await reconcile(now, deps)
+
+    expect(revokeKey).toHaveBeenCalledTimes(1)
+    expect(revokeKey.mock.calls[0]?.[0]).toBe(expiredKey)
+  })
+
+  test('live-set membership does NOT protect an expired key — revokes anyway', async () => {
+    const now = 1_000_000
+    const expiredKey = ghactKey('run-active', now - 1)
+    // Key IS in the live set (e.g. stale entry that outlived its own TTL sweep).
+    const liveEntry = makeEntry(expiredKey, now + 60_000, 'run-active')
+
+    const revokeKey = mock(async (_key: string, _deps: unknown) => {})
+    const removeKey = mock((_key: string) => {})
+    const listLive = mock(() => [liveEntry])
+    const listApiKeys = mock(async () => [expiredKey])
+
+    const deps: SweeperDeps = {
+      revokeKey,
+      removeKey,
+      listLive,
+      listApiKeys,
+      markReady: mock(() => {}),
+      mintDeps: makeMintDeps(),
+    }
+
+    await reconcile(now, deps)
+
+    // The key-name expiry (past) is authoritative — live-set membership is irrelevant.
+    expect(revokeKey).toHaveBeenCalledTimes(1)
+    expect(revokeKey.mock.calls[0]?.[0]).toBe(expiredKey)
+  })
+
+  test('boundary: expiry === now → revoke; expiry === now + 1 → keep', async () => {
+    const now = 1_000_000
+    const atBoundaryKey = ghactKey('run-boundary', now, 'aaaa1111')
+    const justAfterKey = ghactKey('run-boundary', now + 1, 'bbbb2222')
+
+    const revokeKey = mock(async (_key: string, _deps: unknown) => {})
+    const removeKey = mock((_key: string) => {})
+    const listLive = mock(() => [] as LiveEntry[])
+    const listApiKeys = mock(async () => [atBoundaryKey, justAfterKey])
+
+    const deps: SweeperDeps = {
+      revokeKey,
+      removeKey,
+      listLive,
+      listApiKeys,
+      markReady: mock(() => {}),
+      mintDeps: makeMintDeps(),
+    }
+
+    await reconcile(now, deps)
+
+    expect(revokeKey).toHaveBeenCalledTimes(1)
+    expect(revokeKey.mock.calls[0]?.[0]).toBe(atBoundaryKey)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reconcile — legacy/malformed ghact- keys: never revoked (migration safety)
+// ---------------------------------------------------------------------------
+
+describe('reconcile — legacy/malformed ghact- key handling', () => {
+  test('does NOT revoke a legacy ghact- key with no numeric expiry segment, logs a warning', async () => {
+    const now = 1_000_000
+    const legacyKey = 'ghact-run123-abcd'
+
+    const revokeKey = mock(async (_key: string, _deps: unknown) => {})
+    const removeKey = mock((_key: string) => {})
+    const listLive = mock(() => [] as LiveEntry[])
+    const listApiKeys = mock(async () => [legacyKey])
+    const loggerError = mock((_msg: string) => {})
+
+    const deps: SweeperDeps = {
+      revokeKey,
+      removeKey,
+      listLive,
+      listApiKeys,
+      markReady: mock(() => {}),
+      mintDeps: makeMintDeps(),
+      logger: {error: loggerError},
+    }
+
+    await reconcile(now, deps)
+
+    expect(revokeKey).not.toHaveBeenCalled()
+    expect(loggerError).toHaveBeenCalledTimes(1)
+    const msg: string = loggerError.mock.calls[0]?.[0] ?? ''
+    expect(msg).toContain('skipping unparseable ghact- key')
+    expect(msg).toContain('legacy/malformed')
+    // Only a short prefix of the key is logged, not the full key.
+    expect(msg).toContain(legacyKey.slice(0, 12))
   })
 })
 
@@ -234,17 +328,18 @@ describe('reconcile — integration: restart recovery', () => {
 // ---------------------------------------------------------------------------
 
 describe('reconcile — safety: never deletes non-ghact- keys', () => {
-  test('only revokes the stale ghact- key; leaves durable key and other consumers untouched', async () => {
+  test('only revokes the expired ghact- key; leaves durable key and other consumers untouched', async () => {
+    const now = 1_000_000
     const durableKey = 'sk-ant-durable-key-abc123'
     const otherConsumerKey = 'some-other-consumer-key'
-    const staleGhactKey = 'ghact-run-stale-xyz'
+    const expiredGhactKey = ghactKey('run-stale', now - 1)
 
     const revokeKey = mock(async (_key: string, _deps: unknown) => {})
     const removeKey = mock((_key: string) => {})
     // Live set is empty (broker restarted)
     const listLive = mock(() => [] as LiveEntry[])
     // cliproxy has all three keys
-    const listApiKeys = mock(async () => [durableKey, otherConsumerKey, staleGhactKey])
+    const listApiKeys = mock(async () => [durableKey, otherConsumerKey, expiredGhactKey])
 
     const deps: SweeperDeps = {
       revokeKey,
@@ -255,11 +350,11 @@ describe('reconcile — safety: never deletes non-ghact- keys', () => {
       mintDeps: makeMintDeps(),
     }
 
-    await reconcile(deps)
+    await reconcile(now, deps)
 
-    // Only the stale ghact- key is revoked
+    // Only the expired ghact- key is revoked
     expect(revokeKey).toHaveBeenCalledTimes(1)
-    expect(revokeKey.mock.calls[0]?.[0]).toBe(staleGhactKey)
+    expect(revokeKey.mock.calls[0]?.[0]).toBe(expiredGhactKey)
 
     // The durable key and other consumer key are never touched
     const revokedKeys = revokeKey.mock.calls.map(c => c[0])
@@ -267,15 +362,16 @@ describe('reconcile — safety: never deletes non-ghact- keys', () => {
     expect(revokedKeys).not.toContain(otherConsumerKey)
   })
 
-  test('revokes multiple stale ghact- keys but leaves all non-ghact- keys', async () => {
+  test('revokes multiple expired ghact- keys but leaves all non-ghact- keys', async () => {
+    const now = 1_000_000
     const durableKey = 'sk-ant-durable-key-abc123'
-    const staleKey1 = 'ghact-run-stale-1-abc'
-    const staleKey2 = 'ghact-run-stale-2-xyz'
+    const expiredKey1 = ghactKey('run-stale-1', now - 1, 'aaaa0001')
+    const expiredKey2 = ghactKey('run-stale-2', now - 1, 'bbbb0002')
 
     const revokeKey = mock(async (_key: string, _deps: unknown) => {})
     const removeKey = mock((_key: string) => {})
     const listLive = mock(() => [] as LiveEntry[])
-    const listApiKeys = mock(async () => [durableKey, staleKey1, staleKey2])
+    const listApiKeys = mock(async () => [durableKey, expiredKey1, expiredKey2])
 
     const deps: SweeperDeps = {
       revokeKey,
@@ -286,16 +382,17 @@ describe('reconcile — safety: never deletes non-ghact- keys', () => {
       mintDeps: makeMintDeps(),
     }
 
-    await reconcile(deps)
+    await reconcile(now, deps)
 
     expect(revokeKey).toHaveBeenCalledTimes(2)
     const revokedKeys = revokeKey.mock.calls.map(c => c[0])
-    expect(revokedKeys).toContain(staleKey1)
-    expect(revokedKeys).toContain(staleKey2)
+    expect(revokedKeys).toContain(expiredKey1)
+    expect(revokedKeys).toContain(expiredKey2)
     expect(revokedKeys).not.toContain(durableKey)
   })
 
   test('does nothing when cliproxy has no ghact- keys', async () => {
+    const now = 1_000_000
     const revokeKey = mock(async (_key: string, _deps: unknown) => {})
     const removeKey = mock((_key: string) => {})
     const listLive = mock(() => [] as LiveEntry[])
@@ -310,7 +407,7 @@ describe('reconcile — safety: never deletes non-ghact- keys', () => {
       mintDeps: makeMintDeps(),
     }
 
-    await reconcile(deps)
+    await reconcile(now, deps)
 
     expect(revokeKey).not.toHaveBeenCalled()
   })
@@ -322,8 +419,9 @@ describe('reconcile — safety: never deletes non-ghact- keys', () => {
 
 describe('startupReconcile — startup gate ordering', () => {
   test('runs reconcile BEFORE markReady — stale key is gone before ready flips', async () => {
+    const now = 1_000_000
     const callOrder: string[] = []
-    const staleKey = 'ghact-run-stale-boot-abc'
+    const staleKey = ghactKey('run-stale-boot', now - 1)
 
     const revokeKey = mock(async (_key: string, _deps: unknown) => {
       callOrder.push('revokeKey')
@@ -345,6 +443,7 @@ describe('startupReconcile — startup gate ordering', () => {
       listApiKeys,
       markReady,
       mintDeps: makeMintDeps(),
+      clock: () => now,
     }
 
     await startupReconcile(deps)
@@ -544,7 +643,7 @@ describe('reconcile — error path: listApiKeys failure caught', () => {
     }
 
     // Must not throw
-    await expect(reconcile(deps)).resolves.toBeUndefined()
+    await expect(reconcile(1_000_000, deps)).resolves.toBeUndefined()
 
     expect(loggerError).toHaveBeenCalledTimes(1)
     const msg: string = loggerError.mock.calls[0]?.[0] ?? ''
@@ -561,7 +660,8 @@ describe('reconcile — error path: listApiKeys failure caught', () => {
 
 describe('reconcile — error path: revokeKey failure reported via logger', () => {
   test('calls logger.error with key prefix when revokeKey throws during reconcile', async () => {
-    const staleKey = 'ghact-run-stale-fail-xyz'
+    const now = 1_000_000
+    const staleKey = ghactKey('run-stale-fail', now - 1, 'abcd1234')
 
     const revokeKey = mock(async (_key: string, _deps: unknown) => {
       throw new Error('revoke network error')
@@ -581,7 +681,7 @@ describe('reconcile — error path: revokeKey failure reported via logger', () =
       logger: {error: loggerError},
     }
 
-    await reconcile(deps)
+    await reconcile(now, deps)
 
     expect(loggerError).toHaveBeenCalledTimes(1)
     const msg: string = loggerError.mock.calls[0]?.[0] ?? ''
@@ -624,6 +724,7 @@ describe('startupReconcile — bounded retry on listApiKeys failure', () => {
   })
 
   test('succeeds on first attempt when listApiKeys works', async () => {
+    const now = 1_000_000
     const markReady = mock(() => {})
     const revokeKey = mock(async () => {})
 
@@ -631,9 +732,10 @@ describe('startupReconcile — bounded retry on listApiKeys failure', () => {
       revokeKey,
       removeKey: mock(() => {}),
       listLive: mock(() => [] as LiveEntry[]),
-      listApiKeys: mock(async () => ['ghact-run-stale-abc']),
+      listApiKeys: mock(async () => [ghactKey('run-stale', now - 1)]),
       markReady,
       mintDeps: makeMintDeps(),
+      clock: () => now,
     }
 
     await startupReconcile(deps)
@@ -736,8 +838,8 @@ describe('startSweeper — periodic ticks', () => {
     expect(clearedIds).toHaveLength(2)
   })
 
-  test('reconcile tick revokes stale ghact- keys via injected setInterval', async () => {
-    const staleKey = 'ghact-run-reconcile-tick-abc'
+  test('reconcile tick revokes expired ghact- keys via injected setInterval', async () => {
+    const staleKey = ghactKey('run-reconcile-tick', Date.now() - 1)
     let reconcileTickFn: (() => void) | undefined
     let callCount = 0
 

--- a/apps/broker/src/sweeper.ts
+++ b/apps/broker/src/sweeper.ts
@@ -4,17 +4,27 @@
  * Guarantees minted keys are revoked even when a run crashes or cancels
  * without signalling. Two mechanisms:
  *
- * 1. `sweepExpired(now, deps)` — for each live entry with expiresAt <= now,
- *    revokes the key and removes it from the live set. This is the mandatory
- *    TTL backstop, independent of any run-end callback.
+ * 1. `sweepExpired(now, deps)` — for each live entry, revokes the key when
+ *    its AUTHORITATIVE expiry (parsed from the key name via `parseKeyExpiry`,
+ *    falling back to the live-set's `expiresAt` only if the key is
+ *    unparseable) is `<= now`. This is the mandatory TTL backstop,
+ *    independent of any run-end callback.
  *
- * 2. `reconcile(deps)` — lists cliproxy's current api-keys; for every key
- *    that starts with KEY_PREFIX (`ghact-`) AND is NOT in the current live
- *    set, revokes it. Recovers from a broker restart where the in-memory live
- *    set is empty but stale broker-owned keys remain in cliproxy.
+ * 2. `reconcile(now, deps)` — lists cliproxy's current api-keys and makes a
+ *    TIME-BASED decision per key, using ONLY the key name — never live-set
+ *    membership:
+ *      - non-`ghact-` key → skip (never touched).
+ *      - `ghact-` key with a parseable expiry `<= now` → revoke (truly expired).
+ *      - `ghact-` key with a parseable expiry `> now` → keep (still valid,
+ *        regardless of live-set membership — this is what makes an in-flight
+ *        key survive a broker restart, when the live set is empty).
+ *      - `ghact-` key with NO parseable expiry (legacy/malformed) → keep and
+ *        log a warning. We can never prove a key we cannot parse is expired,
+ *        so the safe default is to leave it for manual cleanup.
  *
  *    SAFETY INVARIANT: reconcile NEVER deletes a non-`ghact-` key. The prefix
- *    guard is explicit and tested hard.
+ *    guard is explicit and tested hard. The live set is a cache/audit aid
+ *    only — it is never consulted for revocation evidence.
  *
  * 3. `startupReconcile(deps)` — runs reconcile once, then calls markReady().
  *    Order is mandatory: reconcile BEFORE markReady so /v1/mint cannot serve
@@ -32,7 +42,7 @@ import type {LiveEntry} from './live-set'
 import type {MintDeps} from './mint'
 
 import {auditRevoke} from './audit'
-import {KEY_PREFIX} from './mint'
+import {KEY_PREFIX, parseKeyExpiry} from './mint'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,6 +77,8 @@ export interface SweeperDeps {
   logger?: SweeperLogger
   /** Audit logger for revoke events. When omitted, revoke events are not audited. */
   auditLogger?: AuditLoggerDeps
+  /** Injectable clock returning current epoch ms (default: Date.now). Used by startupReconcile. */
+  clock?: () => number
 }
 
 /** Injectable options for startSweeper. */
@@ -95,7 +107,15 @@ const DEFAULT_RECONCILE_INTERVAL_MS = 300_000
 // ---------------------------------------------------------------------------
 
 /**
- * Sweep all live entries whose expiresAt <= now.
+ * Sweep all live entries whose AUTHORITATIVE expiry is <= now.
+ *
+ * The authoritative expiry is `parseKeyExpiry(entry.key)` when the key name
+ * parses (the normal case for every key minted since this fix); it falls
+ * back to the live-set's own `entry.expiresAt` only when the key is
+ * unparseable (shouldn't happen for new keys, but keeps this function
+ * correct for any legacy live-set entry). This keeps a single source of
+ * truth — the key name — while preserving the live set's role for
+ * runId/jti audit and the happy-path revoke.
  *
  * For each expired entry: revokes the key via cliproxy management API, then
  * removes it from the live set. This is the mandatory TTL backstop —
@@ -111,7 +131,8 @@ export async function sweepExpired(now: number, deps: SweeperDeps): Promise<void
   const ts = new Date(now).toISOString()
 
   for (const entry of entries) {
-    if (entry.expiresAt <= now) {
+    const authoritativeExpiry = parseKeyExpiry(entry.key) ?? entry.expiresAt
+    if (authoritativeExpiry <= now) {
       try {
         await revokeKey(entry.key, mintDeps)
         // Only remove from live set on successful revoke so the next tick retries.
@@ -132,22 +153,35 @@ export async function sweepExpired(now: number, deps: SweeperDeps): Promise<void
 }
 
 /**
- * Reconcile cliproxy's api-keys list against the in-memory live set.
+ * Reconcile cliproxy's api-keys list using a TIME-BASED decision per key —
+ * never live-set membership. The live set is a cache/audit aid only; it is
+ * not consulted here.
  *
- * Lists all current cliproxy api-keys. For every key that:
- *   - starts with the broker prefix (`ghact-`), AND
- *   - is NOT present in the current live set
- * → revokes it.
+ * Lists all current cliproxy api-keys. For each key:
+ *   - non-`ghact-` prefix → skip (SAFETY INVARIANT: never touch non-broker
+ *     keys — durable key, other consumers' keys).
+ *   - `ghact-` key with a parseable expiry `<= now` → revoke (truly expired).
+ *   - `ghact-` key with a parseable expiry `> now` → keep, regardless of
+ *     live-set membership. This is what makes an in-flight key survive a
+ *     broker restart: the live set is empty after restart, but the key name
+ *     itself proves the key is still valid.
+ *   - `ghact-` key with NO parseable expiry (legacy/malformed — e.g. the
+ *     pre-fix `ghact-<runId>-<hex>` format with no expiry segment) → keep
+ *     and log a warning. We can never prove an unparseable key is expired,
+ *     so the safe default is to leave it in place rather than delete a
+ *     possibly-active key.
  *
  * This recovers from a broker restart where the in-memory live set is empty
- * but stale broker-owned keys remain in cliproxy.
+ * but a still-valid, in-flight run's key remains in cliproxy — the old
+ * membership-based logic would incorrectly treat that as stale and revoke
+ * it, causing 401s in the running job.
  *
  * SAFETY INVARIANT: only keys starting with `ghact-` are ever revoked.
  * Non-broker keys (durable key, other consumers' keys) are NEVER touched.
  * This guard is explicit and tested.
  */
-export async function reconcile(deps: SweeperDeps): Promise<void> {
-  const {revokeKey, listApiKeys, listLive, mintDeps, logger = console} = deps
+export async function reconcile(now: number, deps: SweeperDeps): Promise<void> {
+  const {revokeKey, listApiKeys, mintDeps, logger = console} = deps
 
   let allKeys: string[]
   try {
@@ -158,25 +192,34 @@ export async function reconcile(deps: SweeperDeps): Promise<void> {
     return
   }
 
-  const liveEntries = listLive()
-
-  // Build a set of keys currently in the live set for O(1) lookup.
-  const liveKeys = new Set(liveEntries.map(e => e.key))
-
   for (const key of allKeys) {
     // SAFETY: only touch broker-owned keys. Never delete non-ghact- keys.
     if (!key.startsWith(KEY_PREFIX)) {
       continue
     }
 
-    // Key is broker-owned but not in the live set → stale, revoke it.
-    if (!liveKeys.has(key)) {
-      try {
-        await revokeKey(key, mintDeps)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        logger.error(`[sweeper] reconcile: revokeKey failed for key prefix ${key.slice(0, 12)}…: ${message}`)
-      }
+    const expiry = parseKeyExpiry(key)
+
+    if (expiry === null) {
+      // Legacy/malformed ghact- key — cannot prove expiry, do not revoke.
+      logger.error(
+        `[sweeper] reconcile: skipping unparseable ghact- key ${key.slice(0, 12)}… — not revoking (legacy/malformed)`,
+      )
+      continue
+    }
+
+    if (expiry > now) {
+      // Still valid per the key's own embedded expiry — keep it, even if
+      // the live set has no record of it (e.g. post-restart).
+      continue
+    }
+
+    // Expiry <= now — truly expired, revoke it.
+    try {
+      await revokeKey(key, mintDeps)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error(`[sweeper] reconcile: revokeKey failed for key prefix ${key.slice(0, 12)}…: ${message}`)
     }
   }
 }
@@ -200,11 +243,11 @@ const STARTUP_RECONCILE_BACKOFF_MS = [500, 1_000] as const
  * permanently is worse than a brief stale-key window.
  */
 export async function startupReconcile(deps: SweeperDeps): Promise<void> {
-  const {logger = console} = deps
+  const {logger = console, clock = Date.now} = deps
 
   for (let attempt = 0; attempt < STARTUP_RECONCILE_MAX_ATTEMPTS; attempt++) {
     try {
-      await reconcile(deps)
+      await reconcile(clock(), deps)
       deps.markReady()
       return
     } catch (error) {
@@ -253,7 +296,7 @@ export function startSweeper(deps: SweeperDeps, opts: SweeperOpts = {}): () => v
   }, sweepIntervalMs)
 
   const reconcileId = setIntervalFn(async () => {
-    await reconcile(deps)
+    await reconcile(clock(), deps)
   }, reconcileIntervalMs)
 
   return () => {


### PR DESCRIPTION
## Problem

The broker tracked each minted key's expiry only in an in-memory live-set, and `reconcile()` revoked any `ghact-` key that wasn't in that set. On a broker restart — a deploy, crash, or OOM — the live-set starts empty, so the startup reconcile treated every outstanding minted key as an orphan and revoked it, including the still-valid keys of runs that were live at the time. The running merge agent then failed with `401 Invalid API key`.

This bit in production: a deploy force-recreated the broker mid-run, the startup reconcile deleted the in-flight key, and the merge's model call 401'd. `reconcile` was using "absent from the in-memory live-set" as revocation evidence, which is false after a restart — it can't tell an orphan from a previous instance apart from an in-flight key of a currently-running job.

## Fix

Make the key name carry the one restart-stable fact — its expiry — and make the lifecycle decision time-based instead of membership-based.

- **Key format:** `ghact-<runId>-<expiresAtEpochMs>-<hexrand>`. Expiry is computed once at mint and both embedded in the key and recorded in the live-set.
- **`reconcile` is now time-based:** parse the embedded expiry; revoke only if it's `<= now`; keep a valid key regardless of live-set membership. A restart can no longer misjudge an in-flight key as orphaned.
- **Legacy/malformed `ghact-` keys** (no embedded expiry) are skipped with a warning, never auto-revoked — so the first deploy of this change cannot wipe a pre-existing in-flight key.
- **`sweepExpired`** derives authoritative expiry from the key name (falling back to the live-set entry only if unparseable). The live-set is now a cache / audit aid, not the liveness authority.

The design was reviewed independently before implementation. `cliproxy` still does not itself enforce the embedded expiry — if a hard server-side max lifetime is ever required, that belongs in cliproxy's request authorization; this change is about not deleting keys we can't prove are expired.

## Verification

221 broker tests pass (new coverage: `parseKeyExpiry` including hyphenated runIds and legacy-key rejection; reconcile keeps a valid post-restart key, revokes an expired one, ignores live-set membership for an expired key, skips legacy keys; boundary at `expiry === now`). Type-check and lint clean.

## Rollout note

There are no `ghact-` keys in cliproxy at present, so the migration edge is clean, and legacy keys are skipped-not-revoked regardless. Best deployed outside an active harness run.
