### PR TITLE
chore(gateway): bump upstream fro-bot/agent to v0.83.0

### DIFF
--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.81.0"
+  "ref": "v0.83.0"
 }


### PR DESCRIPTION
Bumps the gateway daemon pin `apps/gateway/upstream.json` from `v0.81.0` to `v0.83.0`.

## Verify-at-tag

Diffed the daemon deploy contract between `v0.81.0` and `v0.83.0` — no new required secret or env var, so no deploy-script change is needed:

- `deploy/compose.yaml` — identical
- `deploy/gateway.Dockerfile` — identical
- `deploy/mitmproxy/allowlist.py` — identical
- `deploy/workspace-entrypoint.sh` — identical
- `deploy/workspace.Dockerfile` — only the `OPENCODE_VERSION` build-metadata tag changes (same 1.17.13 base)

## What's in v0.82.0 → v0.83.0

Application-level gateway run-lifecycle work (event-count timeout detection, sanitized operator failure reason on run status, operator-initiated run cancellation) plus run-state persistence fixes. None of it touches the deploy contract.

Note: the Fro Bot review-action SHA in `.github/workflows/fro-bot.yaml` is a separate, independently-tracked pin and is intentionally not changed here.