### PR TITLE
docs(solutions): agent S3 rollout learnings (key-layout divergence + hermetic AWS env)

### DIFF
--- a/docs/runbooks/agent-s3-durable-storage.md
+++ b/docs/runbooks/agent-s3-durable-storage.md
@@ -108,6 +108,8 @@ The command performs fail-closed checks before writing any S3 variable:
 
 The AWS readback requires `AGENT_AWS_ACCESS_KEY_ID` and `AGENT_AWS_SECRET_ACCESS_KEY`; `AGENT_AWS_SESSION_TOKEN` and `AGENT_AWS_REGION` are optional. Credential bytes are never placed in AWS argv, error text, logs, or repository values. If any precheck or workflow verification fails, no repository variables are written.
 
+The `aws` subprocess runs in a hermetic, default-deny child environment sourced only from these dedicated `AGENT_AWS_*` values (plus `PATH`/`HOME`/`TMPDIR`/locale), with `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` forced to `/dev/null`. This is deliberate: because Bun auto-loads the repo-root `.env`, any ambient `AWS_*` values there (for example the object-only gateway identity) would otherwise be inherited by `aws` and silently win over the dedicated identity, failing the readback closed in a way that looks like a resource problem. Preserving `HOME` alone is not enough — without the `/dev/null` overrides the AWS CLI still reads `~/.aws/config` and `~/.aws/credentials`. See [`../solutions/best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md`](../solutions/best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md).
+
 After all checks pass it writes exactly these non-secret repository variables:
 
 | Variable                           | Value                            |

--- a/docs/runbooks/agent-s3-durable-storage.md
+++ b/docs/runbooks/agent-s3-durable-storage.md
@@ -206,7 +206,7 @@ Proceed only if every item is verified:
 - [ ] The STS role duration is at least 7200 seconds.
 - [ ] The storage job has no artifact/cache/output handoff from a content-reachable job.
 - [ ] A forced cache miss restores session state from S3.
-- [ ] Writes land only under `<prefix>/github/<owner-repo>/storage/...` (for this rollout, `<prefix>/github/marcusrbrown-infra/storage/...`).
+- [ ] Session writes land only under `<prefix>/github/<owner>/<repo>/...` and the coordination lock under `<prefix>/coordination/<owner>/<repo>/locks/repo.json` (for this rollout, `fro-bot-state/github/marcusrbrown/infra/...` and `fro-bot-state/coordination/marcusrbrown/infra/locks/repo.json`).
 - [ ] Lock acquire and release complete, leaving no stale lock.
 - [ ] Content-triggered execution has no `id-token`, no AWS environment, no available OIDC token, and no durable storage; its behavior matches the pre-storage path.
 

