### PR TITLE
chore(gateway): bump upstream fro-bot/agent to v0.86.0

### DIFF
--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.83.0"
+  "ref": "v0.86.0"
 }


### PR DESCRIPTION
Bumps the gateway daemon pin `apps/gateway/upstream.json` from `v0.83.0` to `v0.86.0` (v0.84.x, v0.85.x, v0.86.0).

## Verify-at-tag

Diffed the daemon deploy contract between `v0.83.0` and `v0.86.0` — no new required secret or env var, no deploy-script change needed:

- `deploy/compose.yaml` — identical
- `deploy/gateway.Dockerfile` — identical
- `deploy/mitmproxy/allowlist.py` — identical
- `deploy/workspace-entrypoint.sh` — identical
- `deploy/workspace.Dockerfile` — build-metadata only: `OPENCODE_VERSION` 1.17.13+harness → **1.17.18+harness.4ec05a47**, `SYSTEMATIC_VERSION` 2.32.1 → 2.33.2

## What's in v0.83.0 → v0.86.0

Application-level gateway/harness work: run-lifecycle features and state-persistence fixes (v0.83.x–v0.84.x), removal of the agent's GitHub credential on comment/review flows (v0.85.1, #1170), OpenCode harness base bump to 1.17.18 with 17 carries (v0.86.0). None of it touches the deploy contract.

Note: the Fro Bot review-action SHA in `.github/workflows/fro-bot.yaml` is a separate, independently-tracked pin (already at v0.85.0 via #808) and is not changed here.