### PR TITLE
docs(solutions): document bind-mounted caddy stale-reload deploy trap

### DIFF
--- a/docs/solutions/integration-issues/dashboard-caddy-bind-mount-stale-reload-2026-07-26.md
+++ b/docs/solutions/integration-issues/dashboard-caddy-bind-mount-stale-reload-2026-07-26.md
@@ -1,0 +1,83 @@
+---
+title: 'Bind-mounted Caddyfile changes not loaded on dashboard deploy (missing --force-recreate)'
+problem_type: integration_issue
+component: tooling
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+date: 2026-07-26
+tags: [dashboard, caddy, docker-compose, bind-mount, stale-config, deploy, force-recreate]
+module: apps/dashboard
+related_issues:
+  - https://github.com/marcusrbrown/infra/pull/953
+  - https://github.com/marcusrbrown/infra/pull/954
+  - https://github.com/marcusrbrown/infra/pull/948
+  - https://github.com/marcusrbrown/infra/pull/740
+related_docs:
+  - docs/solutions/integration-issues/broker-credential-lifecycle-restart-races-2026-07-02.md
+  - docs/solutions/integration-issues/dashboard-spa-caddy-catchall-deep-link-404-2026-06-25.md
+  - docs/solutions/workflow-issues/gateway-deploy-stale-image-2026-05-31.md
+---
+
+# Bind-mounted Caddyfile changes not loaded on dashboard deploy
+
+## Problem
+
+The dashboard Caddyfile is bind-mounted into the caddy container (`./config/Caddyfile:/etc/caddy/Caddyfile` in `apps/dashboard/docker-compose.yaml`). `docker compose up -d` does **not** recreate a service solely because the *content* of a bind-mounted file changed — it recreates only on image, service-definition, or environment changes. So a deploy can `scp` a new Caddyfile to the droplet, report success, and leave the running Caddy process serving the previous routing. **A green deploy and a correct on-disk config are not proof that the live process loaded them** — the same class as the broker stale-bundle trap ([#740](https://github.com/marcusrbrown/infra/pull/740)).
+
+## Symptoms
+
+- After extension-based asset routing merged in [#953](https://github.com/marcusrbrown/infra/pull/953) and the dashboard deploy reported success, `https://dashboard.fro.bot/sw.js` and `/static/operator-stream.js` still returned stale `302`/`text/html` instead of `200 text/javascript`.
+- The operator **Runs** view showed "Service unavailable" because its module script (`operator-stream.js`) and the service worker (`sw.js`) failed browser MIME checks (`Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"`).
+- The caddy container's `.State.StartedAt` was ~`2026-07-13` with `RestartCount: 0` — ~13 days before the deploy, proving the container was never recreated.
+- Reading the Caddyfile on disk showed the correct new content, which masked the real gap: the *running* Caddy still held its old startup config.
+
+## What Didn't Work
+
+- Chasing operator auth: the `401` on `/operator/session` from unauthenticated probes was expected noise, not the cause.
+- Chasing the SSE run-stream path: downstream symptom of the asset failure, not the root cause.
+- Verifying the uploaded Caddyfile on disk: necessary but not sufficient — it does not prove the running container reloaded it. The decisive signal was the browser console MIME error plus the pre-deploy `.State.StartedAt`.
+
+## Solution
+
+**Immediate recovery** (restore production without touching certs):
+
+```sh
+docker compose up -d --no-deps --force-recreate --wait --wait-timeout 120 caddy
+```
+
+Never use `docker compose down -v` for this — `-v` removes the named `caddy_data` volume holding ACME/TLS state, and re-issuance can hit Let's Encrypt rate limits.
+
+**Durable fix** ([#954](https://github.com/marcusrbrown/infra/pull/954)) — add `--force-recreate` to the Phase 11 caddy bring-up in `apps/dashboard/src/deploy.ts`:
+
+```diff
+- cd ${REMOTE_DIR} && docker compose up -d --no-build --wait --wait-timeout 120 caddy
++ cd ${REMOTE_DIR} && docker compose up -d --no-build --force-recreate --wait --wait-timeout 120 caddy
+```
+
+The dashboard **app** bring-up (Phase 9) intentionally keeps no `--force-recreate` — it is digest-gated and must not be needlessly recreated.
+
+## Why This Works
+
+`--force-recreate` forces the caddy container to be replaced, so it re-reads the bind-mounted Caddyfile on start. The `caddy_data` named volume stays attached across recreation, preserving ACME certificates — only volume deletion (`down -v`) removes that state. Scoping the flag to the caddy service (no `--always-recreate-deps`) leaves the already-health-gated app container untouched.
+
+## Prevention
+
+- **Treat any bind-mounted config or artifact as needing explicit recreation/reload after upload.** `docker compose up -d` silently no-ops on mounted-file *content* changes (Caddyfile here; broker `dist/main.js` in [#740](https://github.com/marcusrbrown/infra/pull/740)).
+- **Deploy-green ≠ config-live.** Verify both: the container `.State.StartedAt` advanced into the deploy window, and the live endpoint returns the expected status/content-type (`/sw.js` → `200 text/javascript`; `/operator/*` still gateway-routed).
+- **Never `down -v`** for a config reload — scope `--force-recreate` to the service consuming the changed mount, preserving the ACME cert volume.
+- **Pin the contract in a deploy test** so the recreate step can't silently regress (`apps/dashboard/src/deploy.test.ts`):
+
+```ts
+expect(dashboardUpCall?.cmd.join(' ')).not.toContain('--force-recreate')
+expect(caddyUpCall?.cmd.join(' ')).toContain('--force-recreate')
+```
+
+## Related Issues
+
+- [#953](https://github.com/marcusrbrown/infra/pull/953) — extension-based Caddy asset routing (the change that exposed the stale-reload trap).
+- [#954](https://github.com/marcusrbrown/infra/pull/954) — the durable `--force-recreate` fix documented here.
+- [#948](https://github.com/marcusrbrown/infra/pull/948) — dashboard listener-state persistence (same incident window, different root cause).
+- [broker-credential-lifecycle-restart-races-2026-07-02.md](./broker-credential-lifecycle-restart-races-2026-07-02.md) — strongest precedent: the same bind-mounted-content-vs-container-recreation trap for the broker's `dist/main.js`, fixed with `--force-recreate` in [#740](https://github.com/marcusrbrown/infra/pull/740).
+- [dashboard-spa-caddy-catchall-deep-link-404-2026-06-25.md](./dashboard-spa-caddy-catchall-deep-link-404-2026-06-25.md) — same `apps/dashboard/config/Caddyfile`; its `@owned` asset allowlist drifted and served operator assets as `text/html`, superseded by the extension matcher in [#953](https://github.com/marcusrbrown/infra/pull/953).
+- [gateway-deploy-stale-image-2026-05-31.md](../workflow-issues/gateway-deploy-stale-image-2026-05-31.md) — same "green deploy does not prove freshness" lesson for stale Docker images.

--- a/docs/solutions/integration-issues/dashboard-spa-caddy-catchall-deep-link-404-2026-06-25.md
+++ b/docs/solutions/integration-issues/dashboard-spa-caddy-catchall-deep-link-404-2026-06-25.md
@@ -1,6 +1,7 @@
 ---
 title: Dashboard SPA deep links 404 without a Caddy catch-all rewrite
 date: 2026-06-25
+last_updated: 2026-07-26
 category: docs/solutions/integration-issues/
 module: apps/dashboard
 problem_type: integration_issue
@@ -57,16 +58,24 @@ The dashboard `/` view was rebuilt as a Vite + React SPA served from the contain
             header_up X-Forwarded-Proto https
         }
     }
-    @owned path /api/* /auth/* /assets/* /manifest.webmanifest /icon-*
-    handle @owned {
-        reverse_proxy dashboard:3000   # backend-owned + assets, original path unchanged
+    handle /api/* {                   # backend routes, original path unchanged
+        reverse_proxy dashboard:3000
+    }
+    handle /auth/* {
+        reverse_proxy dashboard:3000
+    }
+    @assets path_regexp \.[A-Za-z0-9]+$   # any file-with-extension -> app, original path
+    handle @assets {
+        reverse_proxy dashboard:3000
     }
     handle {
-        rewrite * /                    # unknown client route -> /
+        rewrite * /                    # unknown (extensionless) client route -> /
         reverse_proxy dashboard:3000   # backend serves index.html at /
     }
 }
 ```
+
+> **Update (2026-07-26, [#953](https://github.com/marcusrbrown/infra/pull/953)):** the original fix used a hand-maintained `@owned path /api/* /auth/* /assets/* /manifest.webmanifest /icon-*` allowlist. That allowlist **drifted**: the operator UI shipped root-level assets (`operator-stream.js`, `sw.js`, `static/operator-*.js`) that were never added to it, so the catch-all rewrote them to `/` and served the SPA HTML shell — the browser rejected the module script and service worker for MIME `text/html` and the operator Runs view went "Service unavailable". The block above shows the current, drift-proof shape: route any path **with a file extension** to the app at its real path (subsuming `/assets/*`, `/manifest.webmanifest`, `/icon-*`), and rewrite only extensionless client routes to the SPA entrypoint. See [dashboard-caddy-bind-mount-stale-reload-2026-07-26.md](./dashboard-caddy-bind-mount-stale-reload-2026-07-26.md) for the follow-on deploy trap where this Caddyfile change did not load until the caddy container was force-recreated.
 
 Validate the rendered config with `caddy adapt` against the pinned image:
 
@@ -82,7 +91,7 @@ docker run --rm -i caddy:2.11.3-alpine caddy adapt --adapter caddyfile - < apps/
 
 - **Verification method — compare the unknown route to `/`, not to the SPA document.** An unknown client route must return the *same* response as `/`. Here both return `302 → /operator/auth/github/start?return_to=/operator` because `/` is auth-gated in SESSION mode. The `302`-equals-`/` result (not a backend `404` for the deep-link path) proves `rewrite * /` reached the backend at `/`. An unauthenticated probe correctly gets the auth redirect rather than the SPA doc; an authenticated browser gets `index.html`. Expecting the SPA document from an unauthenticated probe on an auth-gated root is a false-negative trap.
 - Also confirm the unchanged paths after deploy: `/api/healthz` still `200`, `/operator/health` unchanged, asset paths still proxy unchanged.
-- Use this pattern whenever a reverse proxy fronts a container-served SPA plus same-origin backend: enumerate owned paths explicitly, then fall back the rest to the SPA entrypoint via `rewrite * /` (not `file_server`, since assets are in the container).
+- Use this pattern whenever a reverse proxy fronts a container-served SPA plus same-origin backend: route file-with-extension paths to the app at their real path, then fall back extensionless client routes to the SPA entrypoint via `rewrite * /` (not `file_server`, since assets are in the container). Prefer this over a hand-maintained asset allowlist — an allowlist silently drifts as the app adds root-level assets ([#953](https://github.com/marcusrbrown/infra/pull/953)).
 - Prefer named matchers for multi-path groups in Caddy — inline multi-path `handle` is rejected.
 - Always `caddy adapt`-validate edge config against the pinned image to catch directive-ordering and syntax mistakes before deploy.
 - A Caddyfile structure test (in `apps/dashboard/src/deploy.test.ts`) pins owned-paths-before-fallback ordering and the `rewrite * /`-before-`reverse_proxy` shape so the routing contract can't silently regress.
@@ -90,6 +99,8 @@ docker run --rm -i caddy:2.11.3-alpine caddy adapt --adapter caddyfile - < apps/
 ## Related Issues
 
 - infra#669 (closed via PR #676) — the issue this resolves.
+- [#953](https://github.com/marcusrbrown/infra/pull/953) — replaced this doc's `@owned` allowlist with extension-based routing after the allowlist drifted and served operator assets as `text/html`.
+- [dashboard-caddy-bind-mount-stale-reload-2026-07-26.md](./dashboard-caddy-bind-mount-stale-reload-2026-07-26.md) — the follow-on trap: the [#953](https://github.com/marcusrbrown/infra/pull/953) Caddyfile change did not load until the caddy container was force-recreated on deploy ([#954](https://github.com/marcusrbrown/infra/pull/954)).
 - [gateway-caddy-announce-ingress-self-404-2026-06-04.md](./gateway-caddy-announce-ingress-self-404-2026-06-04.md) — direct Caddy lineage: directive-ordering self-404 trap, same `caddy adapt` + mutually-exclusive `handle` discipline (different failure class).
 - [dashboard-operator-session-container-hairpin-2026-06-21.md](./dashboard-operator-session-container-hairpin-2026-06-21.md) — broader dashboard/operator Caddy routing context (container hairpin, not SPA fallback).
 - `docs/plans/2026-06-18-003-feat-dashboard-operator-private-path-plan.md` — established the dashboard `/operator/*` Caddy route and the `caddy adapt` validation precedent.


### PR DESCRIPTION
## Summary
- New `docs/solutions/integration-issues/` entry documenting the bind-mounted-Caddyfile stale-reload deploy trap: `docker compose up -d` does not recreate a container when only a mounted file's contents change, so a deployed Caddyfile change never loads until the caddy service is force-recreated (fixed in #954). Cross-references the same-class broker `dist/main.js` trap (#740).
- Refreshes the 2026-06-25 SPA Caddy routing doc: its hand-maintained `@owned` asset allowlist drifted and served operator UI assets as `text/html`; #953 replaced it with extension-based routing. Updated the recommended Caddyfile shape, prevention guidance, and cross-links.

## Verification
- Both docs render; all relative cross-links resolve to existing files.
- Docs-only change — no deploy, no changeset.
