### PR TITLE
fix(dashboard): force-recreate caddy so config changes load on deploy

### DIFF
--- a/apps/dashboard/src/deploy.test.ts
+++ b/apps/dashboard/src/deploy.test.ts
@@ -162,10 +162,10 @@ const fetchHealthzFail = async (_url: string, _opts?: RequestInit): Promise<Resp
  *   7: chown 1000:1000 github-app.pem
  *   8: rm -f docker-compose.override.yaml (stale legacy override cleanup)
  *   9: docker compose pull
- *  10: docker compose up -d --no-build --wait dashboard
+ *  10: docker compose up -d --no-build --wait --wait-timeout 120 dashboard
  *  11: docker inspect (resolve image SHA for dashboard)
  *  12: docker inspect (RepoDigests for dashboard image)
- *  13: docker compose up -d --no-build --wait caddy
+ *  13: docker compose up -d --no-build --force-recreate --wait --wait-timeout 120 caddy
  *  14: (extra buffer)
  */
 function makeHappyPathResponses(): SpawnResult[] {
@@ -1775,10 +1775,10 @@ const RESOLVED_DIGEST = `sha256:${'c'.repeat(64)}`
  *   8: chown 1000:1000 github-app.pem
  *   9: rm -f docker-compose.override.yaml
  *  10: docker compose pull
- *  11: docker compose up -d --no-build --wait dashboard
+ *  11: docker compose up -d --no-build --wait --wait-timeout 120 dashboard
  *  12: docker inspect (resolve image SHA)
  *  13: docker inspect (RepoDigests)
- *  14: docker compose up -d --no-build --wait caddy
+ *  14: docker compose up -d --no-build --force-recreate --wait --wait-timeout 120 caddy
  *  15: (buffer)
  */
 function makeVersionedHappyPathResponses(): SpawnResult[] {
@@ -2413,11 +2413,10 @@ describe('public probe: final warning includes last error or status', () => {
   })
 })
 
-// ─── RED: --wait-timeout 120 in compose up commands ──────────────────────────
+// ─── compose up safety flags ─────────────────────────────────────────────────
 //
-// Both `docker compose up -d --no-build --wait dashboard` and
-// `docker compose up -d --no-build --wait caddy` must include `--wait-timeout 120`
-// to bound the wait and surface clear timeout errors.
+// The dashboard app must remain digest-gated without forced recreation. Caddy
+// must force recreation so bind-mounted Caddyfile content changes are loaded.
 
 describe('docker compose up: --wait-timeout 120', () => {
   it('dashboard compose up includes --wait-timeout 120', async () => {
@@ -2439,9 +2438,11 @@ describe('docker compose up: --wait-timeout 120', () => {
     })
     expect(dashboardUpCall).toBeDefined()
     expect(dashboardUpCall?.cmd.join(' ')).toContain('--wait-timeout 120')
+    expect(dashboardUpCall?.cmd.join(' ')).toContain('--no-build')
+    expect(dashboardUpCall?.cmd.join(' ')).not.toContain('--force-recreate')
   })
 
-  it('caddy compose up includes --wait-timeout 120', async () => {
+  it('caddy compose up includes --force-recreate, --wait-timeout 120, and --no-build', async () => {
     const {spawnFn, calls} = makeFakeSpawn(makeHappyPathResponses())
 
     await deploy({
@@ -2459,6 +2460,8 @@ describe('docker compose up: --wait-timeout 120', () => {
       return s.includes('docker compose up') && s.includes('caddy')
     })
     expect(caddyUpCall).toBeDefined()
+    expect(caddyUpCall?.cmd.join(' ')).toContain('--force-recreate')
     expect(caddyUpCall?.cmd.join(' ')).toContain('--wait-timeout 120')
+    expect(caddyUpCall?.cmd.join(' ')).toContain('--no-build')
   })
 })

--- a/apps/dashboard/src/deploy.ts
+++ b/apps/dashboard/src/deploy.ts
@@ -709,9 +709,9 @@ async function resolveImageDigest(version: string, spawnFn: SpawnFn, deployEnv: 
  * 12. chown 1000:1000 github-app.pem so the container's node user (UID 1000) can read it
  * 13. rm -f /opt/dashboard/docker-compose.override.yaml (idempotent legacy cleanup)
  * 14. docker compose pull (pulls digest-pinned GHCR image from docker-compose.yaml)
- * 15. docker compose up -d --no-build --wait dashboard (app health gate first)
+ * 15. docker compose up -d --no-build --wait --wait-timeout 120 dashboard (app health gate first)
  * 16. Verify RepoDigests: assert running image includes selected digest (fail closed)
- * 17. docker compose up -d --no-build --wait caddy (public exposure after app healthy)
+ * 17. docker compose up -d --no-build --force-recreate --wait --wait-timeout 120 caddy (public exposure after app healthy)
  * 18. Probe https://$DASHBOARD_DOMAIN/api/healthz — bounded retry; warning-only on ACME lag
  */
 export async function deploy(opts: DeployOpts = {}): Promise<void> {
@@ -1015,11 +1015,12 @@ export async function deploy(opts: DeployOpts = {}): Promise<void> {
 
     // Phase 11: Start Caddy — now safe to expose publicly (app is healthy + digest verified).
     // --wait-timeout 120 bounds the health-check wait and surfaces clear timeout errors.
+    // Bind-mounted Caddyfile content changes do not trigger recreation; force reload it every deploy.
     await runCommand(
       'Starting Caddy (public exposure)',
       sshCommand(
         host,
-        `cd ${REMOTE_DIR} && docker compose up -d --no-build --wait --wait-timeout 120 caddy`,
+        `cd ${REMOTE_DIR} && docker compose up -d --no-build --force-recreate --wait --wait-timeout 120 caddy`,
         keyPath,
         controlPath,
       ),


### PR DESCRIPTION
## Summary
- The dashboard Caddyfile is bind-mounted into the caddy container. `docker compose up -d` does not recreate a container when only a mounted file's contents change, so a changed Caddyfile was deployed to the droplet but never loaded by the running Caddy — the deploy reported success while Caddy kept serving stale routing.
- This caused a production incident: the operator Runs view's static assets (`operator-stream.js`, `sw.js`) were served as `text/html` until the caddy container was manually recreated.
- Add `--force-recreate` to the caddy service bring-up so every deploy loads the Caddyfile. The digest-gated dashboard app bring-up is unchanged, and named volumes (Caddy's ACME certificate store) are preserved.

## Verification
- `bun test apps/dashboard/src/deploy.test.ts apps/dashboard/docker-compose.test.ts` — 154 pass, 0 fail (asserts caddy bring-up includes `--force-recreate`, dashboard bring-up does not)
- `bunx tsc --noEmit`
- `git diff --check`
