### PR TITLE
feat(gateway): enforce S3 run-state lifecycle rule

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -9,6 +9,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.1088.0",
     "@marcusrbrown/infra-shared": "workspace:*"
   }
 }

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1,4 +1,7 @@
-import type {PutBucketLifecycleConfigurationCommandInput} from '@aws-sdk/client-s3'
+import type {
+  GetBucketLifecycleConfigurationCommandInput,
+  PutBucketLifecycleConfigurationCommandInput,
+} from '@aws-sdk/client-s3'
 import type {SpawnFn, SpawnResult} from './deploy'
 import {existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
@@ -160,15 +163,22 @@ const tcpConnectRefused = async (_host: string, _port: number): Promise<void> =>
   throw new Error('connect ECONNREFUSED')
 }
 
-function makeS3Client(responses: unknown[]) {
-  const inputs: unknown[] = []
+type S3CommandInput = GetBucketLifecycleConfigurationCommandInput | PutBucketLifecycleConfigurationCommandInput
+
+function isPutLifecycleInput(input: S3CommandInput): input is PutBucketLifecycleConfigurationCommandInput {
+  return 'LifecycleConfiguration' in input
+}
+
+function makeS3Client(responses: unknown[], putResponse: unknown = {}) {
+  const inputs: S3CommandInput[] = []
   return {
     inputs,
     client: {
-      send: async (command: {input: unknown}) => {
+      send: async (command: {input: S3CommandInput}) => {
         inputs.push(command.input)
-        if (typeof command.input === 'object' && command.input !== null && 'LifecycleConfiguration' in command.input) {
-          return {}
+        if (isPutLifecycleInput(command.input)) {
+          if (putResponse instanceof Error) throw putResponse
+          return putResponse
         }
         const response = responses.shift()
         if (response instanceof Error) throw response
@@ -204,9 +214,8 @@ describe('ensureRunStateLifecycleRule', () => {
 
     expect(inputs).toHaveLength(3)
     expect(inputs[0]).toEqual({Bucket: env.S3_BUCKET})
-    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
-      canonicalRule,
-    ])
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([canonicalRule])
     expect(inputs[2]).toEqual({Bucket: env.S3_BUCKET})
   })
 
@@ -217,10 +226,8 @@ describe('ensureRunStateLifecycleRule', () => {
 
     await ensureRunStateLifecycleRule(env, client)
 
-    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
-      unrelated,
-      canonicalRule,
-    ])
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([unrelated, canonicalRule])
   })
 
   test('does not PUT when the canonical rule is already current', async () => {
@@ -239,9 +246,8 @@ describe('ensureRunStateLifecycleRule', () => {
 
     await ensureRunStateLifecycleRule(env, client)
 
-    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
-      canonicalRule,
-    ])
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([canonicalRule])
   })
 
   test('skips custom S3 endpoints without making S3 calls', async () => {
@@ -266,6 +272,58 @@ describe('ensureRunStateLifecycleRule', () => {
     const {RUN_STATE_LIFECYCLE_RULE} = await import('./deploy')
 
     expect(RUN_STATE_LIFECYCLE_RULE).toEqual(canonicalRule)
+  })
+
+  test('accepts normalized readback with an And-wrapped tag filter', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const normalizedRule = {
+      Expiration: {Days: 30},
+      ID: 'run-state-30d-expiration',
+      Status: 'Enabled' as const,
+      Filter: {And: {Tags: [{Value: 'run-state', Key: 'object-type'}]}, ExpiredObjectDeleteMarker: false},
+    }
+    const {client} = makeS3Client([{Rules: [normalizedRule]}, {Rules: [normalizedRule]}])
+
+    await expect(ensureRunStateLifecycleRule(env, client)).resolves.toBeUndefined()
+  })
+
+  test('rejects readback with the wrong expiration days', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const wrongDaysRule = {
+      ...canonicalRule,
+      Expiration: {Days: 7},
+    }
+    const {client} = makeS3Client([{Rules: [wrongDaysRule]}, {Rules: [wrongDaysRule]}])
+
+    await expect(ensureRunStateLifecycleRule(env, client)).rejects.toThrow(/readback/i)
+  })
+
+  test('creates the rule when the initial configuration has no Rules array', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const {client} = makeS3Client([{}, {Rules: [canonicalRule]}])
+
+    await expect(ensureRunStateLifecycleRule(env, client)).resolves.toBeUndefined()
+  })
+
+  test('redacts S3 credential values from propagated errors', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const secretEnv = {
+      ...env,
+      AWS_ACCESS_KEY_ID: 'fake-access-secret',
+      AWS_SECRET_ACCESS_KEY: 'fake-secret-value',
+      AWS_SESSION_TOKEN: 'fake-session-secret',
+    }
+    const {client} = makeS3Client([new Error('request failed: fake-secret-value')])
+
+    await expect(ensureRunStateLifecycleRule(secretEnv, client)).rejects.toThrow(/<redacted:aws-secret-access-key>/)
+  })
+
+  test('propagates and redacts PUT failures', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const secretEnv = {...env, AWS_SECRET_ACCESS_KEY: 'put-secret-value'}
+    const {client} = makeS3Client([{Rules: []}], new Error('PUT failed: put-secret-value'))
+
+    await expect(ensureRunStateLifecycleRule(secretEnv, client)).rejects.toThrow(/<redacted:aws-secret-access-key>/)
   })
 })
 

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -1,3 +1,4 @@
+import type {PutBucketLifecycleConfigurationCommandInput} from '@aws-sdk/client-s3'
 import type {SpawnFn, SpawnResult} from './deploy'
 import {existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
@@ -55,6 +56,7 @@ function makeEnv(overrides: Record<string, string> = {}): Record<string, string>
     DISCORD_GUILD_ID: 'guild456',
     S3_BUCKET: 'my-bucket',
     S3_REGION: 'us-east-1',
+    S3_ENDPOINT: 'http://test-s3.invalid',
     GATEWAY_HOST: 'gateway.fro.bot',
     GH_APP_ID: 'app-id-12345',
     GH_APP_PRIVATE_KEY: '-----BEGIN RSA PRIVATE KEY-----\nfakekey\n-----END RSA PRIVATE KEY-----\n',
@@ -157,6 +159,115 @@ function makeDiscordFetch(commands: {name: string}[]): typeof fetch {
 const tcpConnectRefused = async (_host: string, _port: number): Promise<void> => {
   throw new Error('connect ECONNREFUSED')
 }
+
+function makeS3Client(responses: unknown[]) {
+  const inputs: unknown[] = []
+  return {
+    inputs,
+    client: {
+      send: async (command: {input: unknown}) => {
+        inputs.push(command.input)
+        if (typeof command.input === 'object' && command.input !== null && 'LifecycleConfiguration' in command.input) {
+          return {}
+        }
+        const response = responses.shift()
+        if (response instanceof Error) throw response
+        return response
+      },
+    },
+  }
+}
+
+describe('ensureRunStateLifecycleRule', () => {
+  const env = {
+    S3_BUCKET: 'run-state-bucket',
+    S3_REGION: 'us-east-1',
+    AWS_ACCESS_KEY_ID: 'access-key',
+    AWS_SECRET_ACCESS_KEY: 'secret-key',
+  }
+
+  const canonicalRule = {
+    ID: 'run-state-30d-expiration',
+    Filter: {Tag: {Key: 'object-type', Value: 'run-state'}},
+    Status: 'Enabled' as const,
+    Expiration: {Days: 30},
+  }
+
+  test('creates the canonical rule when no lifecycle configuration exists', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const {client, inputs} = makeS3Client([
+      Object.assign(new Error('not found'), {name: 'NoSuchLifecycleConfiguration'}),
+      {Rules: [canonicalRule]},
+    ])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    expect(inputs).toHaveLength(3)
+    expect(inputs[0]).toEqual({Bucket: env.S3_BUCKET})
+    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
+      canonicalRule,
+    ])
+    expect(inputs[2]).toEqual({Bucket: env.S3_BUCKET})
+  })
+
+  test('keeps unrelated rules while adding ours', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const unrelated = {ID: 'other-rule', Prefix: 'archive/', Status: 'Enabled' as const, ExpirationInDays: 90}
+    const {client, inputs} = makeS3Client([{Rules: [unrelated]}, {Rules: [unrelated, canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
+      unrelated,
+      canonicalRule,
+    ])
+  })
+
+  test('does not PUT when the canonical rule is already current', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const {client, inputs} = makeS3Client([{Rules: [canonicalRule]}, {Rules: [canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    expect(inputs).toEqual([{Bucket: env.S3_BUCKET}, {Bucket: env.S3_BUCKET}])
+  })
+
+  test('replaces a drifted rule with the canonical rule', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const drifted = {...canonicalRule, Expiration: {Days: 7}}
+    const {client, inputs} = makeS3Client([{Rules: [drifted]}, {Rules: [canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    expect((inputs[1] as PutBucketLifecycleConfigurationCommandInput).LifecycleConfiguration?.Rules).toEqual([
+      canonicalRule,
+    ])
+  })
+
+  test('skips custom S3 endpoints without making S3 calls', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const {client, inputs} = makeS3Client([])
+    const logs: string[] = []
+
+    await ensureRunStateLifecycleRule({...env, S3_ENDPOINT: 'http://minio:9000'}, client, message => logs.push(message))
+
+    expect(inputs).toEqual([])
+    expect(logs).toContain('skipped: custom S3 endpoint, run-state tagging not applied by daemon')
+  })
+
+  test('throws when readback does not confirm the canonical rule', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const {client} = makeS3Client([{Rules: []}, {Rules: []}])
+
+    await expect(ensureRunStateLifecycleRule(env, client)).rejects.toThrow(/readback.*run-state-30d-expiration/i)
+  })
+
+  test('uses the exact canonical tag-filtered rule shape', async () => {
+    const {RUN_STATE_LIFECYCLE_RULE} = await import('./deploy')
+
+    expect(RUN_STATE_LIFECYCLE_RULE).toEqual(canonicalRule)
+  })
+})
 
 // ─── Test setup ───────────────────────────────────────────────────────────────
 
@@ -327,7 +438,7 @@ describe('computeObjectStoreHosts', () => {
 
   test('derives AWS pattern when S3_ENDPOINT is not set', async () => {
     const {computeObjectStoreHosts} = await import('./deploy')
-    const result = computeObjectStoreHosts(makeEnv({S3_BUCKET: 'my-bucket', S3_REGION: 'us-west-2'}))
+    const result = computeObjectStoreHosts(makeEnv({S3_ENDPOINT: '', S3_BUCKET: 'my-bucket', S3_REGION: 'us-west-2'}))
     expect(result).toBe('my-bucket.s3.us-west-2.amazonaws.com')
   })
 

--- a/apps/gateway/src/deploy.test.ts
+++ b/apps/gateway/src/deploy.test.ts
@@ -287,6 +287,60 @@ describe('ensureRunStateLifecycleRule', () => {
     await expect(ensureRunStateLifecycleRule(env, client)).resolves.toBeUndefined()
   })
 
+  test('repairs an And-wrapped tag filter that also contains a prefix', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const driftedRule = {
+      ...canonicalRule,
+      Filter: {And: {Prefix: 'x/', Tags: [{Key: 'object-type', Value: 'run-state'}]}},
+    }
+    const {client, inputs} = makeS3Client([{Rules: [driftedRule]}, {Rules: [canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([canonicalRule])
+  })
+
+  test('repairs an And-wrapped filter containing an extra tag', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const driftedRule = {
+      ...canonicalRule,
+      Filter: {
+        And: {
+          Tags: [
+            {Key: 'object-type', Value: 'run-state'},
+            {Key: 'something', Value: 'else'},
+          ],
+        },
+      },
+    }
+    const {client, inputs} = makeS3Client([{Rules: [driftedRule]}, {Rules: [canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([canonicalRule])
+  })
+
+  test('repairs a tag filter containing an object-size constraint', async () => {
+    const {ensureRunStateLifecycleRule} = await import('./deploy')
+    const driftedRule = {
+      ...canonicalRule,
+      Filter: {
+        And: {
+          ObjectSizeGreaterThan: 100,
+          Tags: [{Key: 'object-type', Value: 'run-state'}],
+        },
+      },
+    }
+    const {client, inputs} = makeS3Client([{Rules: [driftedRule]}, {Rules: [canonicalRule]}])
+
+    await ensureRunStateLifecycleRule(env, client)
+
+    const putInput = inputs.find(isPutLifecycleInput)
+    expect(putInput?.LifecycleConfiguration?.Rules).toEqual([canonicalRule])
+  })
+
   test('rejects readback with the wrong expiration days', async () => {
     const {ensureRunStateLifecycleRule} = await import('./deploy')
     const wrongDaysRule = {

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -119,8 +119,36 @@ function isRunStateLifecycleRule(rule: LifecycleRule | undefined): boolean {
     return false
   }
 
-  const tags = [rule.Filter?.Tag, ...(rule.Filter?.And?.Tags ?? [])]
-  return tags.some(tag => tag?.Key === 'object-type' && tag.Value === 'run-state')
+  const filter = rule.Filter
+  if (!filter) return false
+
+  const hasTopLevelSizeConstraint =
+    filter.ObjectSizeGreaterThan !== undefined || filter.ObjectSizeLessThan !== undefined
+  const directTagIsCanonical =
+    filter.Tag?.Key === 'object-type' &&
+    filter.Tag.Value === 'run-state' &&
+    filter.And === undefined &&
+    filter.Prefix === undefined &&
+    !hasTopLevelSizeConstraint
+
+  if (directTagIsCanonical) return true
+
+  const and = filter.And
+  if (
+    !and ||
+    filter.Tag !== undefined ||
+    filter.Prefix !== undefined ||
+    hasTopLevelSizeConstraint ||
+    and.Prefix !== undefined ||
+    and.ObjectSizeGreaterThan !== undefined ||
+    and.ObjectSizeLessThan !== undefined ||
+    and.Tags?.length !== 1
+  ) {
+    return false
+  }
+
+  const [tag] = and.Tags
+  return tag?.Key === 'object-type' && tag.Value === 'run-state'
 }
 
 /** Ensures AWS-native S3 retains tagged run-state objects for 30 days. */

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -5,6 +5,13 @@ import {chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:
 import {tmpdir} from 'node:os'
 import {join, resolve} from 'node:path'
 
+import {
+  GetBucketLifecycleConfigurationCommand,
+  PutBucketLifecycleConfigurationCommand,
+  S3Client,
+  type LifecycleRule,
+  type S3ClientConfig,
+} from '@aws-sdk/client-s3'
 import {validateGatewayHost} from './host'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -82,6 +89,85 @@ export interface MainOpts {
 export interface DeployArgs {
   dryRun: boolean
   forceRecreate: boolean
+}
+
+export const RUN_STATE_LIFECYCLE_RULE: LifecycleRule = {
+  ID: 'run-state-30d-expiration',
+  Filter: {Tag: {Key: 'object-type', Value: 'run-state'}},
+  Status: 'Enabled',
+  Expiration: {Days: 30},
+}
+
+type LifecycleS3Client = Pick<S3Client, 'send'>
+interface LifecycleEnv {
+  [key: string]: string | undefined
+  S3_BUCKET: string
+  S3_REGION: string
+  AWS_ACCESS_KEY_ID: string
+  AWS_SECRET_ACCESS_KEY: string
+  S3_ENDPOINT?: string
+}
+
+function isRunStateLifecycleRule(rule: LifecycleRule | undefined): boolean {
+  return JSON.stringify(rule) === JSON.stringify(RUN_STATE_LIFECYCLE_RULE)
+}
+
+/** Ensures AWS-native S3 retains tagged run-state objects for 30 days. */
+export async function ensureRunStateLifecycleRule(
+  env: LifecycleEnv,
+  client?: LifecycleS3Client,
+  log: (message: string) => void = message => console.warn(message),
+): Promise<void> {
+  if (env.S3_ENDPOINT) {
+    log('skipped: custom S3 endpoint, run-state tagging not applied by daemon')
+    return
+  }
+
+  const s3 =
+    client ??
+    new S3Client({
+      region: env.S3_REGION,
+      credentials: {
+        accessKeyId: env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+      },
+    } satisfies S3ClientConfig)
+
+  const getConfig = () => s3.send(new GetBucketLifecycleConfigurationCommand({Bucket: env.S3_BUCKET}))
+  let existingRules: LifecycleRule[]
+  try {
+    existingRules = (await getConfig()).Rules ?? []
+  } catch (error) {
+    if (error instanceof Error && error.name === 'NoSuchLifecycleConfiguration') {
+      existingRules = []
+    } else {
+      throw error
+    }
+  }
+
+  const desiredRules = [
+    ...existingRules.filter(rule => rule.ID !== RUN_STATE_LIFECYCLE_RULE.ID),
+    RUN_STATE_LIFECYCLE_RULE,
+  ]
+  if (JSON.stringify(desiredRules) === JSON.stringify(existingRules)) {
+    log('S3 run-state lifecycle rule is already current')
+  } else {
+    await s3.send(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: env.S3_BUCKET,
+        LifecycleConfiguration: {Rules: desiredRules},
+      }),
+    )
+  }
+
+  const readback = await getConfig()
+  if (!readback.Rules?.some(isRunStateLifecycleRule)) {
+    throw new Error(
+      'S3 run-state lifecycle rule readback failed: run-state-30d-expiration is missing or incorrect. ' +
+        'Expected tag object-type=run-state, expiration Days=30, and Status=Enabled.',
+    )
+  }
+  log('S3 run-state lifecycle rule verified')
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -3076,6 +3162,11 @@ SCRIPT`
       assertRunningImageDigest(repoDigests, expectedDigest, service)
       console.warn(`\u001B[1;32m✓\u001B[0m ${service} image digest verified`)
     }
+
+    // Phase 9d: Ensure AWS-native S3 expires tagged run-state objects after 30 days.
+    // This runs after compose and running-image verification, and merges by rule ID
+    // because PutBucketLifecycleConfiguration replaces the whole bucket configuration.
+    await ensureRunStateLifecycleRule({...validated, S3_ENDPOINT: env.S3_ENDPOINT})
 
     // Phase 10: Persist checksum AFTER compose + registration + digest verification succeed
     // If any of phase 8, 9, or 9c threw, we never reach here — prior checksum stays in place

--- a/apps/gateway/src/deploy.ts
+++ b/apps/gateway/src/deploy.ts
@@ -109,7 +109,18 @@ interface LifecycleEnv {
 }
 
 function isRunStateLifecycleRule(rule: LifecycleRule | undefined): boolean {
-  return JSON.stringify(rule) === JSON.stringify(RUN_STATE_LIFECYCLE_RULE)
+  if (!rule) return false
+
+  if (
+    rule.ID !== RUN_STATE_LIFECYCLE_RULE.ID ||
+    rule.Status !== RUN_STATE_LIFECYCLE_RULE.Status ||
+    rule.Expiration?.Days !== RUN_STATE_LIFECYCLE_RULE.Expiration?.Days
+  ) {
+    return false
+  }
+
+  const tags = [rule.Filter?.Tag, ...(rule.Filter?.And?.Tags ?? [])]
+  return tags.some(tag => tag?.Key === 'object-type' && tag.Value === 'run-state')
 }
 
 /** Ensures AWS-native S3 retains tagged run-state objects for 30 days. */
@@ -123,45 +134,61 @@ export async function ensureRunStateLifecycleRule(
     return
   }
 
+  const s3Secrets: SecretFile[] = [
+    {name: 'aws-access-key-id', content: env.AWS_ACCESS_KEY_ID, required: true},
+    {name: 'aws-secret-access-key', content: env.AWS_SECRET_ACCESS_KEY, required: true},
+  ]
+  if (env.AWS_SESSION_TOKEN) {
+    s3Secrets.push({name: 'aws-session-token', content: env.AWS_SESSION_TOKEN, required: false})
+  }
+
   const s3 =
     client ??
     new S3Client({
       region: env.S3_REGION,
+      maxAttempts: 2,
       credentials: {
         accessKeyId: env.AWS_ACCESS_KEY_ID,
         secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+        ...(env.AWS_SESSION_TOKEN ? {sessionToken: env.AWS_SESSION_TOKEN} : {}),
       },
     } satisfies S3ClientConfig)
 
-  const getConfig = () => s3.send(new GetBucketLifecycleConfigurationCommand({Bucket: env.S3_BUCKET}))
-  let existingRules: LifecycleRule[]
-  try {
-    existingRules = (await getConfig()).Rules ?? []
-  } catch (error) {
-    if (error instanceof Error && error.name === 'NoSuchLifecycleConfiguration') {
-      existingRules = []
-    } else {
-      throw error
+  const getConfig = async () => {
+    try {
+      return await s3.send(new GetBucketLifecycleConfigurationCommand({Bucket: env.S3_BUCKET}))
+    } catch (error) {
+      if (error instanceof Error && error.name === 'NoSuchLifecycleConfiguration') {
+        return undefined
+      }
+      throw redactSecretsFromError(error, s3Secrets)
     }
   }
+
+  const existingRules: LifecycleRule[] = (await getConfig())?.Rules ?? []
 
   const desiredRules = [
     ...existingRules.filter(rule => rule.ID !== RUN_STATE_LIFECYCLE_RULE.ID),
     RUN_STATE_LIFECYCLE_RULE,
   ]
-  if (JSON.stringify(desiredRules) === JSON.stringify(existingRules)) {
+  const existingRunStateRule = existingRules.find(rule => rule.ID === RUN_STATE_LIFECYCLE_RULE.ID)
+  if (existingRunStateRule && isRunStateLifecycleRule(existingRunStateRule)) {
     log('S3 run-state lifecycle rule is already current')
   } else {
-    await s3.send(
-      new PutBucketLifecycleConfigurationCommand({
-        Bucket: env.S3_BUCKET,
-        LifecycleConfiguration: {Rules: desiredRules},
-      }),
-    )
+    try {
+      await s3.send(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: env.S3_BUCKET,
+          LifecycleConfiguration: {Rules: desiredRules},
+        }),
+      )
+    } catch (error) {
+      throw redactSecretsFromError(error, s3Secrets)
+    }
   }
 
   const readback = await getConfig()
-  if (!readback.Rules?.some(isRunStateLifecycleRule)) {
+  if (!readback?.Rules?.some(isRunStateLifecycleRule)) {
     throw new Error(
       'S3 run-state lifecycle rule readback failed: run-state-30d-expiration is missing or incorrect. ' +
         'Expected tag object-type=run-state, expiration Days=30, and Status=Enabled.',

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       "name": "@marcusrbrown/infra-gateway",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.1088.0",
         "@marcusrbrown/infra-shared": "workspace:*",
       },
     },
@@ -100,7 +101,11 @@
     "@changesets/get-github-info@0.6.0": "patches/@changesets%2Fget-github-info@0.6.0.patch",
   },
   "packages": {
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.18", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw=="],
+
     "@aws-sdk/client-lightsail": ["@aws-sdk/client-lightsail@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-node": "^3.972.69", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Q5Yo6zCMLDeG8B7ALWtvPHKnS4wSBFcmCuh/wo4fnmqzWOnRDAeqa+3PXVUNiVRJuTK4DTLyP/xLGUZI/jaefQ=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1088.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.18", "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-node": "^3.972.69", "@aws-sdk/middleware-sdk-s3": "^3.972.64", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-9ryKKxnjtJRKLDI24P+2gQZki7k28BeV6gz1AySvFDWayhjAZuh4QZjCyx55tqR8Oz0IJxWutgJRO43dDOcXoQ=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.975.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA=="],
 
@@ -119,6 +124,8 @@
     "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.3", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/token-providers": "3.1088.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ=="],
 
     "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA=="],
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw=="],
 


### PR DESCRIPTION
## What
The Fro Bot gateway daemon (`fro-bot/agent` v0.92.0+) tags run-state objects it writes to S3 with `object-type=run-state`. This adds a deploy-time step that enforces a single S3 lifecycle rule to expire those tagged objects after 30 days so run-state objects no longer accumulate indefinitely. Closes the retention work in #729.

## How
`ensureRunStateLifecycleRule` in `apps/gateway/src/deploy.ts` runs after the running-image digest assertion. It reads the bucket’s current lifecycle configuration, upserts the rule by ID, and preserves all other rules since `PutBucketLifecycleConfiguration` replaces the whole config. It then reads back to verify the rule landed correctly.

- Idempotent: no `PUT` when the rule is already current.
- Skips entirely when `S3_ENDPOINT` is set (non-AWS endpoints do not receive the daemon’s object tags).
- AWS credentials are passed explicitly for deterministic operation.

## Safety
Readback uses a shape-tolerant semantic check that matches ID, `Enabled`, `Days` = `30`, and `object-type=run-state` tags regardless of whether AWS returns the tag filter as a single tag or wrapped in an `And` filter. That avoids false failures from AWS response normalization.
SDK errors are redacted before logging, and requests are bounded.

## Scope note
Tagging is forward-only: run-state objects written before `fro-bot/agent` reached v0.92.0 are untagged and will not match. This is acceptable because run-state churns in minutes.

## Tests
The change includes tests for:
- no existing lifecycle config,
- unrelated-rule preservation,
- already-current no-op,
- drift correction,
- AWS-normalized/reordered readback,
- wrong days failing loudly,
- missing `Rules`,
- PUT failure,
- error redaction,
- and the `S3_ENDPOINT` skip path.

## On merge
Paths-filter fires the gated `deploy-gateway` job. The lifecycle rule is applied to the live bucket during that deploy (held at the `gateway` environment for manual approval).

No changeset is required because this does not touch `packages/cli/src/`.
