### PR TITLE
fix(agent): handle first-provision IAM absence safely

### DIFF
--- a/apps/agent/server/provision.test.ts
+++ b/apps/agent/server/provision.test.ts
@@ -226,6 +226,8 @@ function makeTeardownClients(
   options: {
     role?: Record<string, unknown>
     policy?: string
+    deletePolicyError?: Error
+    deleteRoleError?: Error
     stateError?: Error
     lockError?: Error
     versionError?: Error
@@ -253,9 +255,11 @@ function makeTeardownClients(
         return {PolicyDocument: encodeURIComponent(policy)}
       case 'DeleteRolePolicyCommand':
         policy = ''
+        if (options.deletePolicyError) throw options.deletePolicyError
         return {}
       case 'DeleteRoleCommand':
         role = undefined as unknown as Record<string, unknown>
+        if (options.deleteRoleError) throw options.deleteRoleError
         return {}
       default:
         throw new Error(`Unexpected IAM teardown command: ${command.constructor.name}`)
@@ -643,15 +647,20 @@ describe('GitHub OIDC provider provisioning', () => {
 
   it('fails closed when bucket configuration is missing', async () => {
     const providerArn = 'arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com'
-    const {client} = makeClient(async command => {
+    const {client, calls} = makeClient(async command => {
       if (command.constructor.name === 'ListOpenIDConnectProvidersCommand') return listResponse(providerArn)
       if (command.constructor.name === 'GetOpenIDConnectProviderCommand') return providerDetails(providerArn)
       throw new Error(`Unexpected IAM command: ${command.constructor.name}`)
     })
+    const s3 = makeS3Client(async command => {
+      throw new Error(`Unexpected S3 call: ${command.constructor.name}`)
+    })
 
-    await expect(performProvisioning({client, repository: roleRepository})).rejects.toThrow(
-      /agent S3.*configuration|bucket/i,
-    )
+    await expect(
+      performProvisioning({client, env: {}, repository: roleRepository, s3Client: s3.client}),
+    ).rejects.toThrow(/agent S3.*configuration|bucket/i)
+    expect(calls).toEqual([])
+    expect(s3.calls).toEqual([])
   })
 
   it('fails closed on an unknown action layout before applying any AWS policy', async () => {
@@ -758,6 +767,40 @@ describe('GitHub OIDC provider provisioning', () => {
     })
 
     expect(report.join('\n')).toMatch(/plan.*(current|would)/i)
+    expect(iam.calls.some(call => /^(?:Create|Put|Update|Tag|Add|Delete)/.test(call.name))).toBe(false)
+    expect(s3.calls.some(call => /^(?:Create|Put|Update|Delete)/.test(call.name))).toBe(false)
+  })
+
+  it('plans absent IAM role and inline policy reported as NoSuchEntityException', async () => {
+    const iam = makeClient(async command => {
+      switch (command.constructor.name) {
+        case 'ListOpenIDConnectProvidersCommand':
+          return listResponse(roleProviderArn)
+        case 'GetOpenIDConnectProviderCommand':
+          return providerDetails(roleProviderArn)
+        case 'GetRoleCommand':
+          throw namedError('NoSuchEntityException', 'role does not exist')
+        case 'GetRolePolicyCommand':
+          throw namedError('NoSuchEntityException', 'inline policy does not exist')
+        default:
+          throw new Error(`Unexpected IAM plan command: ${command.constructor.name}`)
+      }
+    })
+    const s3 = makeCurrentBucketClient()
+    const report: string[] = []
+
+    await performProvisioning({
+      client: iam.client,
+      s3Client: s3.client,
+      bucket: bucketConfig,
+      repository: roleRepository,
+      actionRef: AGENT_ACTION_LAYOUT_VERSION,
+      plan: true,
+      printLine: line => report.push(line),
+    })
+
+    expect(report.join('\n')).toMatch(/would create IAM role fro-bot-agent-storage-marcusrbrown-infra/i)
+    expect(report.join('\n')).toMatch(/would attach IAM inline policy fro-bot-agent-storage-marcusrbrown-infra/i)
     expect(iam.calls.some(call => /^(?:Create|Put|Update|Tag|Add|Delete)/.test(call.name))).toBe(false)
     expect(s3.calls.some(call => /^(?:Create|Put|Update|Delete)/.test(call.name))).toBe(false)
   })
@@ -1278,6 +1321,22 @@ describe('agent storage teardown', () => {
       s3Client: s3.client,
       manifest: teardownManifest,
       repository: teardownRepository(),
+    })
+
+    await expect(
+      performTeardown({
+        client: iam.client,
+        s3Client: s3.client,
+        manifest: teardownManifest,
+        repository: teardownRepository(),
+      }),
+    ).resolves.toMatchObject({roleDeleted: false, policyDeleted: false})
+  })
+
+  it('treats NoSuchEntityException during inline policy and role deletion as idempotent success', async () => {
+    const {iam, s3} = makeTeardownClients({
+      deletePolicyError: namedError('NoSuchEntityException', 'inline policy already absent'),
+      deleteRoleError: namedError('NoSuchEntityException', 'role already absent'),
     })
 
     await expect(

--- a/apps/agent/server/provision.ts
+++ b/apps/agent/server/provision.ts
@@ -1375,7 +1375,7 @@ async function readAgentRole(
     if (!role) throw new Error(`IAM role ${roleName} readback did not include a role`)
     return role
   } catch (error: unknown) {
-    if (isNamedError(error, ['NoSuchEntity'])) return undefined
+    if (isNamedError(error, ['NoSuchEntity', 'NoSuchEntityException'])) return undefined
     throw redactAwsError(error, secrets)
   }
 }
@@ -1634,7 +1634,7 @@ async function readAgentStoragePolicy(
     }
     return response.PolicyDocument
   } catch (error: unknown) {
-    if (isNamedError(error, ['NoSuchEntity'])) return undefined
+    if (isNamedError(error, ['NoSuchEntity', 'NoSuchEntityException'])) return undefined
     throw redactAwsError(error, secrets)
   }
 }
@@ -2151,7 +2151,7 @@ export async function performTeardown(options: AgentTeardownDeps): Promise<Agent
       await client.send(new DeleteRolePolicyCommand({RoleName: identity.roleName, PolicyName: identity.policyName}))
       policyDeleted = true
     } catch (error: unknown) {
-      if (!isNamedError(error, ['NoSuchEntity'])) throw redactAwsError(error, secrets)
+      if (!isNamedError(error, ['NoSuchEntity', 'NoSuchEntityException'])) throw redactAwsError(error, secrets)
     }
   }
 
@@ -2161,7 +2161,7 @@ export async function performTeardown(options: AgentTeardownDeps): Promise<Agent
       await client.send(new DeleteRoleCommand({RoleName: identity.roleName}))
       roleDeleted = true
     } catch (error: unknown) {
-      if (!isNamedError(error, ['NoSuchEntity'])) throw redactAwsError(error, secrets)
+      if (!isNamedError(error, ['NoSuchEntity', 'NoSuchEntityException'])) throw redactAwsError(error, secrets)
     }
   }
 


### PR DESCRIPTION
## Summary
This patch fixes first-run and teardown behavior in the private `agent storage` provisioner flows, while keeping CLI behavior unchanged for existing users.

## What changed
- `--plan` now handles `NoSuchEntityException` from AWS SDK v3 when expected IAM role/policy objects are missing, and reports that they would be created instead of failing.
- Teardown now treats already-absent IAM role/policy resources as idempotent, so repeated/late cleanup runs no longer error.
- Provisioner tests are now hermetic: missing-config coverage no longer inherits local `AGENT_*` variables and does not attempt real AWS calls.

## Verification
- Plan path: `bunx @marcusrbrown/infra agent plan --repo dummy/placeholder --no-apply` exits 0 and reports only intended would-create actions.
- Agent tests: 50 passed.
- Full tests with env disabled: 2,837 passed.
- Type check: `bunx tsc --noEmit` clean.
- Lint: 0 errors.

No changeset was added because this is an operator-only provisioning reliability improvement; public CLI behavior is unchanged.
