### PR TITLE
chore(deps): update caddy Docker tag to v2.11.4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,10 +24,9 @@
       sourceUrl: 'https://github.com/caddyserver/caddy',
       changelogUrl: 'https://github.com/caddyserver/caddy/releases',
       groupName: null,
-      // caddy:2.11.4-alpine@sha256:eb37... had no linux/amd64 manifest on 2026-06-03,
-      // which broke cliproxy and umami deploys on DigitalOcean droplets. Keep Caddy below
-      // that release until a newer tag is manually verified against linux/amd64.
-      allowedVersions: '<=2.11.3',
+      // caddy:2.11.4-alpine@sha256:5f5c864... was manually verified to have a linux/amd64
+      // manifest on 2026-07-13. Next minor stays gated pending the same verification.
+      allowedVersions: '<2.12.0',
       automerge: false,
       dependencyDashboardApproval: true,
     },

--- a/apps/broker/docker-compose.test.ts
+++ b/apps/broker/docker-compose.test.ts
@@ -14,7 +14,7 @@ describe('broker docker compose', () => {
 
   it('uses the last known linux/amd64-compatible Caddy image', () => {
     expect(compose).toContain(
-      'image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794',
+      'image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648',
     )
   })
 

--- a/apps/broker/docker-compose.yaml
+++ b/apps/broker/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   caddy:
     # renovate: datasource=docker depName=caddy versioning=docker
-    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     restart: unless-stopped
     ports:
       - '80:80'

--- a/apps/cliproxy/docker-compose.test.ts
+++ b/apps/cliproxy/docker-compose.test.ts
@@ -5,7 +5,7 @@ const compose = await Bun.file(new URL('docker-compose.yaml', import.meta.url)).
 describe('cliproxy docker compose', () => {
   it('uses the last known linux/amd64-compatible Caddy image', () => {
     expect(compose).toContain(
-      'image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794',
+      'image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648',
     )
   })
 })

--- a/apps/cliproxy/docker-compose.yaml
+++ b/apps/cliproxy/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     restart: unless-stopped
     ports:
       - '80:80'

--- a/apps/dashboard/docker-compose.test.ts
+++ b/apps/dashboard/docker-compose.test.ts
@@ -5,7 +5,7 @@ const compose = await Bun.file(new URL('docker-compose.yaml', import.meta.url)).
 describe('dashboard docker compose', () => {
   it('uses the last known linux/amd64-compatible Caddy image', () => {
     expect(compose).toContain(
-      'image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794',
+      'image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648',
     )
   })
 

--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     restart: unless-stopped
     ports:
       - '80:80'

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -1858,7 +1858,7 @@ describe('no-version fallback', () => {
 describe('versioned deploy: writes local compose path after successful deploy', () => {
   const SAMPLE_COMPOSE_FOR_WRITE = `services:
   caddy:
-    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     restart: unless-stopped
   dashboard:
     image: ghcr.io/fro-bot/dashboard:2026.06.15@sha256:${'a'.repeat(64)}

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -3539,7 +3539,7 @@ describe('buildComposeOverride', () => {
     expect(yaml).toContain('caddy_config')
   })
 
-  test('caddy image is pinned to the same digest as cliproxy (caddy:2.11.3-alpine@sha256:...)', async () => {
+  test('caddy image is pinned to the same digest as cliproxy (caddy:2.11.4-alpine@sha256:...)', async () => {
     const {buildComposeOverride} = await import('./deploy')
     const yaml = buildComposeOverride(OVERRIDE_OPTS_ANNOUNCE)
     // Must use a pinned digest (sha256:)

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -1167,7 +1167,7 @@ export function computeSecretsChecksum(secrets: SecretFile[]): string {
 
 // Pinned Caddy image digest — same as apps/cliproxy/docker-compose.yaml and apps/umami/docker-compose.yaml.
 // Renovate tracks the digest in those files; keep in sync when Renovate bumps them.
-const CADDY_IMAGE = 'caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794'
+const CADDY_IMAGE = 'caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648'
 
 export interface ComposeOverrideOpts {
   /** Digest of the gateway image pushed to GHCR (e.g. "sha256:abc..."). */

--- a/apps/umami/docker-compose.test.ts
+++ b/apps/umami/docker-compose.test.ts
@@ -5,7 +5,7 @@ const compose = await Bun.file(new URL('docker-compose.yaml', import.meta.url)).
 describe('umami docker compose', () => {
   it('uses the last known linux/amd64-compatible Caddy image', () => {
     expect(compose).toContain(
-      'image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794',
+      'image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648',
     )
   })
 })

--- a/apps/umami/docker-compose.yaml
+++ b/apps/umami/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     restart: unless-stopped
     ports:
       - '80:80'


### PR DESCRIPTION
## Summary

- update every deployed Caddy pin to `2.11.4-alpine` at the verified multi-arch digest
- update exact-pin tests across broker, CLIProxyAPI, dashboard, gateway, and Umami
- allow Renovate to surface future v2.11.x patches while keeping v2.12+ manually gated

## Compatibility

`docker buildx imagetools inspect caddy:2.11.4-alpine` confirms the pinned index digest includes `linux/amd64`. The deployed Caddyfiles use standard `reverse_proxy` routing and normal forwarded headers; they do not use the underscore-header, backslash-path, encoding-order, or injected-query behavior changed in v2.11.4.

## Verification

- `docker buildx imagetools inspect caddy:2.11.4-alpine`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json5`
- targeted compose/dashboard/gateway tests: 736 passed
- `bun test packages/cli/src/conventions.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` (existing warnings only)
- `git diff --check`

`bun test --recursive` reached 2571 passing tests but hit four existing 5-second timeouts in `packages/cli/src/commands/cliproxy/setup.test.ts`; the failures reproduce on unrelated branches and this PR has no diff in that subsystem.
