### PR TITLE
docs(structure): correct dashboard deploy description

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -10,7 +10,7 @@ Where things live and where to put new code. For system shape, data flow, and in
 │   ├── cliproxy/               CLIProxyAPI Claude proxy (DigitalOcean + Docker Compose)
 │   ├── gateway/                Fro Bot Discord gateway (DigitalOcean + Docker Compose)
 │   ├── umami/                  Umami analytics (DigitalOcean + Docker Compose)
-│   ├── dashboard/              Fro Bot monitoring dashboard (DigitalOcean + Docker Compose + GHCR image build)
+│   ├── dashboard/              Fro Bot monitoring dashboard (DigitalOcean + Docker Compose)
 │   ├── vpn/                    WireGuard egress box (AWS Lightsail eu-west-1, native wg-quick@wg0)
 │   └── broker/                 OIDC credential broker (DigitalOcean + Docker Compose)
 ├── packages/                   Reusable libraries (never import from apps/)


### PR DESCRIPTION
Fixes a stale line in `STRUCTURE.md`. The directory-layout entry for `apps/dashboard/` claimed `+ GHCR image build`, but nothing in this repo builds the dashboard image — `apps/dashboard/` has no Dockerfile and `deploy-dashboard.yaml` has no build step (only image pinning). The image is pulled digest-pinned from `ghcr.io/fro-bot/dashboard`, built by the dashboard's own CI.

This also contradicted the `Key File Locations` table in the same file, which already describes the image as a digest-pinned pull. Dropping `+ GHCR image build` makes the two consistent and matches `ARCHITECTURE.md` ("no CI image build step").

Docs-only, single line. No code or workflow changes.