### PR TITLE
docs(plans): reconcile stale plan statuses against shipped work

### DIFF
--- a/docs/plans/2026-05-20-001-feat-discord-token-lifecycle-runbook-plan.md
+++ b/docs/plans/2026-05-20-001-feat-discord-token-lifecycle-runbook-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Discord token-lifecycle runbook'
 type: feat
-status: active
+status: completed
 date: 2026-05-20
 origin: https://github.com/marcusrbrown/infra/issues/269
 ---

--- a/docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md
+++ b/docs/plans/2026-05-23-001-feat-mcp-fidelity-status-only-plan.md
@@ -1,7 +1,7 @@
 ---
 title: MCP Fidelity for Read-Style CLI Commands
 type: feat
-status: active
+status: completed
 date: 2026-05-23
 origin: docs/brainstorms/2026-05-23-mcp-fidelity-status-only-requirements.md
 ---

--- a/docs/plans/2026-05-23-002-feat-cliproxy-login-codex-plan.md
+++ b/docs/plans/2026-05-23-002-feat-cliproxy-login-codex-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: cliproxy login codex'
 type: feat
-status: active
+status: completed
 date: 2026-05-23
 origin: docs/brainstorms/2026-05-23-cliproxy-login-codex-and-providers-requirements.md
 ---

--- a/docs/plans/2026-05-25-001-feat-cliproxy-openai-provider-opt-in-plan.md
+++ b/docs/plans/2026-05-25-001-feat-cliproxy-openai-provider-opt-in-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: cliproxy setup OpenAI provider opt-in'
 type: feat
-status: active
+status: completed
 date: 2026-05-25
 origin: docs/brainstorms/2026-05-25-fro-bot-openai-routing-opt-in-requirements.md
 ---

--- a/docs/plans/2026-05-27-002-feat-umami-analytics-deployment-plan.md
+++ b/docs/plans/2026-05-27-002-feat-umami-analytics-deployment-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: self-hosted Umami analytics deployment (apps/umami)'
 type: feat
-status: active
+status: completed
 date: 2026-05-27
 origin: 'GitHub issue #315 + Fro Bot triage (comment 4560738565)'
 deepened: 2026-05-27

--- a/docs/plans/2026-05-28-001-fix-provision-ssh-identity-file-plan.md
+++ b/docs/plans/2026-05-28-001-fix-provision-ssh-identity-file-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'fix: SSH identity-file support for droplet provisioning'
 type: fix
-status: active
+status: completed
 date: 2026-05-28
 ---
 

--- a/docs/plans/2026-05-29-001-feat-cliproxy-v7-upgrade-plan.md
+++ b/docs/plans/2026-05-29-001-feat-cliproxy-v7-upgrade-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: CLIProxyAPI v6 → v7 upgrade (minimal compatibility)'
 type: feat
-status: active
+status: completed
 date: 2026-05-29
 origin: docs/brainstorms/2026-05-29-cliproxy-v7-upgrade-requirements.md
 ---

--- a/docs/plans/2026-05-30-001-feat-gateway-v0461-github-app-adoption-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gateway-v0461-github-app-adoption-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Adopt fro-bot/agent v0.46.x — GitHub App secret materialization + cutover"
 type: feat
-status: active
+status: completed
 date: 2026-05-30
 ---
 

--- a/docs/plans/2026-06-02-001-feat-gateway-v0500-workspace-agent-upgrade-plan.md
+++ b/docs/plans/2026-06-02-001-feat-gateway-v0500-workspace-agent-upgrade-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Upgrade gateway daemon to fro-bot/agent v0.50.0 with workspace mention loop'
 type: feat
-status: active
+status: superseded
 date: 2026-06-02
 ---
 

--- a/docs/plans/2026-06-03-001-feat-gateway-v0510-cutover-plan.md
+++ b/docs/plans/2026-06-03-001-feat-gateway-v0510-cutover-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Cut the gateway daemon over to fro-bot/agent v0.51.0 (workspace mention loop)'
 type: feat
-status: active
+status: completed
 date: 2026-06-03
 ---
 

--- a/docs/plans/2026-06-03-002-feat-gateway-announce-presence-ingress-plan.md
+++ b/docs/plans/2026-06-03-002-feat-gateway-announce-presence-ingress-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Gateway announce/presence ingress (Caddy + announce secrets)"
 type: feat
-status: active
+status: completed
 date: 2026-06-03
 origin: docs/brainstorms/2026-06-03-gateway-announce-presence-ingress-requirements.md
 deepened: 2026-06-03

--- a/docs/plans/2026-06-09-001-feat-vpn-egress-box-plan.md
+++ b/docs/plans/2026-06-09-001-feat-vpn-egress-box-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Add WireGuard VPN egress box (apps/vpn)'
 type: feat
-status: active
+status: completed
 date: 2026-06-09
 origin: docs/brainstorms/2026-06-09-vpn-egress-box-requirements.md
 ---

--- a/docs/plans/2026-06-13-001-feat-cliproxy-models-subcommand-plan.md
+++ b/docs/plans/2026-06-13-001-feat-cliproxy-models-subcommand-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Add cliproxy models subcommand'
 type: feat
