### PR TITLE
fix(cli): resolve bundled known_hosts relative to bundle, not cwd

### DIFF
--- a/.changeset/fix-bundled-known-hosts-resolution.md
+++ b/.changeset/fix-bundled-known-hosts-resolution.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Fix pinned `known_hosts` resolution in the published CLI. The bundled host-key file resolved against the current working directory instead of the bundle location, so `infra status` and other SSH-based commands failed closed with "Pinned SSH known_hosts file not found" whenever run outside a repo checkout. The asset is now resolved relative to the bundle, keeping strict host-key checking intact.

--- a/packages/cli/scripts/build.test.ts
+++ b/packages/cli/scripts/build.test.ts
@@ -13,7 +13,8 @@
  * Running the build as a subprocess sidesteps this entirely.
  */
 
-import {existsSync, statSync} from 'node:fs'
+import {existsSync, mkdirSync, rmSync, statSync} from 'node:fs'
+import {tmpdir} from 'node:os'
 import {join, resolve} from 'node:path'
 
 import {afterAll, beforeAll, describe, expect, it} from 'bun:test'
@@ -89,6 +90,37 @@ describe('known_hosts asset', () => {
       expect(new Uint8Array(distBytes)).toEqual(new Uint8Array(srcBytes))
     }
   })
+
+  it('resolves the asset when the built CLI runs from a foreign working directory', async () => {
+    const foreignCwd = join(tmpdir(), `infra-cli-built-${Date.now()}`)
+    mkdirSync(foreignCwd, {recursive: true})
+
+    try {
+      const proc = Bun.spawn([process.execPath, join(distDir, 'cli.js'), 'gateway', 'status'], {
+        cwd: foreignCwd,
+        env: {
+          ...process.env,
+          GATEWAY_HOST: 'localhost',
+          NO_COLOR: '1',
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      expect(`${stdout}\n${stderr}`).not.toContain(
+        'Pinned SSH known_hosts file not found; reinstall @marcusrbrown/infra or run from the repo checkout',
+      )
+      expect(`${stdout}\n${stderr}`).toContain('SSH command failed')
+      expect(exitCode).not.toBe(127)
+    } finally {
+      rmSync(foreignCwd, {recursive: true, force: true})
+    }
+  }, 60_000)
 })
 
 // ── Edge: inline/external split ───────────────────────────────────────────────

--- a/packages/cli/src/lib/known-hosts.ts
+++ b/packages/cli/src/lib/known-hosts.ts
@@ -1,5 +1,5 @@
 import {existsSync} from 'node:fs'
-import {join, resolve} from 'node:path'
+import {isAbsolute, join, resolve} from 'node:path'
 
 // File-asset import: at source-run time Bun resolves this to the real
 // src/resources/known_hosts path. Under `bun build`, the bundler copies the
@@ -62,9 +62,13 @@ export function resolveKnownHostsPath(libDir?: string): string {
   if (existsSync(repoCandidate)) return repoCandidate
 
   // Layout 2: installed/bundled package — use the file-asset import path.
-  // At source-run time: resolves to src/resources/known_hosts.
-  // Under `bun build`: bundler copies asset to dist/ and rewrites this path.
-  if (existsSync(knownHostsAssetPath)) return knownHostsAssetPath
+  // At source-run time Bun returns an absolute path. Under `bun build`, the
+  // bundler returns a relative filename for the asset emitted beside the
+  // bundle, so resolve it relative to this module rather than process.cwd().
+  const assetPath = isAbsolute(knownHostsAssetPath)
+    ? knownHostsAssetPath
+    : resolve(import.meta.dir, knownHostsAssetPath)
+  if (existsSync(assetPath)) return assetPath
 
   throw new Error(FAIL_CLOSED_ERROR)
 }


### PR DESCRIPTION
## Problem
Published `@marcusrbrown/infra` CLI failed closed for SSH-based commands (gateway, vpn, umami, dashboard) when run outside a repo checkout. The pinned `known_hosts` asset was resolved against `process.cwd()` instead of the bundle location, so status/deploy flows reported `Pinned SSH known_hosts file not found`.

## Fix
Resolve bundled known-hosts relative to the module/bundle directory (`import.meta.dir`) so packaged CLI installs find `dist/resources/known_hosts` regardless of working directory. Repo-checkout `.github/known_hosts` precedence remains unchanged. Strict host-key checking and fail-closed behavior are preserved.

## Test
- Adds a build regression test that runs the built `dist/cli.js` from a foreign working directory.

## Verification
- Built `dist/cli.js status` from `/tmp` no longer reports the known_hosts asset error (only expected host-env errors).
- `bunx tsc --noEmit`
- `bun test` (`1171` CLI tests pass)
