### PR TITLE
fix(agent): normalize IAM OIDC provider readback

### DIFF
--- a/apps/agent/server/provision.test.ts
+++ b/apps/agent/server/provision.test.ts
@@ -418,9 +418,13 @@ function makeCurrentBucketClient(
   })
 }
 
-function providerDetails(arn: string, clientIds: string[] = [GITHUB_OIDC_AUDIENCE]): Record<string, unknown> {
+function providerDetails(
+  arn: string,
+  clientIds: string[] = [GITHUB_OIDC_AUDIENCE],
+  url = 'token.actions.githubusercontent.com',
+): Record<string, unknown> {
   return {
-    Url: GITHUB_OIDC_PROVIDER_URL,
+    Url: url,
     ClientIDList: clientIds,
     ThumbprintList: ['bounded-fixture-thumbprint'],
     CreateDate: new Date('2026-08-01T00:00:00.000Z'),
@@ -461,6 +465,26 @@ describe('GitHub OIDC provider provisioning', () => {
     const {client, calls} = makeClient(async command => {
       if (command.constructor.name === 'ListOpenIDConnectProvidersCommand') return listResponse(providerArn)
       if (command.constructor.name === 'GetOpenIDConnectProviderCommand') return providerDetails(providerArn)
+      throw new Error(`Unexpected command: ${command.constructor.name}`)
+    })
+
+    const result = await ensureGitHubOidcProvider(client)
+
+    expect(result).toEqual({classification: 'current', changed: false, providerArn})
+    expect(calls.map(call => call.name)).toEqual([
+      'ListOpenIDConnectProvidersCommand',
+      'GetOpenIDConnectProviderCommand',
+      'GetOpenIDConnectProviderCommand',
+    ])
+  })
+
+  it('accepts the exact HTTPS OIDC URL as current without mutation', async () => {
+    const providerArn = 'arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com'
+    const {client, calls} = makeClient(async command => {
+      if (command.constructor.name === 'ListOpenIDConnectProvidersCommand') return listResponse(providerArn)
+      if (command.constructor.name === 'GetOpenIDConnectProviderCommand') {
+        return providerDetails(providerArn, [GITHUB_OIDC_AUDIENCE], 'https://token.actions.githubusercontent.com')
+      }
       throw new Error(`Unexpected command: ${command.constructor.name}`)
     })
 
@@ -531,6 +555,32 @@ describe('GitHub OIDC provider provisioning', () => {
     await expect(ensureGitHubOidcProvider(client)).rejects.toThrow(/URL drifted/i)
     expect(calls.some(call => call.name === 'CreateOpenIDConnectProviderCommand')).toBe(false)
   })
+
+  for (const [label, url] of [
+    ['http scheme', 'http://token.actions.githubusercontent.com'],
+    ['trailing slash', 'token.actions.githubusercontent.com/'],
+    ['extra path', 'https://token.actions.githubusercontent.com/path'],
+    ['query string', 'https://token.actions.githubusercontent.com?query=1'],
+    ['port', 'https://token.actions.githubusercontent.com:443'],
+    ['uppercase host', 'https://TOKEN.ACTIONS.GITHUBUSERCONTENT.COM'],
+    ['prefix lookalike', 'atoken.actions.githubusercontent.com'],
+    ['suffix lookalike', 'token.actions.githubusercontent.com.attacker.com'],
+    ['malicious host', 'https://malicious.example.invalid'],
+  ] as const) {
+    it(`rejects OIDC URL near-match with ${label}`, async () => {
+      const providerArn = 'arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com'
+      const {client, calls} = makeClient(async command => {
+        if (command.constructor.name === 'ListOpenIDConnectProvidersCommand') return listResponse(providerArn)
+        if (command.constructor.name === 'GetOpenIDConnectProviderCommand') {
+          return providerDetails(providerArn, [GITHUB_OIDC_AUDIENCE], url)
+        }
+        throw new Error(`Unexpected command: ${command.constructor.name}`)
+      })
+
+      await expect(ensureGitHubOidcProvider(client)).rejects.toThrow(/URL drifted/i)
+      expect(calls.some(call => call.name === 'CreateOpenIDConnectProviderCommand')).toBe(false)
+    })
+  }
 
   it('confirms the canonical provider after an EntityAlreadyExists create race', async () => {
     const providerArn = 'arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com'

--- a/apps/agent/server/provision.ts
+++ b/apps/agent/server/provision.ts
@@ -47,6 +47,7 @@ import {assertKnownKeyLayout, buildAgentKeyLayout, type AgentKeyLayout} from '..
 
 export const GITHUB_OIDC_PROVIDER_URL = 'https://token.actions.githubusercontent.com'
 export const GITHUB_OIDC_AUDIENCE = 'sts.amazonaws.com'
+const GITHUB_OIDC_PROVIDER_READBACK_HOST = 'token.actions.githubusercontent.com'
 export const AGENT_AWS_ACCESS_KEY_ID = 'AGENT_AWS_ACCESS_KEY_ID'
 export const AGENT_AWS_SECRET_ACCESS_KEY = 'AGENT_AWS_SECRET_ACCESS_KEY'
 export const AGENT_AWS_SESSION_TOKEN = 'AGENT_AWS_SESSION_TOKEN'
@@ -980,6 +981,13 @@ export function printManifest(
 // OIDC provider discovery and convergence
 // ---------------------------------------------------------------------------
 
+function canonicalizeGitHubOidcProviderReadbackUrl(url: string): string {
+  if (url === GITHUB_OIDC_PROVIDER_URL || url === GITHUB_OIDC_PROVIDER_READBACK_HOST) {
+    return GITHUB_OIDC_PROVIDER_URL
+  }
+  return url
+}
+
 async function readOidcProvider(
   client: IAMClientLike,
   providerArn: string,
@@ -994,7 +1002,7 @@ async function readOidcProvider(
 
     return {
       providerArn,
-      url: response.Url,
+      url: canonicalizeGitHubOidcProviderReadbackUrl(response.Url),
       clientIds: response.ClientIDList ?? [],
       thumbprints: response.ThumbprintList ?? [],
     }


### PR DESCRIPTION
This fix normalizes how we compare IAM OIDC provider URLs during provisioning so we avoid false drift without changing existing configure semantics.

## Why
AWS IAM expects HTTPS when creating an OIDC provider URL, but the platform readback for the same provider returns the host without a scheme. That mismatch could incorrectly look like drift on every plan run.

## What changed
- Normalize readback URLs before diffing so create input remains unchanged (`https://...`) while comparisons use a canonical form.
- Keep exact matching strict: canonicalized values must match exactly (so near-matches are still flagged), preventing false positives from representation-only differences.
- Preserve existing user input and do not alter the HTTPS value sent at create time.

## Verification
- 60/60 focused agent tests
- Full safe suite: **2918 pass / 1 skip**
- TypeScript: clean
- ESLint: 0 errors
- Live `--plan` identified the provider as current and emitted no AWS mutations
- CloudTrail confirmed zero writes
