### PR TITLE
fix(cli): route agent storage AWS readback through dedicated credentials

### DIFF
--- a/.changeset/agent-storage-dedicated-aws-env.md
+++ b/.changeset/agent-storage-dedicated-aws-env.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': patch
+---
+
+Use dedicated `AGENT_AWS_*` credentials and a restricted child environment for `agent storage` AWS preflight.

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -45,7 +45,7 @@ The `AGENT_S3_SESSION_PREFIX` and `AGENT_S3_METADATA_ARTIFACTS_PREFIX` values ar
 
 ## PROVISIONING FLOW
 
-1. Install the AWS CLI and GitHub CLI locally. The AWS CLI is also required by `agent storage` for its provision-first resource readback.
+1. Install the AWS CLI and GitHub CLI locally. The AWS CLI is also required by `agent storage` for provision-first resource readback; storage passes dedicated `AGENT_AWS_*` credentials through a restricted child environment and ignores ambient `AWS_*` values.
 2. Create the dedicated AWS credentials and seed the root `.env` with the `AGENT_*` values above.
 3. Run the root wrapper:
 
@@ -104,7 +104,7 @@ bunx @marcusrbrown/infra agent storage \
   --manifest handoff.json
 ```
 
-The command verifies live repository identity, the provisioned IAM role and S3 bucket, and the repository OIDC subject before writing only the five non-secret `FRO_BOT_S3_*` variables. It then runs the effective workflow/environment verifier. A failed workflow check emits a pasteable diff and never edits the workflow; apply the diff manually and rerun the command.
+The command verifies live repository identity, the provisioned IAM role and S3 bucket, the repository OIDC subject, and the effective workflow/environment contract before writing only the five non-secret `FRO_BOT_S3_*` variables. AWS readback requires `AGENT_AWS_ACCESS_KEY_ID` and `AGENT_AWS_SECRET_ACCESS_KEY`; ambient `AWS_*` values are ignored. A failed workflow check emits a pasteable diff and never edits the workflow; apply the diff manually and rerun the command.
 
 The storage teardown command removes those five variables and invokes the repository-scoped provisioner teardown:
 

--- a/docs/runbooks/agent-s3-durable-storage.md
+++ b/docs/runbooks/agent-s3-durable-storage.md
@@ -18,7 +18,7 @@ The workflow uses native GitHub OIDC → AWS STS. No static AWS credentials are 
 
 Before provisioning:
 
-1. Install and authenticate the AWS CLI and GitHub CLI on the operator machine. The provisioner uses the AWS SDK with dedicated `AGENT_AWS_*` variables. The storage command shells out to `aws` for readback prechecks, so `aws` must be available on `PATH` and authenticated for the target account.
+1. Install and authenticate the AWS CLI and GitHub CLI on the operator machine. The provisioner and storage readback use dedicated `AGENT_AWS_*` variables; `agent storage` ignores ambient AWS identities and runs `aws` with a restricted child environment. `aws` must be available on `PATH`.
 2. Create dedicated AWS provisioning credentials with only the IAM and S3 permissions required by the provisioner. Do not use the gateway's S3 credentials and do not rely on ambient `AWS_*` credentials for provisioning.
 3. Seed the repository-root `.env` with the dedicated operator credentials and provisioner inputs:
 
@@ -102,10 +102,13 @@ The command performs fail-closed checks before writing any S3 variable:
 
 - the manifest's owner, repository, repository ID, and owner ID match live GitHub metadata;
 - the IAM role and S3 bucket exist, have the expected owner, and have the manifest's region;
-- the repository uses the approved default OIDC subject configuration; and
-- static AWS credential options are absent.
+- the repository uses the approved default OIDC subject configuration;
+- static AWS credential options are absent; and
+- the workflow and protected environment satisfy the storage contract.
 
-After those checks it writes exactly these non-secret repository variables:
+The AWS readback requires `AGENT_AWS_ACCESS_KEY_ID` and `AGENT_AWS_SECRET_ACCESS_KEY`; `AGENT_AWS_SESSION_TOKEN` and `AGENT_AWS_REGION` are optional. Credential bytes are never placed in AWS argv, error text, logs, or repository values. If any precheck or workflow verification fails, no repository variables are written.
+
+After all checks pass it writes exactly these non-secret repository variables:
 
 | Variable                           | Value                            |
 | ---------------------------------- | -------------------------------- |
@@ -115,7 +118,7 @@ After those checks it writes exactly these non-secret repository variables:
 | `FRO_BOT_S3_PREFIX`                | Manifest `s3_prefix`             |
 | `FRO_BOT_S3_EXPECTED_BUCKET_OWNER` | Manifest `expected_bucket_owner` |
 
-The command then invokes the workflow verifier. If the workflow is not yet compliant, the command reports the violations and emits a pasteable diff; it does not modify the workflow. Variables written before a workflow failure are still non-secret configuration, so apply the diff and rerun the storage command to complete verification.
+If the workflow is not yet compliant, the command reports the violations and emits a pasteable diff; it does not modify the workflow. Apply the diff and rerun the storage command to complete verification.
 
 ### 4. Apply the `fro-bot.yaml` job split
 

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -37,7 +37,7 @@ Commands:
     --ack-key-reuse                    Acknowledge that --key matches the bearer token inside the existing OPENCODE_AUTH_JSON. Required in non-interactive mode when --key is supplied for a repo with existing OPENCODE_AUTH_JSON. (default: false)
 
 
-  agent storage                        Verify the provisioned S3 handoff and wire non-secret GitHub storage variables.
+  agent storage                        Verify the provisioned S3 handoff and wire non-secret GitHub storage variables. AWS readback requires AGENT_AWS_ACCESS_KEY_ID and AGENT_AWS_SECRET_ACCESS_KEY and ignores ambient AWS_* values.
 
     --repo [repo]                      Target GitHub repository in owner/repo format.
     --manifest [manifest]              Handoff manifest path, or - to read JSON from stdin. (default: -)

--- a/packages/cli/src/commands/agent/setup-core/gh.test.ts
+++ b/packages/cli/src/commands/agent/setup-core/gh.test.ts
@@ -1,6 +1,18 @@
-import {describe, expect, it} from 'bun:test'
+import {afterEach, beforeEach, describe, expect, it} from 'bun:test'
 
 import {runCommand} from './gh'
+
+const runCommandEnvKey = 'INFRA_RUN_COMMAND_TEST_ENV'
+let envBeforeEach: string | undefined
+
+beforeEach(() => {
+  envBeforeEach = process.env[runCommandEnvKey]
+})
+
+afterEach(() => {
+  if (envBeforeEach === undefined) delete process.env[runCommandEnvKey]
+  else process.env[runCommandEnvKey] = envBeforeEach
+})
 
 describe('bounded CLI subprocesses', () => {
   it('reports a missing CLI as an actionable error', async () => {
@@ -9,5 +21,64 @@ describe('bounded CLI subprocesses', () => {
 
   it('reports a timeout separately from a non-zero exit', async () => {
     await expect(runCommand('bun', ['-e', 'await Bun.sleep(1000)'], 10)).rejects.toThrow(/timed out/i)
+  })
+
+  it('passes an explicit child environment without changing default inheritance', async () => {
+    process.env[runCommandEnvKey] = 'default-value'
+
+    const inherited = await runCommand(
+      'bun',
+      ['-e', `process.stdout.write(process.env.${runCommandEnvKey} ?? '')`],
+      1_000,
+    )
+    const explicit = await runCommand(
+      'bun',
+      ['-e', `process.stdout.write(process.env.${runCommandEnvKey} ?? '')`],
+      1_000,
+      undefined,
+      {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? '',
+        [runCommandEnvKey]: 'explicit-value',
+      },
+    )
+
+    expect(inherited.stdout).toBe('default-value')
+    expect(explicit.stdout).toBe('explicit-value')
+  })
+
+  it('redacts exact credential values from captured stdout and stderr', async () => {
+    const accessKey = 'agent-access-redaction-fixture'
+    const secretKey = 'agent-secret-redaction-fixture'
+    const sessionToken = 'agent-session-redaction-fixture'
+    const stdout = `stdout:${accessKey}:${secretKey}:${sessionToken}`
+    const stderr = `stderr:${sessionToken}:${secretKey}:${accessKey}`
+    const child = await runCommand(
+      'bun',
+      ['-e', `process.stdout.write(${JSON.stringify(stdout)}); process.stderr.write(${JSON.stringify(stderr)})`],
+      1_000,
+      undefined,
+      {PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? ''},
+      [accessKey, secretKey, sessionToken],
+    )
+
+    expect(child.stdout).toBe('stdout:[REDACTED]:[REDACTED]:[REDACTED]')
+    expect(child.stderr).toBe('stderr:[REDACTED]:[REDACTED]:[REDACTED]')
+    expect(child.stdout).not.toContain(accessKey)
+    expect(child.stdout).not.toContain(secretKey)
+    expect(child.stdout).not.toContain(sessionToken)
+    expect(child.stderr).not.toContain(accessKey)
+    expect(child.stderr).not.toContain(secretKey)
+    expect(child.stderr).not.toContain(sessionToken)
+  })
+
+  it('does not include redacted values in operation errors', async () => {
+    const credential = 'agent-operation-redaction-fixture'
+    const failure = await runCommand('/definitely/missing/aws', [credential], 50, undefined, {}, [credential]).catch(
+      error => error,
+    )
+
+    expect(failure).toBeInstanceOf(Error)
+    expect(failure instanceof Error ? failure.message : '').not.toContain(credential)
   })
 })

--- a/packages/cli/src/commands/agent/setup-core/gh.ts
+++ b/packages/cli/src/commands/agent/setup-core/gh.ts
@@ -48,13 +48,23 @@ function readablePipe(pipe: Bun.Subprocess['stdout']): ReadableStream<Uint8Array
   return pipe
 }
 
+function redactExactValues(text: string, values: readonly string[]): string {
+  let redacted = text
+  for (const value of new Set(values)) {
+    if (value.length > 0) redacted = redacted.split(value).join('[REDACTED]')
+  }
+  return redacted
+}
+
 export async function runCommand(
   command: string,
   args: string[],
   timeoutMs = COMMAND_TIMEOUT_MS,
   stdin?: string,
+  env: Record<string, string | undefined> = process.env,
+  redactValues: readonly string[] = [],
 ): Promise<CommandResult> {
-  const operation = `${command} ${args.join(' ')}`.trim()
+  const operation = redactExactValues(`${command} ${args.join(' ')}`.trim(), redactValues)
   const controller = new AbortController()
   let timeout: ReturnType<typeof setTimeout> | undefined
   let child: Bun.Subprocess
@@ -65,7 +75,7 @@ export async function runCommand(
         signal: controller.signal,
         stdout: 'pipe',
         stderr: 'pipe',
-        env: process.env,
+        env,
       })
     } else {
       child = Bun.spawn([command, ...args], {
@@ -73,7 +83,7 @@ export async function runCommand(
         stdin: new Blob([stdin]).stream(),
         stdout: 'pipe',
         stderr: 'pipe',
-        env: process.env,
+        env,
       })
     }
   } catch (error) {
@@ -99,7 +109,11 @@ export async function runCommand(
       timeoutPromise,
     ])
     const [stdout, stderr, exitCode] = result as [string, string, number]
-    return {stdout, stderr, exitCode}
+    return {
+      stdout: redactExactValues(stdout, redactValues),
+      stderr: redactExactValues(stderr, redactValues),
+      exitCode,
+    }
   } catch (error) {
     if (controller.signal.aborted) throw new Error(`${command} CLI timed out during ${operation}.`)
     throw error

--- a/packages/cli/src/commands/agent/storage.test.ts
+++ b/packages/cli/src/commands/agent/storage.test.ts
@@ -1,12 +1,15 @@
 /// <reference types="bun" />
 
-import {describe, expect, it, mock} from 'bun:test'
+import {afterEach, beforeEach, describe, expect, it, mock, spyOn} from 'bun:test'
 
+import {runCommand} from './setup-core/gh'
 import {
+  buildAwsChildEnv,
   runStorageSetup,
   runStorageTeardown,
   STORAGE_VARIABLE_NAMES,
   unwireStorageVariables,
+  verifyProvisionedResources,
   type StorageManifest,
   type StorageSetupDeps,
 } from './storage'
@@ -64,7 +67,258 @@ function makeDeps(writes: {kind: string; name: string; value: string}[], overrid
   } satisfies StorageSetupDeps
 }
 
+const storageEnvKeys = [
+  'AGENT_AWS_ACCESS_KEY_ID',
+  'AGENT_AWS_SECRET_ACCESS_KEY',
+  'AGENT_AWS_SESSION_TOKEN',
+  'AGENT_AWS_REGION',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_DEFAULT_REGION',
+  'AWS_CONFIG_FILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_CA_BUNDLE',
+  'AWS_ENDPOINT_URL',
+  'AWS_PROFILE',
+  'AWS_DEFAULT_PROFILE',
+  'AWS_ROLE_ARN',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+  'AWS_EC2_METADATA_DISABLED',
+  'AWS_REGION',
+  'PATH',
+  'HOME',
+  'TMPDIR',
+  'LANG',
+  'LANGUAGE',
+  'LC_ALL',
+  'LC_CTYPE',
+  'UNRELATED_REPO_SECRET',
+] as const
+
+let storageEnvBeforeEach: Record<string, string | undefined>
+
+beforeEach(() => {
+  storageEnvBeforeEach = Object.fromEntries(storageEnvKeys.map(key => [key, process.env[key]]))
+})
+
+afterEach(() => {
+  for (const key of storageEnvKeys) {
+    const value = storageEnvBeforeEach[key]
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+function setStorageEnv(values: Partial<Record<(typeof storageEnvKeys)[number], string | undefined>>): void {
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}
+
 describe('agent S3 durable storage wiring', () => {
+  it('builds a dedicated AWS child environment with explicit preservation and default denial', () => {
+    const dedicatedAccessKey = 'agent-access-fixture'
+    const dedicatedSecretKey = 'agent-secret-fixture'
+    const ambientAccessKey = 'ambient-access-fixture'
+    const ambientSecretKey = 'ambient-secret-fixture'
+    const sourceEnv = {
+      AGENT_AWS_ACCESS_KEY_ID: dedicatedAccessKey,
+      AGENT_AWS_SECRET_ACCESS_KEY: dedicatedSecretKey,
+      AGENT_AWS_REGION: undefined,
+      AWS_ACCESS_KEY_ID: ambientAccessKey,
+      AWS_SECRET_ACCESS_KEY: ambientSecretKey,
+      AWS_REGION: 'ambient-region',
+      AWS_DEFAULT_REGION: 'ambient-default-region',
+      AWS_CONFIG_FILE: '/tmp/ambient-config',
+      AWS_SHARED_CREDENTIALS_FILE: '/tmp/ambient-credentials',
+      AWS_CA_BUNDLE: '/tmp/ambient-ca.pem',
+      AWS_ENDPOINT_URL: 'http://ambient-endpoint.invalid',
+      AWS_PROFILE: 'gateway-profile',
+      AWS_DEFAULT_PROFILE: 'gateway-profile',
+      AWS_ROLE_ARN: 'arn:aws:iam::999999999999:role/ambient',
+      AWS_WEB_IDENTITY_TOKEN_FILE: '/tmp/ambient-token',
+      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: '/v2/credentials/ambient',
+      AWS_CONTAINER_CREDENTIALS_FULL_URI: 'http://169.254.170.2/ambient',
+      AWS_CONTAINER_AUTHORIZATION_TOKEN: 'ambient-auth-fixture',
+      AWS_EC2_METADATA_DISABLED: 'false',
+      AWS_SESSION_TOKEN: 'ambient-session-fixture',
+      PATH: '/fixture/bin',
+      HOME: '/fixture/home',
+      TMPDIR: '/fixture/tmp',
+      LANG: 'C.UTF-8',
+      LANGUAGE: 'en_US',
+      LC_ALL: 'C.UTF-8',
+      LC_CTYPE: 'C.UTF-8',
+      UNRELATED_REPO_SECRET: 'unrelated-fixture',
+    }
+    const childEnv = buildAwsChildEnv(manifest, sourceEnv)
+
+    expect(childEnv).toEqual(
+      expect.objectContaining({
+        AWS_ACCESS_KEY_ID: dedicatedAccessKey,
+        AWS_SECRET_ACCESS_KEY: dedicatedSecretKey,
+        AWS_REGION: manifest.bucket_region,
+        AWS_DEFAULT_REGION: manifest.bucket_region,
+        PATH: sourceEnv.PATH,
+        HOME: sourceEnv.HOME,
+        TMPDIR: sourceEnv.TMPDIR,
+        LANG: sourceEnv.LANG,
+        LANGUAGE: sourceEnv.LANGUAGE,
+        LC_ALL: sourceEnv.LC_ALL,
+        LC_CTYPE: sourceEnv.LC_CTYPE,
+      }),
+    )
+
+    for (const key of [
+      'AWS_CONFIG_FILE',
+      'AWS_SHARED_CREDENTIALS_FILE',
+      'AWS_CA_BUNDLE',
+      'AWS_ENDPOINT_URL',
+      'AWS_PROFILE',
+      'AWS_DEFAULT_PROFILE',
+      'AWS_ROLE_ARN',
+      'AWS_WEB_IDENTITY_TOKEN_FILE',
+      'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+      'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+      'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+      'AWS_EC2_METADATA_DISABLED',
+      'AWS_SESSION_TOKEN',
+      'UNRELATED_REPO_SECRET',
+    ]) {
+      expect(childEnv).not.toHaveProperty(key)
+    }
+    expect(childEnv).not.toHaveProperty('AGENT_AWS_ACCESS_KEY_ID')
+    expect(childEnv).not.toHaveProperty('AGENT_AWS_SECRET_ACCESS_KEY')
+    expect(childEnv.AWS_REGION).not.toBe('ambient-region')
+    expect(childEnv.AWS_DEFAULT_REGION).not.toBe('ambient-default-region')
+  })
+
+  it('fails before spawning aws when dedicated credentials are missing, partial, or whitespace-only', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn')
+    const cases = [
+      {AGENT_AWS_ACCESS_KEY_ID: undefined, AGENT_AWS_SECRET_ACCESS_KEY: undefined},
+      {AGENT_AWS_ACCESS_KEY_ID: 'partial-access-fixture', AGENT_AWS_SECRET_ACCESS_KEY: undefined},
+      {AGENT_AWS_ACCESS_KEY_ID: undefined, AGENT_AWS_SECRET_ACCESS_KEY: 'partial-secret-fixture'},
+      {AGENT_AWS_ACCESS_KEY_ID: '   ', AGENT_AWS_SECRET_ACCESS_KEY: 'dedicated-secret-fixture'},
+      {AGENT_AWS_ACCESS_KEY_ID: 'dedicated-access-fixture', AGENT_AWS_SECRET_ACCESS_KEY: '\t'},
+    ] as const
+
+    try {
+      for (const values of cases) {
+        setStorageEnv(values)
+        let failure: unknown
+        try {
+          await verifyProvisionedResources(manifest)
+        } catch (error) {
+          failure = error
+        }
+
+        expect(failure).toBeInstanceOf(Error)
+        const message = failure instanceof Error ? failure.message : ''
+        expect(message).toMatch(/AGENT_AWS_ACCESS_KEY_ID.*AGENT_AWS_SECRET_ACCESS_KEY/)
+        expect(message).not.toContain('partial-access-fixture')
+        expect(message).not.toContain('partial-secret-fixture')
+      }
+      expect(spawnSpy).not.toHaveBeenCalled()
+    } finally {
+      spawnSpy.mockRestore()
+    }
+  })
+
+  it('passes the dedicated session token only when configured and removes ambient session state otherwise', () => {
+    const sourceEnv = {
+      AGENT_AWS_ACCESS_KEY_ID: 'agent-access-fixture',
+      AGENT_AWS_SECRET_ACCESS_KEY: 'agent-secret-fixture',
+      AGENT_AWS_SESSION_TOKEN: 'agent-session-fixture',
+      AWS_SESSION_TOKEN: 'ambient-session-fixture',
+    }
+    expect(buildAwsChildEnv(manifest, sourceEnv).AWS_SESSION_TOKEN).toBe('agent-session-fixture')
+
+    expect(buildAwsChildEnv(manifest, {...sourceEnv, AGENT_AWS_SESSION_TOKEN: undefined})).not.toHaveProperty(
+      'AWS_SESSION_TOKEN',
+    )
+  })
+
+  it('prefers the dedicated region and falls back to the manifest region', () => {
+    const sourceEnv = {
+      AGENT_AWS_ACCESS_KEY_ID: 'agent-access-fixture',
+      AGENT_AWS_SECRET_ACCESS_KEY: 'agent-secret-fixture',
+      AGENT_AWS_REGION: 'eu-west-1',
+    }
+    expect(buildAwsChildEnv(manifest, sourceEnv).AWS_REGION).toBe('eu-west-1')
+    expect(buildAwsChildEnv(manifest, {...sourceEnv, AGENT_AWS_REGION: undefined}).AWS_REGION).toBe(
+      manifest.bucket_region,
+    )
+  })
+
+  it('keeps injected AWS runners hermetic and does not require dedicated process credentials', async () => {
+    setStorageEnv({
+      AGENT_AWS_ACCESS_KEY_ID: undefined,
+      AGENT_AWS_SECRET_ACCESS_KEY: undefined,
+      AWS_ACCESS_KEY_ID: undefined,
+      AWS_SECRET_ACCESS_KEY: undefined,
+    })
+    const runAws = mock(async (args: string[]) => {
+      if (args[0] === 'iam') return makeGhResult(JSON.stringify({Role: {Arn: manifest.role_arn}}))
+      if (args[1] === 'head-bucket') return makeGhResult('')
+      return makeGhResult(JSON.stringify({LocationConstraint: manifest.bucket_region}))
+    })
+
+    await expect(
+      runStorageSetup('owner/repo', {manifest: '-'}, makeDeps([], {verifyResources: undefined, runAws})),
+    ).resolves.toBeUndefined()
+    expect(runAws).toHaveBeenCalledTimes(3)
+  })
+
+  it('redacts dedicated credentials from default AWS stdout, stderr, and thrown preflight errors', async () => {
+    const accessKey = 'agent-access-redaction-fixture'
+    const secretKey = 'agent-secret-redaction-fixture'
+    const sessionToken = 'agent-session-redaction-fixture'
+    setStorageEnv({
+      AGENT_AWS_ACCESS_KEY_ID: accessKey,
+      AGENT_AWS_SECRET_ACCESS_KEY: secretKey,
+      AGENT_AWS_SESSION_TOKEN: sessionToken,
+    })
+
+    let captured: {stdout: string; stderr: string} | undefined
+    const awsCalls: string[][] = []
+    const runAwsCommand: NonNullable<StorageSetupDeps['runAwsCommand']> = async (args, env, redactValues) => {
+      awsCalls.push(args)
+      const outputScript = [
+        'process.stdout.write("stdout:" + process.env.AWS_ACCESS_KEY_ID + ":" + process.env.AWS_SECRET_ACCESS_KEY + ":" + process.env.AWS_SESSION_TOKEN);',
+        'process.stderr.write("stderr:" + process.env.AWS_ACCESS_KEY_ID + ":" + process.env.AWS_SECRET_ACCESS_KEY + ":" + process.env.AWS_SESSION_TOKEN);',
+      ].join(' ')
+      const result = await runCommand('bun', ['-e', outputScript], 1_000, undefined, env, redactValues)
+      captured = result
+      return {...result, exitCode: 1}
+    }
+
+    const failure = runStorageSetup(
+      'owner/repo',
+      {manifest: '-'},
+      makeDeps([], {verifyResources: undefined, runAwsCommand}),
+    )
+    await expect(failure).rejects.toThrow('AWS IAM role preflight failed')
+
+    expect(captured?.stdout).toBe('stdout:[REDACTED]:[REDACTED]:[REDACTED]')
+    expect(captured?.stderr).toBe('stderr:[REDACTED]:[REDACTED]:[REDACTED]')
+    expect(awsCalls).toHaveLength(1)
+    for (const value of [accessKey, secretKey, sessionToken]) {
+      expect(awsCalls[0]).not.toContain(value)
+    }
+    const error = await failure.catch(error_ => error_)
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toContain('[REDACTED]')
+    expect(message).not.toContain(accessKey)
+    expect(message).not.toContain(secretKey)
+    expect(message).not.toContain(sessionToken)
+  })
+
   it('writes exactly the non-secret S3 variables after all prechecks pass', async () => {
     const writes: {kind: string; name: string; value: string}[] = []
 

--- a/packages/cli/src/commands/agent/storage.test.ts
+++ b/packages/cli/src/commands/agent/storage.test.ts
@@ -1,5 +1,9 @@
 /// <reference types="bun" />
 
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
 import {afterEach, beforeEach, describe, expect, it, mock, spyOn} from 'bun:test'
 
 import {runCommand} from './setup-core/gh'
@@ -164,6 +168,8 @@ describe('agent S3 durable storage wiring', () => {
         AWS_SECRET_ACCESS_KEY: dedicatedSecretKey,
         AWS_REGION: manifest.bucket_region,
         AWS_DEFAULT_REGION: manifest.bucket_region,
+        AWS_CONFIG_FILE: '/dev/null',
+        AWS_SHARED_CREDENTIALS_FILE: '/dev/null',
         PATH: sourceEnv.PATH,
         HOME: sourceEnv.HOME,
         TMPDIR: sourceEnv.TMPDIR,
@@ -175,8 +181,6 @@ describe('agent S3 durable storage wiring', () => {
     )
 
     for (const key of [
-      'AWS_CONFIG_FILE',
-      'AWS_SHARED_CREDENTIALS_FILE',
       'AWS_CA_BUNDLE',
       'AWS_ENDPOINT_URL',
       'AWS_PROFILE',
@@ -196,6 +200,32 @@ describe('agent S3 durable storage wiring', () => {
     expect(childEnv).not.toHaveProperty('AGENT_AWS_SECRET_ACCESS_KEY')
     expect(childEnv.AWS_REGION).not.toBe('ambient-region')
     expect(childEnv.AWS_DEFAULT_REGION).not.toBe('ambient-default-region')
+  })
+
+  it('neutralizes ambient AWS config and credentials files under the preserved HOME', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agent-storage-home-'))
+    const awsDir = join(home, '.aws')
+    mkdirSync(awsDir)
+    writeFileSync(join(awsDir, 'config'), '[default]\nendpoint_url = http://ambient-endpoint.invalid\n')
+    writeFileSync(join(awsDir, 'credentials'), '[default]\naws_access_key_id = ambient-access-fixture\n')
+
+    try {
+      const childEnv = buildAwsChildEnv(manifest, {
+        AGENT_AWS_ACCESS_KEY_ID: 'agent-access-fixture',
+        AGENT_AWS_SECRET_ACCESS_KEY: 'agent-secret-fixture',
+        HOME: home,
+      })
+
+      expect(childEnv).toEqual(
+        expect.objectContaining({
+          HOME: home,
+          AWS_CONFIG_FILE: '/dev/null',
+          AWS_SHARED_CREDENTIALS_FILE: '/dev/null',
+        }),
+      )
+    } finally {
+      rmSync(home, {recursive: true, force: true})
+    }
   })
 
   it('fails before spawning aws when dedicated credentials are missing, partial, or whitespace-only', async () => {

--- a/packages/cli/src/commands/agent/storage.ts
+++ b/packages/cli/src/commands/agent/storage.ts
@@ -233,6 +233,8 @@ export function buildAwsChildEnv(
     }
   }
 
+  childEnv.AWS_CONFIG_FILE = '/dev/null'
+  childEnv.AWS_SHARED_CREDENTIALS_FILE = '/dev/null'
   childEnv.AWS_ACCESS_KEY_ID = accessKeyId
   childEnv.AWS_SECRET_ACCESS_KEY = secretAccessKey
   childEnv.AWS_REGION = sourceEnv.AGENT_AWS_REGION?.trim() || manifest.bucket_region

--- a/packages/cli/src/commands/agent/storage.ts
+++ b/packages/cli/src/commands/agent/storage.ts
@@ -70,6 +70,7 @@ export interface StorageSetupDeps {
   readManifest?: (source: string) => Promise<string>
   verifyResources?: (manifest: StorageManifest) => Promise<void>
   runAws?: (args: string[]) => Promise<CommandResult>
+  runAwsCommand?: AwsCommandRunner
   /** Explicit test/operator override; production defaults to the effective-job-graph verifier. */
   verifyWorkflow?: (repo: string, manifest: StorageManifest) => Promise<void>
   /** Injected provisioner boundary used by teardown tests and operator wrappers. */
@@ -191,8 +192,56 @@ function parseManifest(raw: string): StorageManifest {
   }
 }
 
-async function runAwsCommand(args: string[]): Promise<CommandResult> {
-  return runCommand('aws', args)
+async function runAwsCommand(
+  args: string[],
+  env: Record<string, string>,
+  redactValues: readonly string[],
+): Promise<CommandResult> {
+  return runCommand('aws', args, undefined, undefined, env, redactValues)
+}
+
+type AwsCommandRunner = typeof runAwsCommand
+
+const AWS_CHILD_LOCALE_KEYS = new Set(['LANG', 'LANGUAGE'])
+
+/**
+ * Build the least-privileged environment used by the local AWS readback.
+ * Dedicated operator credentials are required; the parent process environment
+ * is never passed through wholesale.
+ *
+ * @internal
+ */
+export function buildAwsChildEnv(
+  manifest: StorageManifest,
+  sourceEnv: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+  const accessKeyId = sourceEnv.AGENT_AWS_ACCESS_KEY_ID?.trim()
+  const secretAccessKey = sourceEnv.AGENT_AWS_SECRET_ACCESS_KEY?.trim()
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error(
+      'Dedicated AWS credentials are required for agent storage preflight. Set AGENT_AWS_ACCESS_KEY_ID and AGENT_AWS_SECRET_ACCESS_KEY in the operator-local environment.',
+    )
+  }
+
+  const childEnv: Record<string, string> = {}
+  for (const [key, value] of Object.entries(sourceEnv)) {
+    if (
+      value !== undefined &&
+      (key === 'PATH' || key === 'HOME' || key === 'TMPDIR' || AWS_CHILD_LOCALE_KEYS.has(key) || key.startsWith('LC_'))
+    ) {
+      childEnv[key] = value
+    }
+  }
+
+  childEnv.AWS_ACCESS_KEY_ID = accessKeyId
+  childEnv.AWS_SECRET_ACCESS_KEY = secretAccessKey
+  childEnv.AWS_REGION = sourceEnv.AGENT_AWS_REGION?.trim() || manifest.bucket_region
+  childEnv.AWS_DEFAULT_REGION = childEnv.AWS_REGION
+
+  const sessionToken = sourceEnv.AGENT_AWS_SESSION_TOKEN?.trim()
+  if (sessionToken) childEnv.AWS_SESSION_TOKEN = sessionToken
+
+  return childEnv
 }
 
 async function runProvisionerCommand(manifest: string, options: {purgeState?: boolean; plan?: boolean}): Promise<void> {
@@ -246,9 +295,20 @@ function canonicalBucketRegion(location: unknown): string {
  */
 export async function verifyProvisionedResources(
   manifest: StorageManifest,
-  runAws: (args: string[]) => Promise<CommandResult> = runAwsCommand,
+  runAws?: (args: string[]) => Promise<CommandResult>,
+  awsCommand: AwsCommandRunner = runAwsCommand,
 ): Promise<void> {
-  const roleResult = await runAws([
+  let executeAws: (args: string[]) => Promise<CommandResult>
+  if (runAws) {
+    executeAws = runAws
+  } else {
+    const awsEnv = buildAwsChildEnv(manifest)
+    const redactValues = [awsEnv.AWS_ACCESS_KEY_ID, awsEnv.AWS_SECRET_ACCESS_KEY, awsEnv.AWS_SESSION_TOKEN].filter(
+      (value): value is string => value !== undefined && value.length > 0,
+    )
+    executeAws = (args: string[]) => awsCommand(args, awsEnv, redactValues)
+  }
+  const roleResult = await executeAws([
     'iam',
     'get-role',
     '--role-name',
@@ -278,7 +338,7 @@ export async function verifyProvisionedResources(
     )
   }
 
-  const bucketResult = await runAws([
+  const bucketResult = await executeAws([
     's3api',
     'head-bucket',
     '--bucket',
@@ -293,7 +353,7 @@ export async function verifyProvisionedResources(
     )
   }
 
-  const locationResult = await runAws([
+  const locationResult = await executeAws([
     's3api',
     'get-bucket-location',
     '--bucket',
@@ -417,7 +477,8 @@ export async function prepareStorageSetup(
   await verifyRepoIdentity(repo, manifest, deps.runGh ?? runGh)
 
   const verifyResources =
-    deps.verifyResources ?? ((value: StorageManifest) => verifyProvisionedResources(value, deps.runAws))
+    deps.verifyResources ??
+    ((value: StorageManifest) => verifyProvisionedResources(value, deps.runAws, deps.runAwsCommand))
   await verifyResources(manifest)
   await verifyOidcSubject(repo, deps.runGh ?? runGh)
   const verifyWorkflowSetup =
@@ -534,7 +595,10 @@ export async function runStorageTeardown(
  */
 export function registerAgentStorageCommand(cli: ReturnType<typeof goke>): void {
   cli
-    .command('agent storage', 'Verify the provisioned S3 handoff and wire non-secret GitHub storage variables.')
+    .command(
+      'agent storage',
+      'Verify the provisioned S3 handoff and wire non-secret GitHub storage variables. AWS readback requires AGENT_AWS_ACCESS_KEY_ID and AGENT_AWS_SECRET_ACCESS_KEY and ignores ambient AWS_* values.',
+    )
     .option('--repo [repo]', z.string().describe('Target GitHub repository in owner/repo format.'))
     .option(
       '--manifest [manifest]',


### PR DESCRIPTION
The `agent storage` AWS preflight built its child environment from the ambient process environment. In this repo Bun auto-loads the repo-root `.env`, so unrelated `AWS_*` credentials there (the object-only gateway identity) silently selected the wrong AWS identity and the readback failed closed — even though the dedicated provisioner identity was available as `AGENT_AWS_*`.

## What changed

- AWS readback now builds a default-deny child environment sourced only from dedicated `AGENT_AWS_*` credentials (plus `PATH`/`HOME`/`TMPDIR`/locale). Ambient `AWS_*` selectors, profiles, and session tokens are never passed through.
- Fails before spawning `aws` when dedicated credentials are absent or blank.
- Region resolves from `AGENT_AWS_REGION`, falling back to the manifest bucket region.
- Exact dedicated credential values are redacted from AWS subprocess stdout, stderr, and operation strings.
- Runbook corrected to the verify-before-write ordering; `agent storage --help` documents the dedicated-credential contract.

## Verification

- Live plan: the exact invocation that previously failed under the ambient gateway identity now succeeds and reports exactly five pending variable writes, zero mutation.
- Focused storage/gh tests, full suite (2950 pass, 1 skip), TypeScript, and lint all clean.
- Multi-persona review clean after redaction, env-boundary, and test-typing hardening.

Unblocks wiring the repository storage variables for the agent S3 durable-storage rollout.