--- a/docs/solutions/best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md
+++ b/docs/solutions/best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md
@@ -1,0 +1,105 @@
+---
+title: Use a dedicated hermetic child environment when a CLI shells out to a cloud CLI
+date: 2026-08-03
+category: best-practices
+module: agent-storage
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - "A CLI spawns a cloud CLI (aws, gcloud, az) that reads credentials from ambient env or config files"
+  - "The operation must run under a dedicated identity distinct from other credentials on the machine"
+  - "The project auto-loads a repo-root .env (Bun loads .env from CWD by default)"
+related_components:
+  - iam
+  - provisioning
+tags:
+  - aws
+  - subprocess
+  - hermetic-env
+  - default-deny
+  - dedicated-identity
+  - bun-dotenv
+  - credential-isolation
+---
+
+# Use a dedicated hermetic child environment when a CLI shells out to a cloud CLI
+
+## Context
+
+The `agent storage` preflight shells out to the `aws` CLI to read back provisioned S3/IAM resources. It must run under a *dedicated* operator identity (`AGENT_AWS_*`), deliberately isolated from the object-only `fro-bot-gateway` identity and every other secret in the repo-root `.env`. The original implementation built the child process environment from ambient `process.env`. Because Bun auto-loads the repo-root `.env` from the current working directory, the unrelated `AWS_*` values in that file were present in `process.env` and the `aws` subprocess silently inherited the wrong identity — the preflight failed closed in a way that looked like a resource problem, not a credential-selection problem.
+
+## Guidance
+
+When a CLI spawns a cloud CLI under a dedicated identity, construct an explicit **default-deny** child environment. Pass through only the process-mechanics variables the child genuinely needs, source the credentials exclusively from the dedicated variables, and force the cloud CLI's config-file lookups to inert paths so ambient default config cannot leak in.
+
+```ts
+// packages/cli/src/commands/agent/storage.ts — buildAwsChildEnv
+const accessKeyId = sourceEnv.AGENT_AWS_ACCESS_KEY_ID?.trim()
+const secretAccessKey = sourceEnv.AGENT_AWS_SECRET_ACCESS_KEY?.trim()
+if (!accessKeyId || !secretAccessKey) {
+  throw new Error('Dedicated AWS credentials are required for agent storage preflight. ...')
+}
+
+const childEnv: Record<string, string> = {}
+for (const [key, value] of Object.entries(sourceEnv)) {
+  if (
+    value !== undefined &&
+    (key === 'PATH' || key === 'HOME' || key === 'TMPDIR' ||
+      AWS_CHILD_LOCALE_KEYS.has(key) || key.startsWith('LC_'))
+  ) {
+    childEnv[key] = value
+  }
+}
+
+// Force the aws CLI to ignore ambient default config/credentials files —
+// preserving HOME alone still lets it read ~/.aws/config and ~/.aws/credentials.
+childEnv.AWS_CONFIG_FILE = '/dev/null'
+childEnv.AWS_SHARED_CREDENTIALS_FILE = '/dev/null'
+
+childEnv.AWS_ACCESS_KEY_ID = accessKeyId
+childEnv.AWS_SECRET_ACCESS_KEY = secretAccessKey
+childEnv.AWS_REGION = sourceEnv.AGENT_AWS_REGION?.trim() || manifest.bucket_region
+childEnv.AWS_DEFAULT_REGION = childEnv.AWS_REGION
+
+const sessionToken = sourceEnv.AGENT_AWS_SESSION_TOKEN?.trim()
+if (sessionToken) childEnv.AWS_SESSION_TOKEN = sessionToken
+
+return childEnv
+```
+
+Also redact the exact dedicated credential values from the subprocess `stdout`/`stderr` and any operation string before they can reach a log or error.
+
+## Why This Matters
+
+Inheriting `process.env` wholesale makes credential selection *implicit* and order-dependent: whichever `AWS_*` values happen to be present win, and an auto-loaded `.env` puts unrelated identities in scope. That is both a correctness bug (wrong identity → confusing fail-closed readbacks) and a blast-radius concern (unrelated secrets are visible to the child). A hermetic, default-deny child env makes the identity explicit and reproducible.
+
+Forcing `AWS_CONFIG_FILE` / `AWS_SHARED_CREDENTIALS_FILE` to `/dev/null` closes the subtler leak: preserving `HOME` alone still lets the AWS CLI load `~/.aws/config` and `~/.aws/credentials`, which can inject endpoint, CA-bundle, or retry overrides into a safety-gate readback.
+
+## When to Apply
+
+- Any CLI that spawns `aws`/`gcloud`/`az` (or similar) and must pin a specific identity.
+- Any Bun project that auto-loads a repo-root `.env` and then shells out — assume the child inherits everything in that file unless you scrub it.
+- Preflight/safety gates whose *result* decides whether to mutate remote state: hermeticity prevents ambient config from changing the answer.
+
+## Examples
+
+Before — child inherits ambient identity:
+
+```ts
+Bun.spawn(['aws', ...args], { env: process.env }) // wrong identity silently wins
+```
+
+After — explicit dedicated identity, config files neutralized:
+
+```ts
+Bun.spawn(['aws', ...args], { env: buildAwsChildEnv(manifest) })
+```
+
+## Related
+
+- [`docs/runbooks/agent-s3-durable-storage.md`](../../runbooks/agent-s3-durable-storage.md) — canonical operator workflow; states `agent storage` uses `AGENT_AWS_*` and ignores ambient `AWS_*`.
+- [`integration-issues/discord-mcp-empty-env-jvm-timeout-2026-06-12.md`](../integration-issues/discord-mcp-empty-env-jvm-timeout-2026-06-12.md) — Bun `.env` / ambient-env behavior precedent.
+- [`workflow-issues/vpn-lightsail-first-provision-cascade-2026-06-10.md`](../workflow-issues/vpn-lightsail-first-provision-cascade-2026-06-10.md) — dedicated-vs-ambient AWS credential isolation precedent.
+- [`integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md`](../integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md) — the sibling key-layout fix from the same rollout.
+- PR #1014.

