### PR TITLE
fix(dashboard): persist listener state

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -25,25 +25,35 @@ release is published. Caddy depends on the `dashboard` service being healthy bef
    `DASHBOARD_COOKIE_KEY`, plus SSH context) and the host string before any SSH argv is built.
 2. DNS preflight — resolves `DASHBOARD_DOMAIN` and fails fast if it does not resolve.
 3. ControlMaster SSH multiplexing setup — a shared socket is created; subsequent steps reuse it.
-4. Remote prep: `mkdir -p /opt/dashboard/config` on the droplet.
-5. Materializes `/opt/dashboard/.env` over SSH **stdin** (never argv). The `.env` includes
+4. Remote prep: a constant-only fail-closed command rejects `/opt/dashboard` and
+   `/opt/dashboard/config` when either is a symlink or existing non-directory before any install or
+   ownership operation. It then creates/converges both as root-owned real directories and verifies
+   `realpath -e` resolves to the literal expected paths.
+5. Remote prep: fail-closed validation rejects `/opt/dashboard/data` when it is a symlink or an
+   existing non-directory before any ownership or mode operation. It then runs a constant-only
+   `set -eu` command that creates/converges the directory with `install -d -m 0700 -o 1000 -g 1000`,
+   recursively chowns existing contents to `1000:1000`, reapplies mode `0700` to the root, and
+   verifies the path remains a real directory. Deploy-time convergence is the ownership authority for
+   existing and newly provisioned hosts, and it completes before materialization or compose operations.
+6. Materializes `/opt/dashboard/.env` over SSH **stdin** (never argv). The `.env` includes
    `DASHBOARD_GITHUB_APP_KEY_FILE=/run/secrets/github-app.pem` (the file path only — the PEM content
    is never written to `.env`) and `DASHBOARD_OAUTH_REDIRECT_URI=https://$DASHBOARD_DOMAIN/auth/callback`
    (derived from `DASHBOARD_DOMAIN`; no separate secret required).
-6. Uploads `docker-compose.yaml` and `config/Caddyfile` via `scp`.
-7. **Uploads the GitHub App private key** to `/opt/dashboard/config/github-app.pem` (0600) via SSH
+7. Uploads `docker-compose.yaml` and `config/Caddyfile` via `scp`.
+8. **Uploads the GitHub App private key** to `/opt/dashboard/config/github-app.pem` (0600) via SSH
    stdin — never as an env var, never logged. PEM bytes flow through stdin only; `umask 077` plus an
-   explicit `chmod 0600` ensure the file is readable only by root.
-8. `docker compose pull` — pulls the digest-pinned image from `ghcr.io/fro-bot/dashboard`.
-9. `docker compose up -d --no-build --wait dashboard` — starts the app only; Caddy is **NOT** started
-   yet. `--no-build` enforces the prebuilt digest; `--wait` uses the container healthcheck
-   (`/api/healthz` on `:3000`) as the authoritative success signal.
-10. **RepoDigests verification** — resolves the running container's image SHA, then inspects the
+   explicit `chmod 0600` and subsequent `chown 1000:1000` ensure the file is owned by UID 1000 and
+   readable only by UID 1000 for the non-root container.
+9. `docker compose pull` — pulls the digest-pinned image from `ghcr.io/fro-bot/dashboard`.
+10. `docker compose up -d --no-build --wait dashboard` — starts the app only; Caddy is **NOT** started
+    yet. `--no-build` enforces the prebuilt digest; `--wait` uses the container healthcheck
+    (`/api/healthz` on `:3000`) as the authoritative success signal.
+11. **RepoDigests verification** — resolves the running container's image SHA, then inspects the
     image's `RepoDigests` and asserts that the compose-pinned digest appears in at least one entry.
     Fails closed with an actionable message if the running image does not match the pinned digest.
-11. `docker compose up -d --no-build --wait caddy` — publicly exposes the service **only after** the
-    app is healthy and the digest is verified.
-12. **Bounded public HTTPS probe** — retries `https://$DASHBOARD_DOMAIN/api/healthz` up to 10 times
+12. `docker compose up -d --no-build --wait caddy` — publicly exposes the service **only after**
+    the app is healthy and the digest is verified.
+13. **Bounded public HTTPS probe** — retries `https://$DASHBOARD_DOMAIN/api/healthz` up to 10 times
     (5 s interval). On first-deploy Caddy ACME issuance lag it emits a warning and still succeeds
     (containers are already healthy); re-running once the cert lands is safe.
 
