### PR TITLE
docs(umami): record retention activation evidence

### DIFF
--- a/apps/umami/AGENTS.md
+++ b/apps/umami/AGENTS.md
@@ -34,7 +34,7 @@ Images are pinned to numbered tags by digest and tracked by Renovate (changelog-
     - validates shell syntax, ownership/modes, and both units with `systemd-analyze verify`;
     - atomically promotes the runtime to `/opt/umami/retention/releases/<hash>` and updates the `/opt/umami/retention/current` symlink;
     - atomically installs `/etc/systemd/system/umami-retention.service` and `/etc/systemd/system/umami-retention.timer`, then runs `systemctl daemon-reload`. The hash covers all five runtime/unit files. A staged validation failure restores the prior `current` target. Deploy never runs `retention.sh --check` or `retention.sh --apply`.
-14. Refreshes only an existing active/enabled timer: an active timer is restarted; an enabled but inactive timer is started; a disabled/inactive timer is left disabled/inactive. First install therefore remains unarmed.
+14. Refreshes only an existing active/enabled timer: an active timer is restarted; an enabled but inactive timer is started; a disabled/inactive timer is left disabled/inactive. First install therefore remains unarmed. Because no prior timer stamp exists, `Persistent=true` does not guarantee a catch-up on first-ever enable; the next scheduled run may be the first timer edge.
 15. **Bounded public-HTTPS probe** — retries `https://$UMAMI_DOMAIN/api/heartbeat` for `{"ok":true}`. On first-deploy Caddy ACME issuance lag it emits a WARNING and still succeeds (containers are already healthy); `compose up` is idempotent, so re-running once the cert lands is safe.
 
 In CI the SSH key is materialized from `UMAMI_SSH_KEY` to a temp file with a trailing newline (GitHub strips trailing whitespace from secrets) and `chmod 600`; locally it uses the ssh-agent.
@@ -457,7 +457,7 @@ The public surfaces are `https://fro.bot/systematic` and `https://mrbro.dev/dev-
 
 ### 6. Explicitly enable and inspect the timer
 
-Only after the supervised apply and post-check are successful, type the approval phrase and enable the timer. Because the timer has `Persistent=true`, `systemctl enable --now` may immediately trigger a catch-up retention service run when the daily window was missed. That is safe only because the supervised apply and post-check already passed and `--apply` is idempotent and advisory-locked. Stay present for the complete possible catch-up run.
+Only after the supervised apply and post-check are successful, type the approval phrase and enable the timer. Because the timer has `Persistent=true`, `systemctl enable --now` may immediately trigger a catch-up retention service run when an already-enabled timer has a recorded missed activation. `Persistent=true` does not guarantee a catch-up on first-ever enable because no prior timer stamp exists; the next scheduled run may be the first timer edge. That is safe only because the supervised apply and post-check already passed and `--apply` is idempotent and advisory-locked. Stay present for the complete possible catch-up run.
 
 ```bash
 read -r -p 'Supervised apply and post-check passed; type ENABLE UMAMI RETENTION to continue: ' APPROVAL
@@ -467,17 +467,20 @@ if [[ "$APPROVAL" != 'ENABLE UMAMI RETENTION' ]]; then
 fi
 ```
 
-Capture the enable timestamp, wait only when the service is active, then capture the settled service result, exit status, execution timestamps, timer state, and journal as a local artifact:
+Capture the ISO enable timestamp for evidence and a separate journalctl-parseable UTC timestamp, wait while the oneshot is active or activating, then capture the settled service result, exit status, execution timestamps, timer state, and journal as a local artifact:
 
 ```bash
 TIMER_ARTIFACT="umami-retention-timer-$(date -u +%Y%m%dT%H%M%SZ).log"
 if ssh "$REMOTE" 'set -Eeuo pipefail
   enable_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  journal_since_timestamp="$(date -u '\''+%Y-%m-%d %H:%M:%S UTC'\'')"
   systemctl enable --now umami-retention.timer
   printf "enable_timestamp_utc=%s\n" "$enable_timestamp"
-  if [[ "$(systemctl is-active umami-retention.service || true)" == active ]]; then
+  printf "journal_since_timestamp_utc=%s\n" "$journal_since_timestamp"
+  service_state="$(systemctl is-active umami-retention.service || true)"
+  if [[ "$service_state" == active || "$service_state" == activating ]]; then
     if ! timeout 1860s bash -c '\''
-      while [[ "$(systemctl is-active umami-retention.service || true)" == active ]]; do
+      while service_state="$(systemctl is-active umami-retention.service || true)"; [[ "$service_state" == active || "$service_state" == activating ]]; do
         sleep 5
       done
     '\''; then
@@ -495,7 +498,7 @@ if ssh "$REMOTE" 'set -Eeuo pipefail
   printf "timer_active=%s\n" "$(systemctl is-active umami-retention.timer)"
   systemctl list-timers --all --no-pager umami-retention.timer
   systemctl status umami-retention.timer --no-pager
-  journalctl -u umami-retention.timer -u umami-retention.service --since "$enable_timestamp" --no-pager
+  journalctl -u umami-retention.timer -u umami-retention.service --since "$journal_since_timestamp" --no-pager
 ' | tee "$TIMER_ARTIFACT"; then
   :
 else
@@ -507,7 +510,7 @@ fi
 shasum -a 256 "$TIMER_ARTIFACT"
 ```
 
-The timer is `Persistent=true`, scheduled at `00:30:00 UTC` with up to `30m` randomized delay and `AccuracySec=1min`. The service is a root oneshot with `TimeoutStartSec=30min` and runs `/opt/umami/retention/current/retention.sh --apply --compose-file /opt/umami/docker-compose.yaml`. If no catch-up occurs after enable, do not infer that the timer fired from enabled/active state or a future `list-timers` entry; the retention record remains pending/NO-GO until the next actual `00:30–01:00 UTC` timer run succeeds. GO requires one successful timer-driven or catch-up service execution after enable, evidenced by the post-enable execution timestamp, `Result=success`, `ExecMainStatus=0`, and the corresponding journal artifact.
+The timer is `Persistent=true`, scheduled at `00:30:00 UTC` with up to `30m` randomized delay and `AccuracySec=1min`. The service is a root oneshot with `TimeoutStartSec=30min` and runs `/opt/umami/retention/current/retention.sh --apply --compose-file /opt/umami/docker-compose.yaml`. If no catch-up occurs after enable, do not infer that the timer fired from enabled/active state or a future `list-timers` entry; record the timer edge as unobserved. GO is allowed through either one successful timer-driven or catch-up service execution after enable, evidenced by the post-enable execution timestamp, `Result=success`, `ExecMainStatus=0`, and the corresponding journal artifact, or an explicit operator override. The override must name the exact gate overridden as `observed timer edge before activation`, state the accepted residual risk, record `systemd-analyze verify` success plus service `Result=success`/`ExecMainStatus=0`, timer enabled/active state, its bound service, and its next scheduled run, and require mandatory post-activation confirmation of the first scheduled timer run. That first scheduled or catch-up edge remains explicitly unobserved until its evidence is captured.
 
 ### 7. Disable or emergency-rollback
 

--- a/apps/umami/evidence/retention/2026-07-31T2012Z-mrb-go.md
+++ b/apps/umami/evidence/retention/2026-07-31T2012Z-mrb-go.md
@@ -1,0 +1,144 @@
+# Umami retention attestation — `2026-07-31T2012Z`
+
+## Attestation
+
+- Date/time (UTC): `2026-07-31T20:12:26Z`
+- Operator: `mrb`
+- Status: `GO (operator override)` — authorized by `mrb` on 2026-07-31 UTC after the service and timer were verified operational; the calendar/catch-up timer edge remains explicitly unobserved.
+- Scope: `first supervised apply` — first supervised apply, post-enable service verification, and timer-state capture.
+
+## Version and release identity
+
+- Infra commit: `aa01b49338a099ad5f3773160eae58d50a940cca`
+- Retention release hash: `9b3bbd52b367287b634b3a486b99da9165d012da6a9fdede447f4fe4e20f647d` — matches `deployed-release.log` and the local content-address calculation.
+- `/opt/umami/retention/current` readlink: `/opt/umami/retention/releases/9b3bbd52b367287b634b3a486b99da9165d012da6a9fdede447f4fe4e20f647d`
+- Umami image/version: `umamisoftware/umami:3.2.0@sha256:d8111e1d6d94be54a54514cd4e1264fbfe905e5ea0d0691804b1d71e627a6fca` — confirmed by the installed-state and post-enable health artifacts.
+- Postgres image/version: `postgres:15-alpine@sha256:cd17e2ac98240fce1541ad2a803b34009b4eea5aec8a832363cdc7eca62e722e` — confirmed by the installed-state and post-enable health artifacts.
+- `/etc/systemd/system/umami-retention.service` SHA-256: `8099354ac3ba8c14b782f7ebaa56391bc0481282d1145dd2a5f6399bdb2668d1`
+- `/etc/systemd/system/umami-retention.timer` SHA-256: `0955f05a1e4b65611103bd247afb6ff5156a9f70219ce367ecf45353dadb1ac6`
+- `mrbro.dev` requirements/plan revision: `docs/plans/2026-07-30-001-feat-privacy-preserving-umami-metrics-plan.md` at `6eaac703d3b14f7630f0c23050b3a41a7c1ca4eb`; originating requirements: `docs/brainstorms/2026-07-30-mrbro-dev-umami-metrics-requirements.md`.
+
+## Approved recovery point
+
+- Backup filename: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/umami.dump`
+- Backup size (bytes): `119055`
+- Backup SHA-256: `efbc1f148fafa0299124896d8b2b9d4c89265dd39e70df34d2c840cf652f231b`
+- Archive format: `PostgreSQL custom (-Fc)` — confirmed by `umami.dump.list` (`Format: CUSTOM`, dumped by PostgreSQL 15.18).
+- Archive-list validation in pinned disposable container: `PASS` — `pg_restore --list` output captured at `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/umami.dump.list`; no local `pg_restore` was used.
+- Source capture state: `caddy+umami stopped, db up; brief analytics downtime acknowledged` — PASS; the stack was restarted and health-checked before restore verification continued.
+- Source manifest path: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/source.manifest`
+- Source manifest SHA-256: `ddaefeea4b8e1e7337888e1a9fd0c378d8332aa4c88eb7d8fb3b90c9f34f93ce`
+- Disposable restore image: `postgres:15-alpine@sha256:cd17e2ac98240fce1541ad2a803b34009b4eea5aec8a832363cdc7eca62e722e` — confirmed.
+- Disposable restore isolation: `--network none; tmpfs /var/lib/postgresql/data; no published ports; trust auth only inside disposable container` — PASS.
+- Restored DB manifest query: `PASS` — completed in the pinned disposable container.
+- Restored manifest path: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/restored.manifest`
+- Restored manifest SHA-256: `ddaefeea4b8e1e7337888e1a9fd0c378d8332aa4c88eb7d8fb3b90c9f34f93ce`
+- Exact source/restored manifest `diff`: `PASS` — `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/manifest.diff` is empty; public-table counts match exactly.
+- Disposable restore container removal: `PASS` — no cleanup failure was reported by the completed recovery drill.
+- Production restart and `/api/heartbeat`: `PASS` — `heartbeat_http=200`; PostgreSQL reported accepting connections; containers were healthy.
+- Backup timestamp (UTC): `2026-07-31T19:49:35Z` — archive header timestamp.
+- Daily automated backup present: `NO` — this was the approved manual recovery point; the runbook does not provide a daily automated backup.
+
+## Pre-check (`--check`)
+
+- Command: `bash /opt/umami/retention/current/retention.sh --check --compose-file /opt/umami/docker-compose.yaml`
+- Output artifact path: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/precheck.log`
+- Output artifact SHA-256: `c2bedb09da2f14e2b8d53a6813900fb0e093a545d6ea9fdf59385ac662b6868e`
+- Null `created_at` status: `0` — all eight retention tables reported `null_created_at=0`.
+- Orphan baseline status: `STABLE` — all orphan tables reported `before=0`, `after=0`, and `delta=0`.
+
+| Table                  | Before | Protected | Eligible/remaining |
+| ---------------------- | -----: | --------: | -----------------: |
+| `event_data`           |    `0` |       `0` |                `0` |
+| `website_event`        |    `0` |       `0` |                `0` |
+| `session_data`         |    `0` |       `0` |                `0` |
+| `revenue`              |    `0` |       `0` |                `0` |
+| `session_replay`       |    `0` |       `0` |                `0` |
+| `session_replay_saved` |    `0` |       `0` |                `0` |
+| `heatmap_event`        |    `0` |       `0` |                `0` |
+| `session`              |    `0` |       `0` |                `0` |
+
+## Supervised apply (`--apply`)
+
+- Approval gate/operator: `APPLY UMAMI RETENTION` — `mrb`; supervised single-run gate.
+- Command: `bash /opt/umami/retention/current/retention.sh --apply --compose-file /opt/umami/docker-compose.yaml`
+- Output artifact path: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/apply-20260731T195339Z.log`
+- Output artifact SHA-256: `002bbe7e71095c08143eee4883a3d9e225f1b08d8f52116c08d3a269af2d8ec7`
+- Apply status: `PASS` — all tables reported zero deleted, zero protected, and zero remaining rows; the command completed successfully.
+- Transaction/rollback result: `PASS` — the supervised transaction completed without rollback, timeout, lock contention, or SQL error.
+
+| Table                  | Before | Deleted | Protected | Remaining |
+| ---------------------- | -----: | ------: | --------: | --------: |
+| `event_data`           |    `0` |     `0` |       `0` |       `0` |
+| `website_event`        |    `0` |     `0` |       `0` |       `0` |
+| `session_data`         |    `0` |     `0` |       `0` |       `0` |
+| `revenue`              |    `0` |     `0` |       `0` |       `0` |
+| `session_replay`       |    `0` |     `0` |       `0` |       `0` |
+| `session_replay_saved` |    `0` |     `0` |       `0` |       `0` |
+| `heatmap_event`        |    `0` |     `0` |       `0` |       `0` |
+| `session`              |    `0` |     `0` |       `0` |       `0` |
+
+| Orphan table     | Before | After | Delta |
+| ---------------- | -----: | ----: | ----: |
+| `event_data`     |    `0` |   `0` |   `0` |
+| `website_event`  |    `0` |   `0` |   `0` |
+| `session_data`   |    `0` |   `0` |   `0` |
+| `revenue`        |    `0` |   `0` |   `0` |
+| `session_replay` |    `0` |   `0` |   `0` |
+| `heatmap_event`  |    `0` |   `0` |   `0` |
+
+## Post-check and health evidence
+
+- Post-check command: `bash /opt/umami/retention/current/retention.sh --check --compose-file /opt/umami/docker-compose.yaml`
+- Post-check output artifact path: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/service-postcheck-20260731T201225Z.log`
+- Post-check output artifact SHA-256: `72c8d92a4c277a0ba66323e4cf1a9b36d6989bcb795d9547435358cea4c5f3e9`
+- Post-enable service health artifact: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/service-health-20260731T201225Z.log` — SHA-256 `16e67ba612746da4448b4d88ac1a64c01f955fe8f912144158da2f9265012e9c`.
+- Post-check eligible/remaining rows: `0` — every retention table reported `remaining=0`.
+- Post-check null `created_at`: `0` — every retention table reported `null_created_at=0`.
+- Post-check orphan deltas: `non-positive` — every orphan delta was `0`.
+- Umami heartbeat (`/api/heartbeat`): `PASS` — `heartbeat_http=200`.
+- DB health (`pg_isready`) and container health: `PASS` — PostgreSQL accepted connections and the Umami/Postgres containers were healthy.
+- `https://fro.bot/systematic` health: `NOT RECORDED` — no separate public-surface status artifact is present in the retained recovery directory.
+- `https://mrbro.dev/dev-like` health: `PASS` — already-active dev-like fresh-ingestion proof returned collector HTTP 200.
+- Fresh-record UTC window: `NOT RECORDED` — the retained recovery directory contains the counts/status proof but not the dashboard query-window boundaries.
+- Fresh-record before count/category: `0 / install-primary`
+- Controlled matching interaction: `exactly one` — `install-primary` controlled interaction.
+- Fresh-record after count/category: `1 / install-primary` — trusted DB and dashboard count after ingestion.
+- Fresh-record delta: `+1` — baseline `0`, trusted DB/dashboard after count `1`, collector HTTP 200.
+
+## Timer evidence
+
+- Systemd unit verification: `PASS` — `systemd-analyze verify /etc/systemd/system/umami-retention.service /etc/systemd/system/umami-retention.timer` completed successfully.
+- Timer enabled: `yes` — `systemctl is-enabled` reported `enabled`.
+- Timer active: `yes` — `systemctl is-active` reported `active`.
+- Timer bound service: `umami-retention.service` — the installed timer unit binds to the retention service.
+- Enable timestamp (UTC): `2026-07-31T20:07:33Z`
+- Catch-up/scheduled service execution timestamp (UTC): `NOT OBSERVED` — the enable artifact reported `ExecMainStartTimestamp=n/a`; no calendar-triggered run occurred in the captured interval.
+- Service `Result`: `success` — manual post-enable execution only.
+- Service `ExecMainStatus`: `0` — manual post-enable execution only.
+- Service execution exit timestamp (UTC): `Fri 2026-07-31 20:10:55 UTC` — manual post-enable execution only; no timer-triggered exit was observed.
+- Timer journal artifact: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/timer-20260731T200733Z.log` — SHA-256 `13473f5708a2270663590cbd9b1c4baf2f9e5df73104a8990d6738131a0287b9`.
+- Successful timer-driven/catch-up service execution after enable: `NO` — the user explicitly directed an immediate manual service execution instead of waiting for the first calendar trigger; that run succeeded but is not timer evidence. Corrected service proof: `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/service-proof-20260731T201225Z.log` — SHA-256 `e8a408cf0b1b8add432339b399e30b3e0c3c37b05ccf7fb2d01e5d617ae11911`.
+- Next run evidence: `Sat 2026-08-01 00:34:29 UTC; timer_enabled=enabled; timer_active=active` — captured after the manual service run.
+- Timer journal evidence: corrected service proof at `/Users/mrbrown/.local/share/umami-retention/recovery/20260731T194933Z/service-proof-20260731T201225Z.log` — it records `manual_service_start_timestamp_utc=2026-07-31T20:10:54Z`, `Result=success`, `ExecMainStatus=0`, and the next scheduled activation; it does not establish a timer-triggered run.
+- Calendar/catch-up timer edge observed: `NO` — this record makes no claim that a calendar-triggered or persistent catch-up timer run occurred.
+- Schedule observed: `00:30–01:00 UTC, Persistent=true` — `OnCalendar=00:30:00 UTC`, `RandomizedDelaySec=30m`, and `AccuracySec=1min`; the next activation remained scheduled for `Sat 2026-08-01 00:34:29 UTC`.
+- First-enable semantics: this was the first-ever enable, so no prior timer stamp existed; `Persistent=true` did not guarantee a catch-up and the next scheduled run may be the first timer edge.
+- Exact gate overridden: `observed timer edge before activation`.
+- Accepted residual risk: the timer edge has not yet been observed, so the first scheduled timer run still requires explicit post-activation confirmation.
+- Mandatory post-activation confirmation of the first scheduled timer run: `REQUIRED` — capture the first scheduled timer service execution timestamp, `Result=success`, `ExecMainStatus=0`, and corresponding journal evidence after activation review.
+
+## Rollback and disable verification
+
+- Disable command/result: `not run` — no rollback or disable operation was requested; production state was not changed by this evidence write.
+- Rollback release hash, if used: `not used`
+- Rollback `current` readlink: `not used`
+- Service/timer unit restore result: `not used`
+- Post-rollback timer state: `not applicable`
+
+## Decision and signoff
+
+- Disposition: `GO (operator override)` — the normal observed timer-edge gate was explicitly overridden by `mrb` after the service and timer operational facts above were verified; the calendar/catch-up edge remains unobserved.
+- Fail-closed reasons observed or ruled out: lock contention `ruled out`; timeout `ruled out`; null timestamps `0`; nonzero eligible remaining `0`; positive orphan delta `ruled out, all deltas 0`; other command/SQL error `none observed`.
+- Operator signoff: `mrb — 2026-07-31T20:12:26Z`
+- Review/signoff reference: `Operator override authorized by mrb on 2026-07-31 UTC. Exact gate overridden: observed timer edge before activation. Accepted residual risk: the first scheduled or catch-up edge remains unobserved. Mandatory post-activation confirmation of the first scheduled timer run is required, including its exact execution timestamps and journal evidence.`

--- a/apps/umami/evidence/retention/README.md
+++ b/apps/umami/evidence/retention/README.md
@@ -1,6 +1,6 @@
 # Umami retention evidence
 
-Retention attestations are version-controlled, dated Markdown records of one supervised rollout or explicit NO-GO. The procedure is defined by [`apps/umami/AGENTS.md`](../../AGENTS.md); copy [`TEMPLATE.md`](TEMPLATE.md) for each new record.
+Retention attestations are version-controlled, dated Markdown records of one supervised rollout, an explicit operator-override GO, or an explicit NO-GO. The procedure is defined by [`apps/umami/AGENTS.md`](../../AGENTS.md); copy [`TEMPLATE.md`](TEMPLATE.md) for each new record.
 
 ## Naming
 

--- a/apps/umami/evidence/retention/TEMPLATE.md
+++ b/apps/umami/evidence/retention/TEMPLATE.md
@@ -6,7 +6,7 @@ Fill every `[fill]` field. Use UTC. Record counts, categories, hashes, and statu
 
 - Date/time (UTC): `[fill]`
 - Operator: `[fill]`
-- Status: `GO` / `NO-GO` — `[fill]`
+- Status: `GO (timer-driven/catch-up)` / `GO (operator override)` / `NO-GO` — `[fill]`
 - Scope: `first supervised apply` / `routine evidence refresh` / `rollback` — `[fill]`
 
 ## Version and release identity
@@ -119,12 +119,17 @@ GO is impossible if any recovery-point field is missing or failing.
 - Service `ExecMainStatus`: `[fill exact value]`
 - Service execution exit timestamp (UTC): `[fill exact ExecMainExitTimestamp or NOT OBSERVED]`
 - Timer journal artifact: `[fill local path and SHA-256]`
-- Successful timer-driven/catch-up service execution after enable: `YES / NO` — `[fill; GO is impossible without YES]`
+- Successful timer-driven/catch-up service execution after enable: `YES / NO` — `[fill; required for the timer-driven/catch-up path; `NO` is allowed only for a documented operator override]`
 - Next run evidence: `[fill exact list-timers/status result]`
 - Timer journal evidence: `[fill artifact/path or concise status]`
 - Schedule observed: `00:30–01:00 UTC, Persistent=true` — `[fill]`
+- First-enable semantics: `Persistent=true` does not guarantee a catch-up on first-ever enable because no prior timer stamp exists; the next scheduled run may be the first timer edge — `[fill]`
+- GO path: `timer-driven/catch-up` / `operator override` — `[fill]`
+- Exact gate overridden: `observed timer edge before activation` / `not applicable` — `[fill]`
+- Accepted residual risk: `[fill; required for operator override]`
+- Mandatory post-activation confirmation of the first scheduled timer run: `[fill required follow-up evidence and owner]`
 
-GO is impossible without a successful timer-driven or catch-up service execution after enable. If no catch-up occurred, leave the record pending/NO-GO until the next actual `00:30–01:00 UTC` timer run succeeds.
+GO is allowed either with a successful timer-driven or catch-up service execution after enable, or through an explicit operator override. For the override path, the timer edge may remain `NOT OBSERVED`, but the record must include accepted residual risk, `systemd-analyze verify` success, service `Result=success` and `ExecMainStatus=0`, timer enabled/active state, the bound service and next scheduled run, plus mandatory post-activation confirmation of the first scheduled timer run. Never claim a calendar or catch-up timer run occurred when it remains unobserved.
 
 ## Rollback and disable verification
 

--- a/apps/umami/systemd.test.ts
+++ b/apps/umami/systemd.test.ts
@@ -4,6 +4,8 @@ import {describe, expect, it} from 'bun:test'
 const appDirectory = new URL('.', import.meta.url).pathname
 const servicePath = `${appDirectory}systemd/umami-retention.service`
 const timerPath = `${appDirectory}systemd/umami-retention.timer`
+const runbookPath = `${appDirectory}AGENTS.md`
+const evidenceTemplatePath = `${appDirectory}evidence/retention/TEMPLATE.md`
 const runnerPath = `${appDirectory}retention.sh`
 const checkSqlPath = `${appDirectory}retention-check.sql`
 const applySqlPath = `${appDirectory}retention.sql`
@@ -76,5 +78,36 @@ describe('Umami retention deployment artifact modes', () => {
         expect(file.mode & 0o777).toBe(mode)
       }),
     )
+  })
+})
+
+describe('Umami retention enable runbook contract', () => {
+  it('separates the journal timestamp and waits through oneshot activation', async () => {
+    const runbook = await artifact(runbookPath)
+
+    expect(runbook).toContain('enable_timestamp_utc=%s')
+    expect(runbook).toContain(String.raw`journal_since_timestamp="$(date -u '\''+%Y-%m-%d %H:%M:%S UTC'\'')"`)
+    expect(runbook).toContain(
+      'journalctl -u umami-retention.timer -u umami-retention.service --since "$journal_since_timestamp"',
+    )
+    expect(runbook).toContain('[[ "$service_state" == active || "$service_state" == activating ]]')
+  })
+})
+
+describe('Umami retention activation evidence contract', () => {
+  it('documents conditional GO paths and first-enable timer semantics', async () => {
+    const [runbook, template] = await Promise.all([artifact(runbookPath), artifact(evidenceTemplatePath)])
+
+    expect(runbook).toContain('`Persistent=true` does not guarantee a catch-up on first-ever enable')
+    expect(runbook).toContain('the next scheduled run may be the first timer edge')
+    expect(runbook).toContain('observed timer edge before activation')
+    expect(runbook).toContain('accepted residual risk')
+    expect(runbook).toContain('mandatory post-activation confirmation of the first scheduled timer run')
+
+    expect(template).toContain('GO (timer-driven/catch-up)')
+    expect(template).toContain('GO (operator override)')
+    expect(template).toContain('observed timer edge before activation')
+    expect(template).toContain('accepted residual risk')
+    expect(template).toContain('mandatory post-activation confirmation of the first scheduled timer run')
   })
 })


### PR DESCRIPTION
## Umami retention activation evidence

- Timer is now `enabled` and `active`.
- Immediate post-enable run was validated: service `Result=success` and `ExecMainStatus=0` for manual operator override execution.
- Post-check and production health were recorded as clean: zero remaining eligible rows, non-positive orphan deltas, and healthy DB/heartbeat checks.
- This go decision is `GO (operator override)` and was authorized by `mrb`.
- The required first scheduled/catch-up timer edge was **not** observed; evidence explicitly treats it as `NOT OBSERVED`.
- This is a documented operator override of gate: `observed timer edge before activation` with accepted residual risk, and does **not** claim a calendar/catch-up timer run.
- Mandatory post-activation monitoring item remains open: capture first scheduled timer run evidence (timestamp, `Result=success`, `ExecMainStatus=0`) after activation before finalizing deployment confidence.