--- a/docs/solutions/integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md
+++ b/docs/solutions/integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md
@@ -1,0 +1,117 @@
+---
+title: Agent S3 key layout diverged from the pinned action's real object-key contract
+date: 2026-08-03
+category: integration-issues
+module: agent-storage
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "GitHub Actions storage run: AccessDenied (403) on s3:PutObject for the coordination lock"
+  - "Denied path: fro-bot-state/coordination/marcusrbrown/infra/locks/repo.json"
+  - "IAM granted access to S3 key paths the upstream action never writes"
+  - "Lock acquisition failed; run proceeded without a lock (non-fatal degradation)"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - provisioning
+  - iam
+  - object-store
+tags:
+  - agent-storage
+  - s3
+  - iam
+  - oidc
+  - key-layout
+  - upstream-contract
+  - source-authority
+  - access-denied
+---
+
+# Agent S3 key layout diverged from the pinned action's real object-key contract
+
+## Problem
+
+The `fro-bot/agent` S3 durable-storage feature provisions a per-repository IAM role whose grant is scoped to the exact S3 key paths the action reads and writes. During the rollout smoke, the role got `AccessDenied` (403) on `s3:PutObject` for the coordination lock: infra had encoded an S3 key layout that did not match what the pinned action actually writes, so the role was authorized on paths the action never touches.
+
+## Symptoms
+
+- Live GitHub Actions run emitted:
+  - `is not authorized to perform: s3:PutObject on resource ".../fro-bot-state/coordination/marcusrbrown/infra/locks/repo.json" because no identity-based policy allows the s3:PutObject action`
+  - `Lock acquisition failed`
+  - `Coordination lock acquisition failed; proceeding without lock`
+- The failure was non-fatal (the action degrades to running without a lock), so a green-ish run masked a broken storage contract. The end-of-run session backup would have failed the same way.
+
+## What Didn't Work
+
+1. **Pinning a version without verifying the paths.** The layout carried `KEY_LAYOUT_VERSION = 'fro-bot/agent@v0.96.0'` and a comment claiming the paths were "the plan's pinned contract," but the actual key strings were never validated against the action's source at that ref. The pin asserted a version; it did not prove the layout.
+2. **Trusting internal self-consistency.** `apps/agent/src/key-layout.ts` and `apps/agent/server/provision.ts` agreed with each other — the IAM ARNs derived cleanly from the layout — so everything looked correct locally. They were consistently wrong: both encoded a fabricated scheme that diverged from the upstream authority on four axes:
+   - an invented `github/` segment on the lock identity;
+   - a hyphenated `owner-repo` segment instead of separate `owner/repo` segments;
+   - an invented `storage/` contentType; and
+   - a `storage.lock` filename instead of `repo.json`.
+3. **Reprovisioning without `--force`.** After the code fix, the provisioner refused to re-put the inline policy, classifying it as managed drift. `--force` was required — but only safe because the bucket, OIDC provider, and role *trust* policy all read back as `current`, so `--force` re-put **only** the drifted inline policy.
+
+## Solution
+
+Correct `buildAgentKeyLayout` to match the upstream authority exactly. The action's key builder — verified at the pinned commit `fro-bot/agent@c29ac295` (v0.96.0), `packages/runtime/src/object-store/key-builder.ts` — produces:
+
+```
+${prefix}/${identity}/${owner}/${repo}/${contentType}[/${suffix}]
+```
+
+with `owner` and `repo` as **separate slash segments** (no `github/` wrapper added by the builder, no hyphenation, no `storage/` contentType). The lock is `getLockKey → buildObjectStoreKey(cfg, 'coordination', repo, 'locks', 'repo.json')`; session backup uses identity `github` (content types `sessions`, `runs`, `artifacts`, `metadata`).
+
+Before (wrong):
+
+```ts
+const repositorySegment = `${ownerSegment}-${repoSegment}`
+const sessionPrefix = `${normalizedPrefix}github/${repositorySegment}/storage/`
+const lockPrefix = `${normalizedPrefix}coordination/github/${repositorySegment}/locks/`
+const lockKey = `${lockPrefix}storage.lock`
+```
+
+After (matches upstream — `apps/agent/src/key-layout.ts`):
+
+```ts
+const sessionPrefix = `${normalizedPrefix}github/${ownerSegment}/${repoSegment}/`
+const lockPrefix = `${normalizedPrefix}coordination/${ownerSegment}/${repoSegment}/locks/`
+const lockKey = `${lockPrefix}repo.json`
+```
+
+The IAM policy and handoff manifest derive from the layout, so correcting the one function fixed the grant automatically (`apps/agent/server/provision.ts`):
+
+```ts
+const sessionObjectArn = `${bucketArn}/${layout.sessionPrefix}*`
+const lockObjectArn = `${bucketArn}/${layout.lockKey}`
+// AllowSessionObjects → Get/Put on sessionObjectArn
+// AllowCoordinationLock → Delete/Get/Put on lockObjectArn
+// DenySessionDeletes → Deny Delete on the session prefix (preserved)
+```
+
+Shipping sequence:
+
+1. Merge the code fix (PR #1022); tests assert the exact upstream strings.
+2. Re-provision the live IAM policy with the dedicated operator identity (`--force`, safe because only the inline policy was drifted).
+3. Independently read back the live policy: lock grant on the exact `.../coordination/<owner>/<repo>/locks/repo.json`, session grant on `.../github/<owner>/<repo>/*`, `DenySessionDeletes` intact.
+4. Regenerate the `0600` handoff manifest (`session_prefix` / `lock_key` change; the wired repository variables do not).
+5. Re-run the storage smoke: lock acquired → session sync (uploaded, 0 failed) → lock released (no stale lock), **0 AccessDenied**.
+
+## Why This Works
+
+There is one authoritative layout function feeding both the manifest and the IAM policy, and its output now matches the object keys the action actually constructs. The lock grant targets the real `repo.json` object; the session grant covers the real `github/<owner>/<repo>/` tree spanning `sessions`/`runs`/`artifacts`/`metadata`. The role can no longer be "correctly" scoped to phantom paths.
+
+## Prevention
+
+- **Source-authority invariant.** When infra mirrors an upstream contract keyed to a pinned ref or SHA, verify the encoded values against the *actual upstream source at that exact ref* before encoding them. A version pin is not verification; internal self-consistency between two local modules is not verification. Read the upstream file at the SHA (`gh api repos/<owner>/<repo>/contents/<path>?ref=<sha> --jq .content | base64 -d`) and confirm the strings.
+- **Tie re-verification to the version bump.** Any change to `KEY_LAYOUT_VERSION` must re-confirm the object-key construction at the new ref; treat the layout constants as a contract test against upstream, not a local convention.
+- **Prefer a non-fatal failure that is still loud.** The lock 403 degraded silently to "proceeding without lock." A rollout smoke must inspect the run logs for `AccessDenied` explicitly rather than trusting the job's overall conclusion.
+- **`--force` only after confirming scope.** When a converge is guarded as managed drift, verify that unrelated resources (bucket, OIDC provider, role trust) read back as `current` first, so `--force` re-puts only the intended resource.
+
+## Related Issues
+
+- [`workflow-issues/gateway-first-deploy-cascade-2026-05-20.md`](../workflow-issues/gateway-first-deploy-cascade-2026-05-20.md) — upstream-contract verification precedent (verify-at-tag mindset).
+- [`workflow-issues/gateway-deploy-stale-image-2026-05-31.md`](../workflow-issues/gateway-deploy-stale-image-2026-05-31.md) — pinned-ref vs actual-running-code freshness discipline.
+- [`best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md`](../best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md) — the sibling credential-boundary fix from the same rollout.
+- Operator procedure: [`docs/runbooks/agent-s3-durable-storage.md`](../../runbooks/agent-s3-durable-storage.md).
+- PRs: #1022 (key-layout fix), #1014 (credential boundary).


### PR DESCRIPTION
Three docs from the `fro-bot/agent` S3 durable-storage rollout — two new compound learnings plus a targeted runbook refresh.

## New docs

**`integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md`**
The provisioned IAM grants encoded an S3 key layout that did not match what the pinned action `fro-bot/agent@v0.96.0` actually writes, causing `AccessDenied` on the coordination-lock `PutObject` during the rollout smoke. Captures the **source-authority invariant**: verify a mirrored upstream contract against the actual upstream source at the pinned ref — internal self-consistency between two local modules is not verification.

**`best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md`**
When a CLI shells out to a cloud CLI under a dedicated identity, build a default-deny hermetic child environment (dedicated creds only, `AWS_CONFIG_FILE`/`AWS_SHARED_CREDENTIALS_FILE` forced to `/dev/null`) rather than inheriting `process.env` — which, with Bun auto-loading the repo-root `.env`, silently selected the wrong AWS identity.

## Runbook refresh

**`runbooks/agent-s3-durable-storage.md`** — documented the ambient-AWS failure mode (Bun `.env` auto-load → wrong identity wins) and the hermetic `/dev/null` config-file detail it previously omitted, with a cross-link to the new best-practices learning.

## Notes

Docs-only — no changeset, no deploy. Frontmatter validated against the solutions schema; cross-references resolve. Reviewed for snippet accuracy against the real source and for secret leakage (none).