@@ -75,12 +85,28 @@ tmpfs:
   - /tmp
 ```
 
-- **`read_only: true`** — the container filesystem is read-only; only `/tmp` (tmpfs) and the
-  App-key mount are writable surfaces.
+- **`read_only: true`** — the container filesystem is read-only; `/tmp` (tmpfs) and the listener data
+  mount are the writable surfaces. The App-key mount remains read-only.
 - **`cap_drop: [ALL]`** — drops all Linux capabilities; the Hono app needs none.
 - **`no-new-privileges: true`** — prevents privilege escalation via setuid/setgid binaries.
 - **`user: node`** — runs as the non-root `node` user baked into the upstream image.
 - **`tmpfs: /tmp`** — provides a writable scratch space without touching the host filesystem.
+
+**Persistent listener storage:**
+
+```yaml
+volumes:
+  - type: bind
+    source: /opt/dashboard/data
+    target: /data
+    bind:
+      create_host_path: false
+```
+
+The `/data` bind mount is the writable surface for the dashboard's listener SQLite state. The host
+directory is converged at deploy time to mode `0700`, owner `1000:1000`, and persists across container
+recreation. `bind.create_host_path: false` prevents Compose from silently creating a missing or
+mis-typed host path; deploy must establish the validated directory first.
 
 **GitHub App private key mount:**
 
@@ -220,6 +246,9 @@ record.
   path.
 - **Never `docker compose down -v`** — destroys the `caddy_data` volume (Caddy TLS certificates and
   ACME state). Use `docker compose down` (no `-v`) to stop services without losing TLS data.
+- **Never remove `/opt/dashboard/data` casually** — it contains persistent listener SQLite state and
+  removing it destroys Inbox data across container recreation. Treat deletion as an explicit destructive
+  storage reset.
 - **Never add `--build` to the dashboard deploy** — the deploy pulls the digest-pinned image from
   `ghcr.io/fro-bot/dashboard`; on-droplet builds are not supported and `--no-build` is enforced in
   the deploy script.

--- a/apps/dashboard/docker-compose.test.ts
+++ b/apps/dashboard/docker-compose.test.ts
@@ -19,6 +19,19 @@ describe('dashboard docker compose', () => {
     expect(compose).toContain('read_only: true')
   })
 
+  it('bind-mounts persistent listener storage with fail-closed host-path creation', () => {
+    const dashboardSection = compose.slice(compose.indexOf('  dashboard:'))
+
+    expect(dashboardSection).toContain('read_only: true')
+    expect(dashboardSection).toContain('user: node')
+    expect(dashboardSection).toContain(`
+      - type: bind
+        source: /opt/dashboard/data
+        target: /data
+        bind:
+          create_host_path: false`)
+  })
+
   it('drops ALL capabilities on the dashboard service (security hardening)', () => {
     expect(compose).toContain('cap_drop:')
     expect(compose).toContain('- ALL')

--- a/apps/dashboard/docker-compose.yaml
+++ b/apps/dashboard/docker-compose.yaml
@@ -47,6 +47,12 @@ services:
     tmpfs:
       - /tmp
     volumes:
+      # Listener SQLite state writable surface; the rest of the root filesystem remains read-only.
+      - type: bind
+        source: /opt/dashboard/data
+        target: /data
+        bind:
+          create_host_path: false
       # Host path (uploaded by deploy.ts, 0600) : container path : read-only
       - /opt/dashboard/config/github-app.pem:/run/secrets/github-app.pem:ro
     healthcheck:

--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -28,6 +28,9 @@ const COMPOSE_DIGEST = parseComposeImageDigest(dashboardImageLine) ?? ''
 if (!COMPOSE_DIGEST) throw new Error('Could not derive COMPOSE_DIGEST from docker-compose.yaml')
 
 const FAKE_DIGEST = `sha256:${'a'.repeat(64)}`
+const REMOTE_DIR_PATH = '/opt/dashboard'
+const REMOTE_CONFIG_DIR_PATH = '/opt/dashboard/config'
+const DATA_DIR_PATH = '/opt/dashboard/data'
 
 const VALID_ENV = {
   PATH: '/usr/bin:/bin',
@@ -149,39 +152,49 @@ const fetchHealthzFail = async (_url: string, _opts?: RequestInit): Promise<Resp
 /**
  * Builds a standard set of responses for a happy-path deploy.
  * Call order (no override upload — digest is sourced from committed compose file):
- *   0: mkdir -p /opt/dashboard/config
- *   1: write .env (stdin)
- *   2: scp docker-compose.yaml
- *   3: scp Caddyfile
- *   4: write github-app.pem (stdin)
- *   5: chmod 0600 github-app.pem
- *   6: chown 1000:1000 github-app.pem
- *   7: rm -f docker-compose.override.yaml (stale legacy override cleanup)
- *   8: docker compose pull
- *   9: docker compose up -d --no-build --wait dashboard
- *  10: docker inspect (resolve image SHA for dashboard)
- *  11: docker inspect (RepoDigests for dashboard image)
- *  12: docker compose up -d --no-build --wait caddy
- *  13: (extra buffer)
+ *   0: constant-only root/config validation and convergence
+ *   1: install -d /opt/dashboard/data (persistent listener storage)
+ *   2: write .env (stdin)
+ *   3: scp docker-compose.yaml
+ *   4: scp Caddyfile
+ *   5: write github-app.pem (stdin)
+ *   6: chmod 0600 github-app.pem
+ *   7: chown 1000:1000 github-app.pem
+ *   8: rm -f docker-compose.override.yaml (stale legacy override cleanup)
+ *   9: docker compose pull
+ *  10: docker compose up -d --no-build --wait dashboard
+ *  11: docker inspect (resolve image SHA for dashboard)
+ *  12: docker inspect (RepoDigests for dashboard image)
+ *  13: docker compose up -d --no-build --wait caddy
+ *  14: (extra buffer)
  */
 function makeHappyPathResponses(): SpawnResult[] {
   const repoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@${COMPOSE_DIGEST}`])
   return [
-    makeSpawnResult(), // 0: mkdir
-    makeSpawnResult(), // 1: write .env
-    makeSpawnResult(), // 2: scp compose
-    makeSpawnResult(), // 3: scp Caddyfile
-    makeSpawnResult(), // 4: write github-app.pem
-    makeSpawnResult(), // 5: chmod 0600
-    makeSpawnResult(), // 6: chown 1000:1000
-    makeSpawnResult(), // 7: rm -f docker-compose.override.yaml
-    makeSpawnResult(), // 8: compose pull
-    makeSpawnResult(), // 9: compose up dashboard
-    makeSpawnResult('sha256:imageid123'), // 10: docker inspect (image SHA)
-    makeSpawnResult(repoDigestsJson), // 11: docker inspect (RepoDigests)
-    makeSpawnResult(), // 12: compose up caddy
-    makeSpawnResult(), // 13: buffer
+    makeSpawnResult(), // 0: root/config validation and convergence
+    makeSpawnResult(), // 1: install -d data directory
+    makeSpawnResult(), // 2: write .env
+    makeSpawnResult(), // 3: scp compose
+    makeSpawnResult(), // 4: scp Caddyfile
+    makeSpawnResult(), // 5: write github-app.pem
+    makeSpawnResult(), // 6: chmod 0600
+    makeSpawnResult(), // 7: chown 1000:1000
+    makeSpawnResult(), // 8: rm -f docker-compose.override.yaml
+    makeSpawnResult(), // 9: compose pull
+    makeSpawnResult(), // 10: compose up dashboard
+    makeSpawnResult('sha256:imageid123'), // 11: docker inspect (image SHA)
+    makeSpawnResult(repoDigestsJson), // 12: docker inspect (RepoDigests)
+    makeSpawnResult(), // 13: compose up caddy
+    makeSpawnResult(), // 14: buffer
   ]
