### PR TITLE
chore(gateway): bump fro-bot/agent daemon pin to v0.93.1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,12 +82,12 @@
       // not inherit the fro-bot/** minor+patch automerge from the shared preset. Require explicit
       // operator approval (dashboard checkbox to create the PR, manual merge) so every daemon bump
       // gets a source-contract verification pass before landing — verify no new boot-required
-      // secrets before the ceiling moves; v0.88.0 verified deploy-consumed contract identical to
-      // v0.86.0, so patch releases in the v0.88.x line may surface but v0.89+ stays gated pending
+      // secrets before the ceiling moves; v0.93.1 verified deploy-consumed contract identical to
+      // v0.88.0, so patch releases in the v0.93.x line may surface but v0.94+ stays gated pending
       // the next verification pass.
       automerge: false,
       dependencyDashboardApproval: true,
-      allowedVersions: '<0.89.0',
+      allowedVersions: '<0.94.0',
     },
   ],
   // Track the upstream daemon source pin (`ref`) in apps/gateway/upstream.json so new

--- a/apps/gateway/upstream.json
+++ b/apps/gateway/upstream.json
@@ -1,4 +1,4 @@
 {
   "repo": "fro-bot/agent",
-  "ref": "v0.88.0"
+  "ref": "v0.93.1"
 }


### PR DESCRIPTION
## What
- bump the gateway daemon source pin `fro-bot/agent` from `v0.88.0` to `v0.93.1`
- raise the Renovate ceiling to `<0.94.0`

## Verify-at-tag (clean)
Deploy contract is unchanged between `v0.88.0` and `v0.93.1` (`deploy/compose.yaml`, `deploy/gateway.Dockerfile`, `deploy/workspace.Dockerfile`, `deploy/mitmproxy/allowlist.py`, `deploy/workspace-entrypoint.sh`).
No new required secrets, env vars, ports, or compose wiring.

## Release range
`v0.89.0`–`v0.93.1` are application-level (harness/OpenCode/Systematic bumps, run-state retention tagging in v0.92.0, PR-validation and release-note fixes). None touch the consumer deploy contract.

## On merge
This gates to `deploy-gateway` via paths-filter and schedules a fresh v0.93.1 image build with the `gateway` environment manual-approval hold.

## Notes
No changeset is required because this does not touch `packages/cli/src/`.
