### PR TITLE
fix(cliproxy): preserve gh HTTP error responses

### DIFF
--- a/packages/cli/src/commands/cliproxy/monitor.test.ts
+++ b/packages/cli/src/commands/cliproxy/monitor.test.ts
@@ -1,8 +1,17 @@
+import {chmod, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 import {goke} from 'goke'
 
 import {createCapturedCtx, MockProcessExit} from '../../__test__/mcp-ctx-fixture'
-import {cliproxyMonitorAction, createGhEnvironment, registerCliproxyMonitor} from './monitor'
+import {
+  cliproxyMonitorAction,
+  createGhEnvironment,
+  interpretGhApiResult,
+  registerCliproxyMonitor,
+  runGhApiOnce,
+} from './monitor'
 
 const originalFetch = globalThis.fetch
 const originalSetTimeout = globalThis.setTimeout
@@ -167,6 +176,53 @@ describe('cliproxy monitor', () => {
     expect(environment.CLIPROXY_API_KEY).toBeUndefined()
     expect(environment.CLIPROXY_AUTH_MONITOR_DISCORD_WEBHOOK).toBeUndefined()
     expect(environment.ARBITRARY_REPO_SECRET).toBeUndefined()
+  })
+
+  it('parses a valid --include HTTP 404 response even when gh exits nonzero', () => {
+    const stdout = 'HTTP/2.0 404 Not Found\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found"}'
+
+    expect(interpretGhApiResult(1, stdout)).toEqual({status: 404, body: '{"message":"Not Found"}'})
+  })
+
+  it('maps a nonzero gh exit with no parseable included response to github-transient', () => {
+    expect(() => interpretGhApiResult(1, 'gh: connection reset by peer\n')).toThrow('github-transient')
+  })
+
+  it('keeps a zero gh exit with malformed output as github-invalid-response', () => {
+    expect(() => interpretGhApiResult(0, 'not a valid http response')).toThrow('github-invalid-response')
+  })
+
+  it('runGhApiOnce parses a real 404 --include response from a nonzero-exit gh process', async () => {
+    const originalPath = process.env.PATH
+    const tempDir = await mkdtemp(join(tmpdir(), 'monitor-gh-boundary-'))
+    const jsonBody = '{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}'
+
+    try {
+      const ghScriptPath = join(tempDir, 'gh')
+      await writeFile(
+        ghScriptPath,
+        [
+          '#!/bin/sh',
+          String.raw`printf 'HTTP/2.0 404 Not Found\r\ncontent-type: application/json; charset=utf-8\r\n\r\n${jsonBody}'`,
+          "echo 'gh: Not Found (HTTP 404)' >&2",
+          'exit 1',
+          '',
+        ].join('\n'),
+      )
+      await chmod(ghScriptPath, 0o755)
+      process.env.PATH = `${tempDir}${originalPath ? `:${originalPath}` : ''}`
+
+      const response = await runGhApiOnce('github-token', '/labels/cliproxy-auth-monitor-test', 'GET')
+
+      expect(response).toEqual({status: 404, body: jsonBody})
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = originalPath
+      }
+      await rm(tempDir, {recursive: true, force: true})
+    }
   })
 
   it('retries transient GitHub responses with bounded backoff', async () => {

--- a/packages/cli/src/commands/cliproxy/monitor.ts
+++ b/packages/cli/src/commands/cliproxy/monitor.ts
@@ -190,18 +190,30 @@ export function createGhEnvironment(token: string): Record<string, string> {
   return environment
 }
 
-function parseGhResponse(output: string): MonitorGhResponse {
+function tryParseGhResponse(output: string): MonitorGhResponse | null {
   const separator = output.indexOf('\r\n\r\n')
   const splitLength = separator === -1 ? 2 : 4
   const splitAt = separator === -1 ? output.indexOf('\n\n') : separator
-  if (splitAt < 0) throw new Error('github-invalid-response')
+  if (splitAt < 0) return null
   const headers = output.slice(0, splitAt)
   const status = /^HTTP\/\S+\s+(\d{3})/m.exec(headers)?.[1]
-  if (!status) throw new Error('github-invalid-response')
+  if (!status) return null
   return {status: Number(status), body: output.slice(splitAt + splitLength)}
 }
 
-async function runGhApiOnce(token: string, path: string, method: string, body?: string): Promise<MonitorGhResponse> {
+export function interpretGhApiResult(exitCode: number, stdout: string): MonitorGhResponse {
+  const parsed = tryParseGhResponse(stdout)
+  if (parsed) return parsed
+  if (exitCode !== 0) throw new Error('github-transient')
+  throw new Error('github-invalid-response')
+}
+
+export async function runGhApiOnce(
+  token: string,
+  path: string,
+  method: string,
+  body?: string,
+): Promise<MonitorGhResponse> {
   const child = Bun.spawn(['gh', 'api', path, '--include', '--method', method, ...(body ? ['--input', '-'] : [])], {
     stdin: body ? 'pipe' : 'ignore',
     stdout: 'pipe',
@@ -224,8 +236,7 @@ async function runGhApiOnce(token: string, path: string, method: string, body?: 
   })
   try {
     const [stdout, _stderr, exitCode] = await Promise.race([operation, timeout])
-    if (exitCode !== 0) throw new Error('github-transient')
-    return parseGhResponse(stdout)
+    return interpretGhApiResult(exitCode, stdout)
   } catch (error) {
     if (timedOut || (error instanceof Error && error.message.startsWith('github-'))) throw error
     throw new Error('github-transient')


### PR DESCRIPTION
## Summary

- parse complete `gh api --include` HTTP responses before interpreting the process exit code
- preserve transport-failure classification when a nonzero exit has no parseable HTTP response
- cover the real `Bun.spawn` adapter boundary with a temporary nonzero-exit `gh` executable

## Root cause

The first post-merge `synthetic-dead` validation failed before creating its test issue: [run 29803572291](https://github.com/marcusrbrown/infra/actions/runs/29803572291).

`ensureLabel()` expects a missing label lookup to return HTTP 404 so it can create the label. `gh api --include` writes that complete 404 response and JSON body to stdout, but exits with code 1. The adapter checked the exit code first and converted the call to `github-transient`, discarding the valid response before reconciliation could observe the status.

## Behavior

- nonzero exit + valid included HTTP response: return the parsed status and body to the GitHub client
- nonzero exit + malformed/no included response: retain `github-transient`
- zero exit + malformed response: retain `github-invalid-response`

## Testing

- regression RED reproduced with the previous exit-before-parse ordering: valid exit-1 404 threw `github-transient`
- real subprocess boundary test: temporary `gh` emits included HTTP 404, writes stderr, exits 1, and `runGhApiOnce` returns the exact parsed response
- `bun test --recursive` — 2649 pass, 0 fail
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors; 58 existing warnings in unrelated files
- Tier-2 review — eight lanes clean after the boundary-test P2 was remediated and re-reviewed

## Changeset

No additional changeset. The monitor has not been released yet and is already covered by `.changeset/monitor-cliproxy-anthropic-auth.md` on `main`.

## Post-Deploy Monitoring & Validation

**Owner:** Marcus  
**Window:** immediately after merge, followed by the existing first-24-hour observation window

1. Re-dispatch `synthetic-dead`; verify label creation, one open isolated test issue, and `discord=outage-sent`.
2. Dispatch `synthetic-healthy`; verify the same issue closes and `discord=recovery-sent`.
3. Dispatch `live`; verify `probe=healthy reason=ok transition=none` and no production outage issue.
4. Confirm subsequent scheduled runs remain green.

**Failure signals:** another reconciliation failure, missing/duplicate test labels or issues, repeated Discord transitions, or any raw upstream response in public output.  
**Rollback:** revert this commit; the scheduled workflow remains fail-closed and does not mutate state when reconciliation fails.