+}
+
+function getDataDirectorySetupCommand(calls: SpawnCall[]): string {
+  return calls.find(c => c.cmd.at(-1)?.includes(DATA_DIR_PATH))?.cmd.at(-1) ?? ''
+}
+
+function getRemoteRootSetupCommand(calls: SpawnCall[]): string {
+  return calls.find(c => c.cmd[0] === 'ssh' && c.cmd.at(-1)?.includes(REMOTE_CONFIG_DIR_PATH))?.cmd.at(-1) ?? ''
 }
 
 // ─── parseComposeImageDigest ──────────────────────────────────────────────────
@@ -425,6 +438,158 @@ describe('happy path deploy', () => {
     ).resolves.toBeUndefined()
   })
 
+  it('converges persistent listener storage before materialization and compose operations', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const dataSetupCalls = calls.filter(c => c.cmd.at(-1)?.includes(DATA_DIR_PATH))
+    expect(dataSetupCalls).toHaveLength(1)
+
+    const dataSetupIdx = calls.findIndex(c => c.cmd.at(-1)?.includes(DATA_DIR_PATH))
+    const envWriteIdx = calls.findIndex(c => c.stdinData.includes('DASHBOARD_DOMAIN='))
+    const appKeyWriteIdx = calls.findIndex(c => c.stdinData.includes('BEGIN RSA PRIVATE KEY'))
+    const composeOperationIndices = calls.flatMap((call, index) => {
+      const command = call.cmd.join(' ')
+      return command.includes('docker compose pull') || command.includes('docker compose up') ? [index] : []
+    })
+
+    expect(dataSetupIdx).toBeLessThan(envWriteIdx)
+    expect(dataSetupIdx).toBeLessThan(appKeyWriteIdx)
+    expect(composeOperationIndices.length).toBeGreaterThanOrEqual(3)
+    expect(composeOperationIndices.every(index => dataSetupIdx < index)).toBe(true)
+  })
+
+  it('fails closed and physically validates the remote root and config directories before mutation', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const command = getRemoteRootSetupCommand(calls)
+    const guards = [
+      `if [ -L '${REMOTE_DIR_PATH}' ]; then echo 'Refusing dashboard root symlink' >&2; exit 1; fi`,
+      `if [ -e '${REMOTE_DIR_PATH}' ] && [ ! -d '${REMOTE_DIR_PATH}' ]; then echo 'Refusing dashboard root non-directory' >&2; exit 1; fi`,
+      `if [ -L '${REMOTE_CONFIG_DIR_PATH}' ]; then echo 'Refusing dashboard config symlink' >&2; exit 1; fi`,
+      `if [ -e '${REMOTE_CONFIG_DIR_PATH}' ] && [ ! -d '${REMOTE_CONFIG_DIR_PATH}' ]; then echo 'Refusing dashboard config non-directory' >&2; exit 1; fi`,
+    ]
+    const firstMutationIndex = Math.min(
+      ...['install -d', 'mkdir -p', 'chown'].map(token => command.indexOf(token)).filter(index => index >= 0),
+    )
+
+    expect(calls.filter(c => c.cmd[0] === 'ssh' && c.cmd.at(-1) === command)).toHaveLength(1)
+    expect(calls.some(c => c.cmd.join(' ').includes('mkdir -p /opt/dashboard/config'))).toBe(false)
+    expect(command).toContain('set -eu')
+    for (const guard of guards) {
+      expect(command).toContain(guard)
+      expect(command.indexOf(guard)).toBeLessThan(firstMutationIndex)
+    }
+    expect(command).toContain(`install -d -m 0755 -o 0 -g 0 '${REMOTE_DIR_PATH}'`)
+    expect(command).toContain(`install -d -m 0755 -o 0 -g 0 '${REMOTE_CONFIG_DIR_PATH}'`)
+    expect(command).toContain(`chown 0:0 '${REMOTE_DIR_PATH}' '${REMOTE_CONFIG_DIR_PATH}'`)
+    expect(command).toContain(`[ "$(realpath -e '${REMOTE_DIR_PATH}')" = '${REMOTE_DIR_PATH}' ]`)
+    expect(command).toContain(`[ "$(realpath -e '${REMOTE_CONFIG_DIR_PATH}')" = '${REMOTE_CONFIG_DIR_PATH}' ]`)
+    expect(command).not.toContain(VALID_ENV.DASHBOARD_DOMAIN)
+    expect(command).not.toContain(VALID_ENV.DASHBOARD_OAUTH_CLIENT_SECRET)
+    expect(command).not.toContain(VALID_ENV.DASHBOARD_COOKIE_KEY)
+  })
+
+  it('rejects symlinks and existing non-directories before changing listener storage', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const command = getDataDirectorySetupCommand(calls)
+    const symlinkGuard = `if [ -L '${DATA_DIR_PATH}' ]; then echo 'Refusing listener data path symlink' >&2; exit 1; fi`
+    const nonDirectoryGuard =
+      `if [ -e '${DATA_DIR_PATH}' ] && [ ! -d '${DATA_DIR_PATH}' ]; then ` +
+      `echo 'Refusing listener data path non-directory' >&2; exit 1; fi`
+    const installIndex = command.indexOf('install -d -m 0700 -o 1000 -g 1000')
+    const chownIndex = command.indexOf('chown -R 1000:1000')
+    const chmodIndex = command.indexOf(`chmod 0700 '${DATA_DIR_PATH}'`)
+
+    expect(command).toContain('set -eu')
+    expect(command).toContain(symlinkGuard)
+    expect(command).toContain(nonDirectoryGuard)
+    expect(installIndex).toBeGreaterThan(command.indexOf(symlinkGuard))
+    expect(installIndex).toBeGreaterThan(command.indexOf(nonDirectoryGuard))
+    expect(chownIndex).toBeGreaterThan(installIndex)
+    expect(chmodIndex).toBeGreaterThan(chownIndex)
+    expect(command).toContain(
+      `[ -d '${DATA_DIR_PATH}' ] && [ ! -L '${DATA_DIR_PATH}' ] && ` +
+        `[ "$(realpath -e '${DATA_DIR_PATH}')" = '${DATA_DIR_PATH}' ]`,
+    )
+  })
+
+  it('recursively converges listener storage ownership and preserves the root mode', async () => {
+    const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
+
+    await deploy({
+      env: VALID_ENV,
+      spawn: spawnFn,
+      resolve: resolvesOk,
+      fetch: fetchHealthzOk,
+      probeAttempts: 1,
+      probeIntervalMs: 0,
+      sleep: async () => {},
+    })
+
+    const command = getDataDirectorySetupCommand(calls)
+    expect(command).toContain(`chown -R 1000:1000 '${DATA_DIR_PATH}'`)
+    expect(command).toContain(`chmod 0700 '${DATA_DIR_PATH}'`)
+    expect(command).toContain(
+      `[ -d '${DATA_DIR_PATH}' ] && [ ! -L '${DATA_DIR_PATH}' ] && ` +
+        `[ "$(realpath -e '${DATA_DIR_PATH}')" = '${DATA_DIR_PATH}' ]`,
+    )
+  })
+
+  it('aborts before image pull or start when persistent listener storage setup fails', async () => {
+    const responses = makeHappyPathResponses()
+    responses[1] = makeSpawnResult('', 'data directory setup failed', 1)
+    const {spawnFn, calls} = makeFakeSpawn(responses)
+
+    await expect(
+      deploy({
+        env: VALID_ENV,
+        spawn: spawnFn,
+        resolve: resolvesOk,
+        fetch: fetchHealthzOk,
+        probeAttempts: 1,
+        probeIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/exit code 1/)
+
+    const dataSetupIdx = calls.findIndex(c => c.cmd.at(-1)?.includes(DATA_DIR_PATH))
+    expect(dataSetupIdx).toBeGreaterThan(-1)
+    expect(calls.some(c => c.cmd.join(' ').includes('docker compose pull'))).toBe(false)
+    expect(calls.some(c => c.cmd.join(' ').includes('docker compose up'))).toBe(false)
+    expect(calls.some(c => c.stdinData.includes('DASHBOARD_DOMAIN='))).toBe(false)
+  })
+
   it('materializes .env via SSH stdin (not argv)', async () => {
     const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
 
@@ -608,7 +773,7 @@ describe('happy path deploy', () => {
   it('uses digest from committed compose file for assertRunningImageDigest', async () => {
     // Provide a RepoDigests response that matches the compose-pinned digest
     const responses = makeHappyPathResponses()
-    // responses[11] already returns COMPOSE_DIGEST — deploy should pass
+    // responses[12] already returns COMPOSE_DIGEST — deploy should pass
     const {spawnFn} = makeFakeSpawn(responses)
 
     await expect(
@@ -757,8 +922,8 @@ describe('edge cases', () => {
     const wrongRepoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@${wrongDigest}`])
 
     const responses = makeHappyPathResponses()
-    // Override the RepoDigests response (index 11) with a mismatched digest
-    responses[11] = makeSpawnResult(wrongRepoDigestsJson)
+    // Override the RepoDigests response (index 12) with a mismatched digest
+    responses[12] = makeSpawnResult(wrongRepoDigestsJson)
 
     const {spawnFn} = makeFakeSpawn(responses)
 
@@ -1585,39 +1750,41 @@ const RESOLVED_DIGEST = `sha256:${'c'.repeat(64)}`
  *
  * Call order for versioned deploy:
  *   0: docker buildx imagetools inspect (resolve digest)
- *   1: mkdir -p /opt/dashboard/config
- *   2: write .env (stdin)
- *   3: write docker-compose.yaml (stdin — generated content)
- *   4: scp Caddyfile
- *   5: write github-app.pem (stdin)
- *   6: chmod 0600 github-app.pem
- *   7: chown 1000:1000 github-app.pem
- *   8: rm -f docker-compose.override.yaml
- *   9: docker compose pull
- *  10: docker compose up -d --no-build --wait dashboard
- *  11: docker inspect (resolve image SHA)
- *  12: docker inspect (RepoDigests)
- *  13: docker compose up -d --no-build --wait caddy
- *  14: (buffer)
+ *   1: constant-only root/config validation and convergence
+ *   2: install -d /opt/dashboard/data (persistent listener storage)
+ *   3: write .env (stdin)
+ *   4: write docker-compose.yaml (stdin — generated content)
+ *   5: scp Caddyfile
+ *   6: write github-app.pem (stdin)
+ *   7: chmod 0600 github-app.pem
+ *   8: chown 1000:1000 github-app.pem
+ *   9: rm -f docker-compose.override.yaml
+ *  10: docker compose pull
+ *  11: docker compose up -d --no-build --wait dashboard
+ *  12: docker inspect (resolve image SHA)
+ *  13: docker inspect (RepoDigests)
+ *  14: docker compose up -d --no-build --wait caddy
+ *  15: (buffer)
  */
 function makeVersionedHappyPathResponses(): SpawnResult[] {
   const repoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@${RESOLVED_DIGEST}`])
   return [
     makeSpawnResult(RESOLVED_DIGEST), // 0: imagetools inspect → resolved digest
-    makeSpawnResult(), // 1: mkdir
-    makeSpawnResult(), // 2: write .env
-    makeSpawnResult(), // 3: write docker-compose.yaml (stdin)
-    makeSpawnResult(), // 4: scp Caddyfile
-    makeSpawnResult(), // 5: write github-app.pem
-    makeSpawnResult(), // 6: chmod 0600
-    makeSpawnResult(), // 7: chown 1000:1000
-    makeSpawnResult(), // 8: rm -f docker-compose.override.yaml
-    makeSpawnResult(), // 9: compose pull
-    makeSpawnResult(), // 10: compose up dashboard
-    makeSpawnResult('sha256:imageid123'), // 11: docker inspect (image SHA)
-    makeSpawnResult(repoDigestsJson), // 12: docker inspect (RepoDigests)
-    makeSpawnResult(), // 13: compose up caddy
-    makeSpawnResult(), // 14: buffer
+    makeSpawnResult(), // 1: root/config validation and convergence
+    makeSpawnResult(), // 2: install -d data directory
+    makeSpawnResult(), // 3: write .env
+    makeSpawnResult(), // 4: write docker-compose.yaml (stdin)
+    makeSpawnResult(), // 5: scp Caddyfile
+    makeSpawnResult(), // 6: write github-app.pem
+    makeSpawnResult(), // 7: chmod 0600
+    makeSpawnResult(), // 8: chown 1000:1000
+    makeSpawnResult(), // 9: rm -f docker-compose.override.yaml
+    makeSpawnResult(), // 10: compose pull
+    makeSpawnResult(), // 11: compose up dashboard
+    makeSpawnResult('sha256:imageid123'), // 12: docker inspect (image SHA)
+    makeSpawnResult(repoDigestsJson), // 13: docker inspect (RepoDigests)
+    makeSpawnResult(), // 14: compose up caddy
+    makeSpawnResult(), // 15: buffer
   ]
 }
 
@@ -1719,8 +1886,8 @@ describe('versioned deploy path', () => {
   it('fails when running image digest does not match resolvedDigest', async () => {
     const wrongRepoDigestsJson = JSON.stringify([`ghcr.io/fro-bot/dashboard@sha256:${'e'.repeat(64)}`])
     const responses = makeVersionedHappyPathResponses()
-    // Override the RepoDigests response (index 12) with a mismatched digest
-    responses[12] = makeSpawnResult(wrongRepoDigestsJson)
+    // Override the RepoDigests response (index 13) with a mismatched digest
+    responses[13] = makeSpawnResult(wrongRepoDigestsJson)
 
     const {spawnFn} = makeFakeSpawn(responses)
 
@@ -1964,7 +2131,7 @@ describe('versioned deploy: writes local compose path after successful deploy', 
     try {
       // Replace the caddy up response (index 13) with a failing exit code.
       const responses = makeVersionedHappyPathResponses()
-      responses[13] = makeSpawnResult('', 'caddy up failed', 1)
+      responses[14] = makeSpawnResult('', 'caddy up failed', 1)
       const {spawnFn} = makeFakeSpawn(responses)
 
       await expect(

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -12,6 +12,28 @@ const REMOTE_DIR = '/opt/dashboard'
 const REMOTE_ENV_PATH = `${REMOTE_DIR}/.env`
 const REMOTE_COMPOSE_PATH = `${REMOTE_DIR}/docker-compose.yaml`
 const REMOTE_CONFIG_DIR = `${REMOTE_DIR}/config`
+const REMOTE_DATA_DIR = `${REMOTE_DIR}/data`
+const REMOTE_ROOT_SETUP_COMMAND = [
+  'set -eu',
+  `if [ -L '${REMOTE_DIR}' ]; then echo 'Refusing dashboard root symlink' >&2; exit 1; fi`,
+  `if [ -e '${REMOTE_DIR}' ] && [ ! -d '${REMOTE_DIR}' ]; then echo 'Refusing dashboard root non-directory' >&2; exit 1; fi`,
+  `if [ -L '${REMOTE_CONFIG_DIR}' ]; then echo 'Refusing dashboard config symlink' >&2; exit 1; fi`,
+  `if [ -e '${REMOTE_CONFIG_DIR}' ] && [ ! -d '${REMOTE_CONFIG_DIR}' ]; then echo 'Refusing dashboard config non-directory' >&2; exit 1; fi`,
+  `install -d -m 0755 -o 0 -g 0 '${REMOTE_DIR}'`,
+  `install -d -m 0755 -o 0 -g 0 '${REMOTE_CONFIG_DIR}'`,
+  `chown 0:0 '${REMOTE_DIR}' '${REMOTE_CONFIG_DIR}'`,
+  `[ "$(realpath -e '${REMOTE_DIR}')" = '${REMOTE_DIR}' ]`,
+  `[ "$(realpath -e '${REMOTE_CONFIG_DIR}')" = '${REMOTE_CONFIG_DIR}' ]`,
+].join('; ')
+const REMOTE_DATA_SETUP_COMMAND = [
+  'set -eu',
+  `if [ -L '${REMOTE_DATA_DIR}' ]; then echo 'Refusing listener data path symlink' >&2; exit 1; fi`,
+  `if [ -e '${REMOTE_DATA_DIR}' ] && [ ! -d '${REMOTE_DATA_DIR}' ]; then echo 'Refusing listener data path non-directory' >&2; exit 1; fi`,
+  `install -d -m 0700 -o 1000 -g 1000 '${REMOTE_DATA_DIR}'`,
+  `chown -R 1000:1000 '${REMOTE_DATA_DIR}'`,
+  `chmod 0700 '${REMOTE_DATA_DIR}'`,
+  `[ -d '${REMOTE_DATA_DIR}' ] && [ ! -L '${REMOTE_DATA_DIR}' ] && [ "$(realpath -e '${REMOTE_DATA_DIR}')" = '${REMOTE_DATA_DIR}' ]`,
+].join('; ')
 const REMOTE_CADDYFILE_PATH = `${REMOTE_CONFIG_DIR}/Caddyfile`
 const REMOTE_APP_KEY_PATH = `${REMOTE_CONFIG_DIR}/github-app.pem`
 const HEALTH_PATH = '/api/healthz'
@@ -672,20 +694,25 @@ async function resolveImageDigest(version: string, spawnFn: SpawnFn, deployEnv: 
  * 5. ControlMaster SSH multiplexing setup (dual-tmpdir: key under os.tmpdir(), socket under /tmp)
  * 6. Versioned: resolve digest via imagetools inspect + cross-check; generate compose content
  *    No-version: read digest from committed docker-compose.yaml
- * 7. Remote prep: mkdir -p /opt/dashboard/config
- * 8. Materialize /opt/dashboard/.env via SSH stdin (includes DASHBOARD_GITHUB_APP_KEY_FILE path)
- * 9. Versioned: upload generated compose via SSH stdin
+ * 7. Remote prep: constant-only fail-closed validation/convergence for /opt/dashboard and
+ *    /opt/dashboard/config; reject symlinks and existing non-directories before mutation,
+ *    create both as root-owned real directories, and verify their physical paths with realpath -e
+ * 8. Remote prep: reject a symlink or existing non-directory at /opt/dashboard/data, then
+ *    install it with mode 0700 and owner 1000:1000, recursively chown existing contents, reapply
+ *    mode 0700 to the root, and verify it remains a real directory
+ * 9. Materialize /opt/dashboard/.env via SSH stdin (includes DASHBOARD_GITHUB_APP_KEY_FILE path)
+ * 10. Versioned: upload generated compose via SSH stdin
  *    No-version: scp committed docker-compose.yaml
  *    Both: scp config/Caddyfile
- * 10. Upload GitHub App private key via SSH stdin to /opt/dashboard/config/github-app.pem (0600)
+ * 11. Upload GitHub App private key via SSH stdin to /opt/dashboard/config/github-app.pem (0600)
  *     SECURITY: PEM bytes flow through stdin ONLY — never in argv, never in a local temp file
- * 11. chown 1000:1000 github-app.pem so the container's node user (UID 1000) can read it
- * 12. rm -f /opt/dashboard/docker-compose.override.yaml (idempotent legacy cleanup)
- * 13. docker compose pull (pulls digest-pinned GHCR image from docker-compose.yaml)
- * 14. docker compose up -d --no-build --wait dashboard (app health gate first)
- * 15. Verify RepoDigests: assert running image includes selected digest (fail closed)
- * 16. docker compose up -d --no-build --wait caddy (public exposure after app healthy)
- * 17. Probe https://$DASHBOARD_DOMAIN/api/healthz — bounded retry; warning-only on ACME lag
+ * 12. chown 1000:1000 github-app.pem so the container's node user (UID 1000) can read it
+ * 13. rm -f /opt/dashboard/docker-compose.override.yaml (idempotent legacy cleanup)
+ * 14. docker compose pull (pulls digest-pinned GHCR image from docker-compose.yaml)
+ * 15. docker compose up -d --no-build --wait dashboard (app health gate first)
+ * 16. Verify RepoDigests: assert running image includes selected digest (fail closed)
+ * 17. docker compose up -d --no-build --wait caddy (public exposure after app healthy)
+ * 18. Probe https://$DASHBOARD_DOMAIN/api/healthz — bounded retry; warning-only on ACME lag
  */
 export async function deploy(opts: DeployOpts = {}): Promise<void> {
   const env = opts.env ?? (process.env as Record<string, string>)
@@ -803,7 +830,16 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
     // Phase 4: Remote prep
     await runCommand(
       'Creating remote directories',
-      sshCommand(host, `mkdir -p ${REMOTE_CONFIG_DIR}`, keyPath, controlPath),
+      sshCommand(host, REMOTE_ROOT_SETUP_COMMAND, keyPath, controlPath),
+      deployEnv,
+      spawnFn,
+    )
+
+    // Phase 4b: Converge persistent listener storage ownership and permissions.
+    // This is the authority for both existing and newly provisioned hosts.
+    await runCommand(
+      'Creating remote listener data directory',
+      sshCommand(host, REMOTE_DATA_SETUP_COMMAND, keyPath, controlPath),
       deployEnv,
       spawnFn,
     )


### PR DESCRIPTION
## Summary
- Persist dashboard listener SQLite state on a dedicated `/data` bind mount while preserving the read-only container root.
- Fail closed on redirected or invalid host paths before ownership changes, then converge existing listener state to UID/GID `1000`.
- Prevent Compose from silently creating a missing host source path.

**Risk:** The deploy path now refuses to run when listener volume paths are misconfigured, which protects host integrity but raises an earlier failure mode during rollout.

## Verification
- `bun test apps/dashboard` — 196 pass, 0 fail
- `bunx tsc --noEmit`
- `bunx eslint --no-error-on-unmatched-pattern apps/dashboard/docker-compose.test.ts apps/dashboard/src/deploy.test.ts apps/dashboard/src/deploy.ts`
- `docker compose -f apps/dashboard/docker-compose.yaml config`
- `git diff --check`
