### PR TITLE
fix(dashboard): make image-pin audit PR idempotent

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -270,13 +270,14 @@ jobs:
 
           supersede_open_pin_prs() {
             local stable_pr_number="$1"
-            local pr_rows pr_number head_ref
-            if ! pr_rows=$(gh pr list --state open --limit 1000 --json number,headRefName --jq '.[] | select(.headRefName == "dashboard-pin" or (.headRefName | startswith("dashboard-pin-"))) | [.number, .headRefName] | @tsv'); then
+            local pr_rows pr_number head_ref author_login
+            if ! pr_rows=$(gh pr list --state open --limit 1000 --json number,headRefName,isCrossRepository,author --jq '.[] | select(.isCrossRepository == false and (.headRefName == "dashboard-pin" or (.headRefName | startswith("dashboard-pin-")))) | [.number, .headRefName, .author.login] | @tsv'); then
               echo "Audit step: unable to list open dashboard pin PRs." >&2
               return 1
             fi
-            while IFS=$'\t' read -r pr_number head_ref; do
+            while IFS=$'\t' read -r pr_number head_ref author_login; do
               [[ -n "${pr_number}" ]] || continue
+              [[ "${author_login}" == "${GIT_USER_NAME}" ]] || continue
               if [[ -n "${stable_pr_number}" && "${pr_number}" == "${stable_pr_number}" ]]; then
                 continue
               fi

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -197,9 +197,9 @@ jobs:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           INPUT_VERSION: ${{ inputs.version }}
           GIT_USER_NAME: ${{ format('{0}[bot]', steps.get-app-token.outputs.app-slug) }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           version="${INPUT_VERSION}"
+          compose_file="apps/dashboard/docker-compose.yaml"
 
           # Revalidate CalVer before constructing branch/commit strings.
           # Prevents unsanitized ref names from reaching git/gh argv.
@@ -208,33 +208,122 @@ jobs:
             exit 1
           fi
 
-          # Unique branch per run to avoid collision on re-runs of the same version.
-          branch="dashboard-pin-${version}-${GITHUB_RUN_ID}"
+          # Capture the exact pin produced by Deploy before resetting the worktree.
+          if ! pinned_image_line="$(awk '
+            /^[[:space:]]*image:[[:space:]]+ghcr[.]io\/fro-bot\/dashboard:[^[:space:]]+@sha256:[0-9a-fA-F]+[[:space:]]*$/ {
+              print
+              found=1
+              exit
+            }
+            END {
+              if (!found) exit 1
+            }
+          ' "${compose_file}")"; then
+            echo "Audit step: dashboard image pin line not found in the deployed compose."
+            exit 1
+          fi
+
+          branch="dashboard-pin"
           commit_msg="chore(dashboard): pin image to ${version}"
+          commit_body="Pins the dashboard image to \`${version}\` after a successful deploy. Merge to record the audit trail in main."
 
           USER_ID=$(gh api "/users/${GIT_USER_NAME}" --jq .id)
           git config user.name "${GIT_USER_NAME}"
           git config user.email "${USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
 
-          git checkout -b "${branch}"
-          git add apps/dashboard/docker-compose.yaml
+          git fetch origin main
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}"
+          else
+            # Remove any stale local tracking ref so a first push can lease-create the branch.
+            git update-ref -d "refs/remotes/origin/${branch}"
+          fi
+          git checkout -B "${branch}" origin/main
+
+          origin_compose="$(mktemp)"
+          if ! git show "origin/main:apps/dashboard/docker-compose.yaml" > "${origin_compose}"; then
+            rm -f "${origin_compose}"
+            echo "Audit step: dashboard compose not found on origin/main."
+            exit 1
+          fi
+
+          rewritten_compose="$(mktemp)"
+          if ! awk -v replacement="${pinned_image_line}" '
+            /^[[:space:]]*image:[[:space:]]+ghcr[.]io\/fro-bot\/dashboard:/ {
+              print replacement
+              count++
+              next
+            }
+            { print }
+            END {
+              if (count != 1) {
+                printf "Audit step: expected exactly one dashboard image line on origin/main, found %d.\n", count > "/dev/stderr"
+                exit 1
+              }
+            }
+          ' "${origin_compose}" > "${rewritten_compose}"; then
+            rm -f "${origin_compose}" "${rewritten_compose}"
+            exit 1
+          fi
+          mv "${rewritten_compose}" "${compose_file}"
+          rm -f "${origin_compose}"
+
+          supersede_open_pin_prs() {
+            local stable_pr_number="$1"
+            local pr_rows pr_number head_ref
+            if ! pr_rows=$(gh pr list --state open --limit 1000 --json number,headRefName --jq '.[] | select(.headRefName == "dashboard-pin" or (.headRefName | startswith("dashboard-pin-"))) | [.number, .headRefName] | @tsv'); then
+              echo "Audit step: unable to list open dashboard pin PRs." >&2
+              return 1
+            fi
+            while IFS=$'\t' read -r pr_number head_ref; do
+              [[ -n "${pr_number}" ]] || continue
+              if [[ -n "${stable_pr_number}" && "${pr_number}" == "${stable_pr_number}" ]]; then
+                continue
+              fi
+              echo "Closing superseded dashboard pin PR #${pr_number} (${head_ref})"
+              gh pr close "${pr_number}" --comment "Superseded by the current dashboard pin PR."
+            done <<< "${pr_rows}"
+          }
+
+          git add "${compose_file}"
 
           if git diff --cached --quiet; then
             echo "No changes to commit — compose pin already up to date."
+            supersede_open_pin_prs ""
             exit 0
           fi
 
           git commit -m "${commit_msg}"
           git push origin "${branch}" --force-with-lease
 
-          # Open PR if none exists for this branch (open PRs only — closed stale PRs are not reused).
-          existing_pr=$(gh pr list --state open --head "${branch}" --json url --jq '.[0].url' 2>/dev/null)
-          if [[ -n "${existing_pr}" ]]; then
-            echo "Audit PR already exists: ${existing_pr}"
+          # Create or update the stable-branch PR before closing superseded pin PRs.
+          if ! existing=$(gh pr list --state open --head "${branch}" --base main --json number --jq '.[0].number // empty'); then
+            echo "Audit step: unable to look up the stable dashboard pin PR." >&2
+            exit 1
+          fi
+
+          stable_pr_number=""
+          if [[ -n "${existing}" ]]; then
+            echo "Updating audit PR #${existing}."
+            gh pr edit "${existing}" \
+              --title "${commit_msg}" \
+              --body "${commit_body}"
+            stable_pr_number="${existing}"
           else
             gh pr create \
               --title "${commit_msg}" \
-              --body "Pins the dashboard image to \`${version}\` after a successful deploy. Merge to record the audit trail in main." \
+              --body "${commit_body}" \
               --head "${branch}" \
               --base main
+            if ! stable_pr_number=$(gh pr list --state open --head "${branch}" --base main --json number --jq '.[0].number // empty'); then
+              echo "Audit step: unable to confirm the stable dashboard pin PR after creation." >&2
+              exit 1
+            fi
           fi
+
+          if [[ -z "${stable_pr_number}" ]]; then
+            echo "Audit step: stable dashboard pin PR number was not confirmed." >&2
+            exit 1
+          fi
+
+          supersede_open_pin_prs "${stable_pr_number}"

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1646,6 +1646,10 @@ describe('deploy-dashboard.yaml: audit step hardening', () => {
     expect(jqQuery).toBeDefined()
     expect(jqQuery).toContain('headRefName')
     expect(jqQuery).toContain('startswith("dashboard-pin-")')
+    expect(jqQuery).toContain('isCrossRepository == false')
+    expect(jqQuery).toContain('.author.login')
+    expect(supersedeBlock).toContain('author_login')
+    expect(supersedeBlock).toMatch(/\[\[\s*"\$\{author_login\}"\s*==\s*"\$\{GIT_USER_NAME\}"\s*\]\]\s*\|\|\s*continue/)
     expect(jqQuery).not.toContain('title')
   })
 

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -1582,30 +1582,33 @@ describe('deploy-dashboard.yaml: pre-gate digest validation step', () => {
 //
 // The audit PR step must:
 // - revalidate version with CalVer before constructing branch/commit strings
-// - use a unique branch per run: dashboard-pin-${version}-${GITHUB_RUN_ID}
-// - use `gh pr list --state open --head "${branch}"` (not just --head)
-// - NOT use `|| true` around push/pr create (audit failures must fail the step)
+// - use the stable `dashboard-pin` branch based on the latest origin/main
+// - reapply only the dashboard image pin with awk after resetting to origin/main
+// - supersede other open pin PRs before leaving at most one current PR
+// - NOT use `|| true` around push/PR operations (audit failures must fail the step)
 
 describe('deploy-dashboard.yaml: audit step hardening', () => {
   const DEPLOY_DASHBOARD_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/deploy-dashboard.yaml')
 
-  it('audit PR step branch name includes github.run_id for uniqueness', async () => {
+  it('audit PR step uses stable dashboard-pin branch based on latest origin/main', async () => {
     const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
-    // The branch must include run_id to avoid collision on re-runs
-    expect(text).toMatch(/run_id|GITHUB_RUN_ID/)
-    // And it must be in the context of the audit PR step (after "Open audit PR")
     const auditStepIdx = text.indexOf('Open audit PR')
     expect(auditStepIdx).toBeGreaterThan(-1)
     const afterAudit = text.slice(auditStepIdx)
-    expect(afterAudit).toMatch(/run_id|GITHUB_RUN_ID/)
+    expect(afterAudit).toMatch(/branch=["']dashboard-pin["']/)
+    expect(afterAudit).not.toMatch(/run_id|GITHUB_RUN_ID/)
+    expect(afterAudit).toContain('git fetch origin main')
+    expect(afterAudit).toMatch(/git checkout -B .*origin\/main/)
   })
 
-  it('audit PR step uses --state open in gh pr list', async () => {
+  it('audit PR step reapplies only the dashboard image pin with awk', async () => {
     const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
     const auditStepIdx = text.indexOf('Open audit PR')
     expect(auditStepIdx).toBeGreaterThan(-1)
     const afterAudit = text.slice(auditStepIdx)
-    expect(afterAudit).toContain('--state open')
+    expect(afterAudit).toMatch(/awk\s+-v\s+\w+=/)
+    expect(afterAudit).toContain('apps/dashboard/docker-compose.yaml')
+    expect(afterAudit).toContain('origin/main:apps/dashboard/docker-compose.yaml')
   })
 
   it('audit PR step revalidates version with CalVer regex before branch construction', async () => {
@@ -1613,20 +1616,104 @@ describe('deploy-dashboard.yaml: audit step hardening', () => {
     const auditStepIdx = text.indexOf('Open audit PR')
     expect(auditStepIdx).toBeGreaterThan(-1)
     const afterAudit = text.slice(auditStepIdx)
-    // Must contain a CalVer regex check (YYYY.MM.N pattern) — look for the bash =~ pattern
-    // The audit step must revalidate version before constructing branch/commit strings.
-    // We check for the presence of a numeric range pattern used in bash =~ checks.
-    expect(afterAudit).toContain('[0-9]')
+    const calVerPattern = String.raw`^[0-9]{4}\.[0-9]{2}\.[0-9]+$`
+    const calVerIdx = afterAudit.indexOf(calVerPattern)
+    const branchIdx = afterAudit.indexOf('branch=')
+    expect(calVerIdx).toBeGreaterThan(-1)
+    expect(branchIdx).toBeGreaterThan(calVerIdx)
   })
 
-  it('audit PR step does NOT use || true around push or pr create', async () => {
+  it('audit PR step lists open pin PRs and closes superseded ones', async () => {
     const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
     const auditStepIdx = text.indexOf('Open audit PR')
     expect(auditStepIdx).toBeGreaterThan(-1)
     const afterAudit = text.slice(auditStepIdx)
-    // || true around push or pr create silences audit failures — must not be present
+    expect(afterAudit).toContain('gh pr list --state open')
+    expect(afterAudit).toContain('gh pr close')
+  })
+
+  it('audit PR supersede selector is limited to bot-owned dashboard pin branches', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    const supersedeStart = afterAudit.indexOf('supersede_open_pin_prs()')
+    const supersedeEnd = afterAudit.indexOf('\n          git add ', supersedeStart)
+    expect(supersedeStart).toBeGreaterThan(-1)
+    expect(supersedeEnd).toBeGreaterThan(supersedeStart)
+    const supersedeBlock = afterAudit.slice(supersedeStart, supersedeEnd)
+    const jqQuery = supersedeBlock.match(/--jq\s+'([^']+)'/)?.[1]
+    expect(jqQuery).toBeDefined()
+    expect(jqQuery).toContain('headRefName')
+    expect(jqQuery).toContain('startswith("dashboard-pin-")')
+    expect(jqQuery).not.toContain('title')
+  })
+
+  it('audit PR step pushes with force-with-lease and updates existing PRs in place', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    const branchRef = '$' + '{branch}'
+    const existingRef = '$' + '{existing}'
+    expect(afterAudit).toContain(`git push origin "${branchRef}" --force-with-lease`)
+    expect(afterAudit).toContain(`gh pr edit "${existingRef}"`)
+  })
+
+  it('audit PR step creates or updates before superseding with a confirmed stable PR number', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    const branchRef = '$' + '{branch}'
+    const existingRef = '$' + '{existing}'
+    const stablePrRef = '$' + '{stable_pr_number}'
+    const createIdx = afterAudit.indexOf('gh pr create')
+    const editIdx = afterAudit.indexOf('gh pr edit')
+    const stableSupersedeIdx = afterAudit.indexOf(`supersede_open_pin_prs "${stablePrRef}"`)
+    expect(createIdx).toBeGreaterThan(-1)
+    expect(editIdx).toBeGreaterThan(-1)
+    expect(stableSupersedeIdx).toBeGreaterThan(Math.max(createIdx, editIdx))
+    expect(afterAudit).toContain(`stable_pr_number="${existingRef}"`)
+    expect(afterAudit).toContain(
+      `stable_pr_number=$(gh pr list --state open --head "${branchRef}" --base main --json number --jq`,
+    )
+    expect(afterAudit).toContain('supersede_open_pin_prs ""')
+  })
+
+  it('audit PR reapply awk replaces exactly one dashboard image line', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    const reapplyStart = afterAudit.indexOf('if ! awk -v replacement=')
+    const rewrittenComposeRef = '$' + '{rewritten_compose}'
+    const reapplyEnd = afterAudit.indexOf(`mv "${rewrittenComposeRef}"`, reapplyStart)
+    expect(reapplyStart).toBeGreaterThan(-1)
+    expect(reapplyEnd).toBeGreaterThan(reapplyStart)
+    const reapplyBlock = afterAudit.slice(reapplyStart, reapplyEnd)
+    expect(reapplyBlock).toMatch(/count\s*!=\s*1/)
+    expect(reapplyBlock).toContain('expected exactly one dashboard image line')
+  })
+
+  it('audit PR step does NOT use || true around push or PR operations', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    // || true around push or PR operations silences audit failures — must not be present
     expect(afterAudit).not.toMatch(/git push[^#\n]*\|\|\s*true/)
     expect(afterAudit).not.toMatch(/gh pr create[^#\n]*\|\|\s*true/)
+    expect(afterAudit).not.toMatch(/gh pr edit[^#\n]*\|\|\s*true/)
+    expect(afterAudit).not.toMatch(/gh pr close[^#\n]*\|\|\s*true/)
+  })
+
+  it('audit PR step preserves the deploy.yaml-compatible commit message prefix', async () => {
+    const text = await Bun.file(DEPLOY_DASHBOARD_WORKFLOW).text()
+    const auditStepIdx = text.indexOf('Open audit PR')
+    expect(auditStepIdx).toBeGreaterThan(-1)
+    const afterAudit = text.slice(auditStepIdx)
+    expect(afterAudit).toContain('chore(dashboard): pin image to ')
   })
 })
 


### PR DESCRIPTION
The dashboard deploy's audit PR step opened a fresh `dashboard-pin-<version>-<run_id>` branch off the dispatched ref on every run and never closed prior pin PRs, so stale pin PRs accumulated and the PR base could lag `main`.

This makes the audit PR idempotent:
- Uses a stable `dashboard-pin` branch reset onto the latest `origin/main`, reapplying only the pinned image line — so the PR is always a clean one-line diff against `main`, independent of the deploy ref.
- Creates or updates the stable PR first, then closes superseded pin PRs by bot-owned branch family (`dashboard-pin` / `dashboard-pin-*`) only — never by title — so exactly one open pin PR survives and unrelated PRs are never touched.
- Fails closed on PR listing and requires exactly one dashboard image line on rewrite.
- Preserves the `chore(dashboard): pin image to ` commit prefix so the pin merge still never triggers a deploy loop.

Contract locked by assertions in `packages/cli/src/conventions.test.ts`.