### PR TITLE
fix(autoheal): expand KeeWeb provider menu

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -397,12 +397,17 @@ env:
        b. Wait for load: `npx agent-browser wait --load networkidle`
        c. Full screenshot: `npx agent-browser screenshot --full`
        d. Snapshot interactive elements: `npx agent-browser snapshot -i`
+       e. Use the snapshot ref to click `More`, then snapshot interactive
+          elements again. KeeWeb keeps storage providers collapsed under
+          `More`; do not judge provider visibility from the initial launcher.
 
        Checks to perform:
        - Page loads without errors or blank content.
        - KeeWeb app initializes (main UI container renders, no spinner
          stuck indefinitely).
-       - Dropbox storage option is visible in the open-file dialog.
+       - After expanding `More`, the Dropbox storage option is visible in
+         the provider menu. Its absence from the collapsed launcher is not
+         a failure.
        - No console errors or failed network requests to Dropbox API
          endpoints.
        - Service worker registers successfully.
@@ -424,8 +429,9 @@ env:
 
        For new issues, create a GitHub issue with:
        - Page URL and description of the problem.
-       - Screenshot filename/path and a short text description of what it
-         shows.
+       - Publicly reproducible text evidence. Include a screenshot only when
+         it has a durable, reader-accessible URL; never cite runner-local
+         screenshot paths as public evidence.
        - Label: `bug` for broken functionality, `enhancement` for UX.
        Do NOT push code changes for site review findings. Issues only.
 


### PR DESCRIPTION
## Summary

- require the live-site check to expand KeeWeb's `More` menu before judging Dropbox visibility
- document that the collapsed launcher intentionally hides storage providers
- require publicly reproducible text or durable screenshot URLs instead of runner-local paths

## Root cause

Autoheal issue #906 clicked `Open` and inspected only the collapsed Open/New/Demo/More launcher. Live verification shows that expanding `More` reveals WebDAV, Dropbox, Google Drive, and OneDrive. #906 was closed as a false positive.

## Verification

- live `agent-browser` snapshot before expansion: Open/New/Demo/More
- live snapshot after clicking `More`: WebDAV/Dropbox/Google Drive/OneDrive
- workflow YAML parse
- `bun test packages/cli/src/conventions.test.ts` — 126 pass
- `bun run lint` — 0 errors; 58 pre-existing gateway-test warnings
- `git diff --check`

## Changeset

None. This changes automation policy, not the published CLI.

## Post-merge validation

Manually dispatch the empty-prompt autoheal workflow and confirm it does not recreate a missing-Dropbox issue while preserving the sole trusted daily report.
