### PR TITLE
chore(gateway): bump upstream fro-bot/agent to v0.81.0

### DIFF
--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.79.1"
+  "ref": "v0.81.0"
 }


### PR DESCRIPTION
Move the pinned gateway daemon ref from `v0.79.1` to `v0.81.0`.

## Verify-at-tag

Diffed the daemon deploy contract at the new tag against our compose wiring before bumping:

- **`deploy/compose.yaml`** — only change is additive container hardening on the gateway service (`cap_drop: ALL`, `security_opt: no-new-privileges:true`; upstream #1053). No new required secret or env var, so the `deploy.ts` secret/env materialization is unaffected, and our generated `compose.override.yaml` still deep-merges cleanly.
- **Dockerfiles** — node base `24.17.0`→`24.18.0`; workspace `OPENCODE_VERSION` `1.17.11`→`1.17.13+harness.035e6656` (baked in CI from the pinned ref).
- **mitmproxy allowlist + workspace entrypoint** — unchanged.

The intervening "Breaking" marker (v0.79.4) is an upstream CI change (TOML config PR-review gate), not part of the gateway daemon deploy contract. v0.80.0/v0.81.0 are the harness credential-broker and OpenCode-build updates.

## Rollout

Merging triggers the gated gateway deploy: CI builds fresh `v0.81.0` gateway + workspace images and the deploy holds at the `gateway` environment approval gate. No changeset — not a `packages/cli/src/` change.