### PR TITLE
fix(autoheal): keep canonical report body-only

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -665,10 +665,15 @@ env:
        comment on repaired PRs.
     g. End state: exactly one open trusted managed report. Untrusted prefix
        collisions do not count toward this invariant and remain untouched.
-    h. Do not post autoheal-summary comments on individual finding issues.
-       The only issue comments created during final report reconciliation
-       are the required one-line supersession comments on closed
-       trusted managed reports described in (e) above.
+    h. NEVER comment on the canonical daily report. Forbidden: `gh issue
+      comment <canonical-number> ...` and the issue-comments API against
+      the canonical issue number. Update it only by editing its body in
+      place (per (d)).
+    i. The final run summary goes to workflow logs only — never posted as
+      an issue comment.
+    j. No autoheal-summary comments on finding issues. The only issue
+      comments allowed here are the one-line supersession comments on
+      closed trusted managed reports (per (e)).
 
     The issue body MUST use this structure. If a section has no rows, do
     not emit an empty table — write "None." directly under that heading.


### PR DESCRIPTION
## Summary

- explicitly forbid comments on the canonical daily autoheal report
- require canonical state updates through issue-body edits only
- route final run summaries to workflow logs
- preserve one-line supersession comments only for trusted reports being closed

## Root cause

Validation run 29845590912 updated #897 correctly, then executed `gh issue comment 897` with a redundant run recap despite the existing no-summary-comment policy. The wording referred to “individual finding issues,” leaving room to treat the canonical report differently. The redundant comment was deleted.

## Verification

- workflow YAML parse
- `bun test packages/cli/src/conventions.test.ts` — 126 pass
- `git diff --check`
- exact indentation parity across policy items `f` through `j`

## Changeset

None. This changes automation policy, not the published CLI.

## Post-merge validation

Manually dispatch the empty-prompt autoheal workflow and confirm #897 is updated in place while its comment count remains zero.
