### PR TITLE
fix(dashboard): handle GNU empty lock metadata

### DIFF
--- a/apps/dashboard/src/remote-deploy.test.ts
+++ b/apps/dashboard/src/remote-deploy.test.ts
@@ -165,10 +165,12 @@ const adaptProgramForUnprivilegedHarness = (
   const darwinStat = process.platform === 'darwin'
   const expectedDirectoryType = darwinStat ? 'Directory' : 'directory'
   const expectedRegularFileType = darwinStat ? 'Regular File' : 'regular file'
-  const shellRawStatExpansion = `${String.fromCharCode(36)}{raw_stat/regular empty file/regular file}`
   const hostFileStat = darwinStat
     ? '/usr/bin/stat -f "%u:%g:%Lp:%HT" "$1"'
-    : String.raw`raw_stat="$(command stat -c "%u:%g:%a:%F" "$1")" || exit $?; printf "%s" "${shellRawStatExpansion}"`
+    : String.raw`command stat -c "%u:%g:%a:%F" "$1"`
+  const hostFileNumericStat = darwinStat
+    ? '/usr/bin/stat -f "%u:%g:%Lp" "$1"'
+    : String.raw`command stat -c "%u:%g:%a" "$1"`
   const hostFileSizeStat = darwinStat ? '/usr/bin/stat -f "%z" "$1"' : 'command stat -c "%s" "$1"'
   const dataPath = join(dashboardRoot, 'data')
   const legacyOverridePath = join(dashboardRoot, 'docker-compose.override.yaml')
@@ -276,7 +278,11 @@ const adaptProgramForUnprivilegedHarness = (
     JSON.stringify(`${dashboardRoot}/docker-compose.override.yaml`),
   )
   program = replaceRequired(program, '0:0:700:directory', `${uid}:${gid}:700:${expectedDirectoryType}`)
-  program = replaceRequired(program, '0:0:600:regular file', `${uid}:${gid}:600:${expectedRegularFileType}`)
+  program = replaceRequired(
+    program,
+    'env) expected_stat="0:0:600:regular file"',
+    `env) expected_stat="${uid}:${gid}:600:${expectedRegularFileType}"`,
+  )
   program = replaceRequired(program, '0:0:644:regular file', `${uid}:${gid}:644:${expectedRegularFileType}`)
   program = replaceRequired(program, '1000:1000:600:regular file', `${uid}:${gid}:600:${expectedRegularFileType}`)
   program = replaceRequired(program, 'readonly ROOT_OWNER="0:0"', `readonly ROOT_OWNER="${uid}:${gid}"`)
@@ -321,6 +327,7 @@ stat() {
     shift 2
     [ "$1" = "--" ] && shift
     case "$format" in
+      "%u:%g:%a") ${hostFileNumericStat} ;;
       "%u:%g:%a:%F") ${hostFileStat} ;;
       "%s") ${hostFileSizeStat} ;;
       *) return 1 ;;

--- a/apps/dashboard/src/remote-deploy.ts
+++ b/apps/dashboard/src/remote-deploy.ts
@@ -65,8 +65,8 @@ const remotePreLockLines = [
   'if [ -L "$LOCK_PATH" ] || { [ -e "$LOCK_PATH" ] && [ ! -f "$LOCK_PATH" ]; }; then fail "unsafe-path" "lock path is not a regular file"; fi',
   'if [ ! -e "$LOCK_PATH" ]; then install -m 0600 -o 0 -g 0 /dev/null "$LOCK_PATH" >/dev/null 2>&1 || fail "unsafe-path" "lock path creation failed"; fi',
   '[ -f "$LOCK_PATH" ] && [ ! -L "$LOCK_PATH" ] || fail "unsafe-path" "lock path is not a regular file"',
-  'lock_stat="$(stat -c "%u:%g:%a:%F" -- "$LOCK_PATH" 2>/dev/null)" || fail "unsafe-path" "lock path stat failed"',
-  '[ "$lock_stat" = "0:0:600:regular file" ] || fail "unsafe-path" "lock path ownership or mode is unsafe"',
+  'lock_stat="$(stat -c "%u:%g:%a" -- "$LOCK_PATH" 2>/dev/null)" || fail "unsafe-path" "lock path stat failed"',
+  '[ "$lock_stat" = "$ROOT_OWNER:600" ] || fail "unsafe-path" "lock path ownership or mode is unsafe"',
   'true',
 ]
 


### PR DESCRIPTION
## Summary
- Validate the deployment lock with numeric owner/group/mode metadata instead of GNU `stat`'s human-readable file-type label.
- Preserve the existing regular-file, no-symlink, root-ownership, and `0600` protections.
- Make the cross-platform shell harness preserve GNU empty-file behavior instead of normalizing it away.

## Root cause
GNU `stat -c %F` reports an empty lock file as `regular empty file`, while the remote transaction required the literal `regular file`. Dashboard deploy run 30727330911 therefore failed at pre-lock path validation before any production mutation.

## Verification
- `bun test --recursive` — 2911 pass, 1 skip, 0 fail, 1 snapshot, 7248 expect() calls
- focused dashboard deploy suite — 67 pass, 0 fail, 307 expect() calls
- real util-linux `flock` lifecycle regression executed successfully in a read-only Linux container
- `bunx tsc --noEmit`
- `bun run lint`
- generated remote transaction passes `bash -n`