-status: active
+status: completed
 date: 2026-06-13
 origin: docs/brainstorms/2026-06-13-cliproxy-models-subcommand-requirements.md
 ---

--- a/docs/plans/2026-06-15-001-feat-dashboard-deploy-stack-plan.md
+++ b/docs/plans/2026-06-15-001-feat-dashboard-deploy-stack-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Add fro-bot dashboard deploy stack (apps/dashboard)'
 type: feat
-status: active
+status: completed
 date: 2026-06-15
 origin: docs/brainstorms/2026-06-15-dashboard-deploy-stack-requirements.md
 ---

--- a/docs/plans/2026-06-15-002-refactor-dashboard-consume-released-image-plan.md
+++ b/docs/plans/2026-06-15-002-refactor-dashboard-consume-released-image-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'refactor: Dashboard consumes the released image by digest'
 type: refactor
-status: active
+status: completed
 date: 2026-06-15
 origin: docs/brainstorms/2026-06-15-dashboard-consume-released-image-requirements.md
 ---

--- a/docs/plans/2026-06-18-001-feat-dashboard-operator-same-origin-plan.md
+++ b/docs/plans/2026-06-18-001-feat-dashboard-operator-same-origin-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Dashboard operator same-origin — ratify dashboard.fro.bot as the browser-visible operator API origin"
 type: feat
-status: active
+status: completed
 date: 2026-06-18
 ---
 

--- a/docs/plans/2026-06-18-002-feat-gateway-operator-auth-config-plan.md
+++ b/docs/plans/2026-06-18-002-feat-gateway-operator-auth-config-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Gateway operator auth/config secrets — wire GitHub OAuth, CSRF, and allowlist into deploy"
 type: feat
-status: active
+status: completed
 date: 2026-06-18
 ---
 

--- a/docs/plans/2026-06-18-003-feat-dashboard-operator-private-path-plan.md
+++ b/docs/plans/2026-06-18-003-feat-dashboard-operator-private-path-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Dashboard operator same-origin — private VPC path to the gateway operator listener'
 type: feat
-status: active
+status: completed
 date: 2026-06-18
 origin: docs/brainstorms/2026-06-18-dashboard-operator-private-path-requirements.md
 ---

--- a/docs/plans/2026-06-20-001-feat-cliproxy-model-aliasing-plan.md
+++ b/docs/plans/2026-06-20-001-feat-cliproxy-model-aliasing-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: CLIProxyAPI model aliasing for short-ID routing parity"
 type: feat
-status: active
+status: completed
 date: 2026-06-20
 origin: docs/brainstorms/2026-06-20-cliproxy-model-aliasing-requirements.md
 ---

--- a/docs/plans/2026-06-20-002-refactor-cli-bun-build-publish-plan.md
+++ b/docs/plans/2026-06-20-002-refactor-cli-bun-build-publish-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: bun build publish step for @marcusrbrown/infra (remove packages/cli → packages/shared boundary)"
 type: refactor
-status: active
+status: completed
 date: 2026-06-20
 origin: docs/brainstorms/2026-06-20-cli-bun-build-publish-requirements.md
 ---

--- a/docs/plans/2026-06-20-003-feat-gateway-dashboard-operator-ui-golive-plan.md
+++ b/docs/plans/2026-06-20-003-feat-gateway-dashboard-operator-ui-golive-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: gateway v0.72.0 + dashboard 2026.06.34 operator UI go-live"
 type: feat
-status: active
+status: completed
 date: 2026-06-20
 ---
 

--- a/docs/plans/2026-06-25-001-feat-dashboard-caddy-spa-fallback-plan.md
+++ b/docs/plans/2026-06-25-001-feat-dashboard-caddy-spa-fallback-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Dashboard Caddy SPA fallback for client-side deep links"
 type: feat
-status: active
+status: completed
 date: 2026-06-25
 ---
 

--- a/docs/plans/2026-06-25-002-fix-deploy-aggregate-concurrency-cancellation-plan.md
+++ b/docs/plans/2026-06-25-002-fix-deploy-aggregate-concurrency-cancellation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Stop aggregate deploy concurrency from cancelling gated deploys"
 type: fix
-status: active
+status: completed
 date: 2026-06-25
 ---
 

--- a/docs/plans/2026-06-30-001-feat-harness-credential-broker-plan.md
+++ b/docs/plans/2026-06-30-001-feat-harness-credential-broker-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Harness merge-agent credential broker'
 type: feat
-status: active
+status: completed
 date: 2026-06-30
 origin: docs/brainstorms/2026-06-30-harness-credential-broker-requirements.md
 ---


### PR DESCRIPTION
Reconciles `status:` frontmatter in `docs/plans/` against what actually shipped — 25 plans were still marked `active`, most delivered weeks ago.

- **23 → `completed`**: verified via merged PRs, live production deployments, or delivered artifacts (runbooks, CLI commands, compose entries).
- **1 → `superseded`**: the gateway v0.50.0 workspace-agent upgrade plan — v0.50.0 was reverted in #389 after a crash-loop and replaced by the v0.51.0 cutover plan.
- **1 stays `active`**: the umami Postgres major-upgrade plan — its migration units are explicitly deferred until a forcing function (PG15 EOL, security fix).

Frontmatter-only: 24 files, one `status:` line each, no other content touched.