### PR TITLE
docs(dashboard): capture image-retention rollout

### DIFF
--- a/docs/plans/2026-08-01-001-fix-dashboard-deploy-image-retention-plan.md
+++ b/docs/plans/2026-08-01-001-fix-dashboard-deploy-image-retention-plan.md
@@ -1,13 +1,34 @@
 ---
 title: "fix: Guard dashboard deploy image retention"
 type: fix
-status: active
+status: completed
 date: 2026-08-01
 origin: docs/brainstorms/2026-08-01-dashboard-deploy-image-retention-requirements.md
 deepened: 2026-08-01
+completed: 2026-08-03
 ---
 
 # fix: Guard dashboard deploy image retention
+
+> **Status note:** Completed on 2026-08-03 against current `main` (`4c006fc`). The dashboard-local retention repair shipped and passed production replacement, audit-pin, same-target, and kernel-lock evidence. This document remains the historical design intent; the dispositions and shipped hardening below record what actually landed.
+
+## Shipped Reality
+
+The shipped implementation is in `apps/dashboard/src/remote-deploy.ts`, with behavior coverage in `apps/dashboard/src/remote-deploy.test.ts`, integrated through `apps/dashboard/src/deploy.ts` and its tests. Both deploy entry paths now use one SSH transaction whose lock-owning process performs inspection, prune, acquisition, active-file mutation, and runtime convergence. The transaction uses a fixed remote program, data-only framed stdin, a sanitized remote environment, kernel `flock` at `/run/dashboard-deploy/lock` with a 180-second wait, a 900-second remote timeout with a 15-second kill-after, and a 960-second caller watchdog. It enforces the 6 GiB floor after prune and acquisition, plus a post-convergence readback; verifies exact cached `repository@digest` images before pulling; publishes active files one at a time with Compose last; and runs advisory probes and audit write-back after the lock is released.
+
+### Implementation-time deviations and hardening
+
+- ControlMaster was not retained; the shipped path uses one supervised SSH transaction rather than connection reuse or a secondary mutating session.
+- Tests include a real Linux kernel-flock lifecycle test and a deterministic stage barrier. The harness keeps BSD and GNU `stat` command forms separate.
+- The production `%F` empty-file failure was fixed in PR #1007 by checking numeric owner, group, and mode while retaining independent file-shape checks.
+- Beyond the origin document's minimum evidence wording, PR #1010 added post-convergence capacity, persistent-state, and prior-image evidence, plus full container-ID normalization for Compose/runtime readback.
+- Caller timeout handling implements the required `TERM` → bounded wait → `KILL` → process reap semantics before settling output readers.
+
+The prior image is inspectable immediately after a replacement. That guarantee ends at the next deployment attempt's pre-prune phase; the next attempt may remove it.
+
+See the shipped production-proof guidance in [`docs/solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md`](../solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md) and the Linux harness/deadline guidance in [`docs/solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md`](../solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md).
+
+---
 
 ## Overview
 
@@ -29,22 +50,22 @@ Deploy-time cleanup is the selected policy owner because the safety proof must h
 
 ## Requirements Trace
 
-| ID | Plan commitment |
-|---|---|
-| R1 | One remote process-bound lock covers inspection, cleanup, image acquisition, active-file mutation, and runtime convergence for both deploy entry paths. |
-| R2 | Every deploy records deterministic before/after container, image, mount, and integer free-byte evidence. |
-| R3 | Cleanup uses unused-image pruning only; running/stopped container references, volumes, and active Compose state are preserved. |
-| R4 | Free-space measurement resolves the filesystem backing Docker/containerd storage and fails closed on absent or malformed evidence. |
-| R5 | A fixed 6 GiB floor is proven after prune and again after acquisition; active-state mutation is blocked when either gate is unmet. |
-| R6 | Pruning is unconditional and any prune error hard-stops the deployment before target acquisition. |
-| R7 | The exact expected image set is verified locally or pulled and verified before active Compose mutation. |
-| R8 | Cleanup is pre-pull only, leaving the replaced image locally present as rollback capacity until the next deployment's pre-pull prune. |
-| R9 | GitHub Actions and local deploys converge on the same deployment engine and remote lock. |
-| R10 | Lock contention and partial failures terminate predictably without stale-lock cleanup or false success. |
-| R11 | Existing digest verification, health checks, public probes, and audit-PR behavior remain intact. |
-| R12 | Logs identify the failed stage and report redacted, deterministic retention evidence without exposing secrets. |
-| R13 | Rerunning after a failed or interrupted deployment reconciles from observed host state without manual lock removal. |
-| R14 | Lock, prune, and storage-probe commands remain fixed host-controlled operations; validated deploy inputs appear only where the selected image/config requires them. |
+| ID | Plan commitment | Disposition |
+|---|---|---|
+| R1 | One remote process-bound lock covers inspection, cleanup, image acquisition, active-file mutation, and runtime convergence for both deploy entry paths. | **Completed** — one lock-owning SSH transaction. |
+| R2 | Every deploy records deterministic before/after container, image, mount, and integer free-byte evidence. | **Completed** — baseline, post-prune, post-acquisition, and post-convergence evidence ship. |
+| R3 | Cleanup uses unused-image pruning only; running/stopped container references, volumes, and active Compose state are preserved. | **Completed** — image-only prune; container and volume state is preserved. |
+| R4 | Free-space measurement resolves the filesystem backing Docker/containerd storage and fails closed on absent or malformed evidence. | **Completed** — Docker/containerd backing mounts are resolved, deduplicated, and fail closed. |
+| R5 | A fixed 6 GiB floor is proven after prune and again after acquisition; active-state mutation is blocked when either gate is unmet. | **Completed** — both gates plus post-convergence capacity readback are enforced. |
+| R6 | Pruning is unconditional and any prune error hard-stops the deployment before target acquisition. | **Completed** — prune failure is terminal. |
+| R7 | The exact expected image set is verified locally or pulled and verified before active Compose mutation. | **Completed** — exact cache verification precedes pull and publication. |
+| R8 | Cleanup is pre-pull only, leaving the replaced image locally present as rollback capacity until the next deployment's pre-pull prune. | **Completed** — bounded prior-image inspectability is recorded honestly. |
+| R9 | GitHub Actions and local deploys converge on the same deployment engine and remote lock. | **Completed** — both paths use the same remote transaction. |
+| R10 | Lock contention and partial failures terminate predictably without stale-lock cleanup or false success. | **Completed** — contention, deadlines, stages, and process lifecycle are deterministic. |
+| R11 | Existing digest verification, health checks, public probes, and audit-PR behavior remain intact. | **Completed** — probes and audit behavior remain downstream of convergence. |
+| R12 | Logs identify the failed stage and report redacted, deterministic retention evidence without exposing secrets. | **Completed** — allowlisted evidence and safe failure codes are emitted. |
+| R13 | Rerunning after a failed or interrupted deployment reconciles from observed host state without manual lock removal. | **Completed** — kernel lock release and same-target reconciliation are verified. |
+| R14 | Lock, prune, and storage-probe commands remain fixed host-controlled operations; validated deploy inputs appear only where the selected image/config requires them. | **Completed** — fixed program, sanitized environment, and data-only payload boundary ship. |
 
 ---
 
@@ -70,8 +91,8 @@ Deploy-time cleanup is the selected policy owner because the safety proof must h
 
 ### Relevant Code and Patterns
 
-- `apps/dashboard/src/deploy.ts` is the single deployment engine used by the GitHub Actions workflow and local CLI path. Its input validation, digest resolution, secret handling, Compose generation, runtime digest check, and bounded public probes remain authoritative.
-- `apps/dashboard/src/deploy.test.ts` already injects process, DNS, fetch, and sleep seams; new failure-order and single-session coverage should extend that behavior-oriented harness.
+- `apps/dashboard/src/deploy.ts` remains the orchestrator used by the GitHub Actions workflow and local CLI path. Its input validation, digest resolution, secret handling, Compose generation, runtime digest check, and bounded public probes remain authoritative; `apps/dashboard/src/remote-deploy.ts` owns the fixed remote transaction and payload boundary.
+- `apps/dashboard/src/deploy.test.ts` and `apps/dashboard/src/remote-deploy.test.ts` cover the orchestration, process lifecycle, payload, ordering, evidence, and Linux lock seams.
 - `packages/cli/src/commands/dashboard/deploy.ts` already routes local deployment to the same dashboard deploy script and remote deployment to the existing workflow. No new entry point is needed.
 - `.github/workflows/deploy-dashboard.yaml` already serializes dashboard workflow runs and opens the compose-pin audit PR after a successful deploy. The remote host lock adds parity for local runs and protects against cross-entry overlap.
 - `apps/gateway/src/deploy.ts` demonstrates safe `docker image prune -af` usage, but its best-effort policy is not reusable because dashboard cleanup must produce evidence and fail closed.
@@ -84,6 +105,8 @@ Deploy-time cleanup is the selected policy owner because the safety proof must h
 - `docs/solutions/integration-issues/dashboard-caddy-bind-mount-stale-reload-2026-07-26.md`: file-write success does not prove live runtime state; force Caddy convergence and verify the running service.
 - `docs/solutions/integration-issues/dashboard-operator-session-container-hairpin-2026-06-21.md`: retain runner-side public probes; host/container-local public-hostname probes are not equivalent network evidence.
 - `docs/solutions/best-practices/major-version-upstream-upgrade-playbook-2026-05-29.md`: immutable identity and a preserved rollback anchor matter more than optimistic success output.
+- [`docs/solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md`](../solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md): replacement, audit-pin, and same-target production proofs are distinct.
+- [`docs/solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md`](../solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md): preserve Linux lock, stat, stage-barrier, and deadline semantics in tests.
 
 ### External References
 
@@ -197,6 +220,7 @@ flowchart TB
   - Error path: remote process cancellation or nonzero exit surfaces the transaction stage and does not report success.
   - Syntax: the generated transaction passes non-executing shell syntax validation without snapshotting arbitrary script prose.
 - **Verification:** The transaction boundary is independently testable, secret-safe, dashboard-specific, and ready to own all remote deploy operations.
+- **Disposition:** **Completed.** `remote-deploy.ts` and `remote-deploy.test.ts` ship the fixed program, framed data-only payload, sanitized environment, allowlisted evidence, and supervised process lifecycle.
 
 ### U2. Replace fragmented SSH mutation with one locked remote transaction
 
@@ -225,6 +249,7 @@ flowchart TB
   - Entry parity: versioned workflow inputs and committed-pin local mode both invoke the same remote transaction contract.
   - Security: lock/prune/probe command text is fixed and unaffected by version, digest, domain, or secret values.
 - **Verification:** Concurrent local/workflow deploys cannot interleave remote phases, and the existing preflight boundaries remain intact.
+- **Disposition:** **Completed.** Both entry paths use one lock-owning SSH transaction; ControlMaster and secondary mutating sessions are not part of the shipped path, and the Linux lock lifecycle is tested directly.
 
 ### U3. Add deterministic audit, prune, and headroom gates
 
@@ -254,6 +279,7 @@ flowchart TB
   - Safety: the transaction never invokes volume prune, container prune, Compose teardown, `docker system prune`, or direct containerd deletion.
   - Diagnostics: a floor failure identifies the limiting mount and stopped-container image pins without logging secrets or private file contents.
 - **Verification:** Every deployment either proves trustworthy post-prune headroom or terminates before pulling/writing anything active.
+- **Disposition:** **Completed.** The shipped transaction performs unconditional image-only prune, mount-aware fail-closed evidence parsing, and the first 6 GiB gate before acquisition.
 
 ### U4. Acquire exact images before active Compose mutation
 
@@ -290,6 +316,7 @@ flowchart TB
   - Partial mutation: support-file replacement before Compose publication, Compose publication before `up`, and dashboard convergence before Caddy convergence each report distinct actual state, perform no automatic rollback, and remain safely rerunnable.
   - Retention: after successful replacement, the prior image remains local because no post-deploy prune runs; the guarantee ends at the next deployment's pre-pull prune.
 - **Verification:** Acquisition failures cannot rewrite desired state, successful deploys run the exact expected image set, and the replaced dashboard image remains local until the next deployment's cleanup phase.
+- **Disposition:** **Completed.** Exact cache verification precedes pull, the second 6 GiB gate and post-convergence readback are enforced, active files publish with Compose last, and prior-image inspectability is explicitly bounded by the next deployment attempt's pre-prune.
 
 ### U5. Preserve entry-path, probe, and audit behavior
 
@@ -320,6 +347,7 @@ flowchart TB
   - CLI parity: `--local` still rejects image inputs, remote dispatch still accepts the established version/digest contract, and no cleanup override is introduced.
   - Rerun: the same target after an interrupted post-mutation attempt re-audits, reacquires/verifies images, replaces active files with the same per-file/Compose-last ordering, and converges without manual lock cleanup.
 - **Verification:** Existing callers observe the same inputs and success artifacts while all host mutation is protected by the new lifecycle.
+- **Disposition:** **Completed.** Workflow and local modes share the transaction; advisory probes run after unlock, and versioned audit write-back remains post-success while audit-pin commits intentionally skip automatic deployment to prevent a loop.
 
 ### U6. Update dashboard operations documentation
 
@@ -337,6 +365,7 @@ flowchart TB
   - Preserve existing secret, volume, listener-data, Caddy, and no-on-host-build warnings.
 - **Test scenarios:** Test expectation: none — these files document behavior already covered by executable deploy tests and production verification; do not add file-content tests.
 - **Verification:** A future operator can distinguish lock contention, prune failure, low-headroom failure, acquisition failure, and post-mutation degradation and can rerun or roll back without destructive cleanup.
+- **Disposition:** **Completed.** `apps/dashboard/AGENTS.md`, `apps/dashboard/README.md`, and `docs/runbooks/dashboard-released-image-rollback.md` document the shipped lock, evidence, bounded retention, and rerun/rollback posture.
 
 ### U7. Verify the policy on the production deployment path
 
@@ -361,7 +390,17 @@ flowchart TB
   - Integration: normal deployment prunes eligible unused images, passes the floor, deploys the exact digest, and leaves persistent volumes/data intact.
   - Integration: same-target rerun succeeds from observed host state and emits complete redacted evidence.
   - Integration: audit PR contains the digest verified by the completed versioned transaction and is opened only after that deployment succeeds.
+
+#### Shipped evidence
+
+- **R1, R10, R13:** A separate production lock drill held `/run/dashboard-deploy/lock` for 240 seconds. The contender waited 180.241 seconds, exited 75, and stopped before payload decode or mutation. This drill was separate from the deployment runs below.
+- **R2-R8, R10-R12:** Production run `30785307051` replaced `2026.08.0` with `2026.08.1`, verified dashboard digest `sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64`, and retained the prior dashboard digest locally after convergence.
+- **R7, R11:** Audit PR `#1021` pinned that exact digest. Its merge was intentionally excluded from automatic deployment so the audit write-back could not create a deployment loop.
+- **R12, R13:** Explicit environment-gated same-target run `30786511189` used committed-pin/cache mode, reconverged the identical digest, passed capacity, persistent-state, normal lock acquisition, and health evidence, and opened no audit PR.
+- The prior image remained inspectable immediately after replacement; the guarantee ends at the next deployment attempt's pre-prune phase.
+
 - **Verification:** Production remains healthy, all target/Compose/runtime/audit identities match, at least 6 GiB remains free after convergence, persistent data/volumes remain, and the replaced digest is locally inspectable immediately after deployment.
+- **Disposition:** **Completed.** U7's lock, replacement, audit-pin, and same-target proofs are recorded above.
 
 ---
 
@@ -404,12 +443,12 @@ flowchart TB
 - **Reuse boundary:** Keep implementation dashboard-local; gateway remains reference code only.
 - **Lock end:** Release after remote runtime health and digest convergence; keep advisory public probes and point-in-time audit work outside the host mutation lock.
 
-### Deferred to Implementation
+### Resolved During Implementation
 
-- **Remote script factoring:** The implementer may adjust helper names and payload framing while preserving the fixed non-secret program, data-only stdin, single mutating process, lock, and redaction contracts.
-- **Cache characterization:** Confirm Docker's local multi-arch reference representation against the real dashboard image. If exact canonical identity cannot be proven locally, retain the cache check only as a miss detector and require registry acquisition.
-- **Evidence rendering:** Exact human-readable formatting may follow existing deploy log style as long as machine-significant values remain deterministic and secrets stay redacted.
-- **Shell behavior harness:** Choose the smallest executable test harness that exercises failure ordering without adding production command configurability or file-content tests.
+- **Remote script factoring:** Implemented in `apps/dashboard/src/remote-deploy.ts` with a fixed non-secret program, data-only framed stdin, one mutating process, kernel lock, sanitized environment, and redacted evidence boundaries. No ControlMaster or secondary mutating session was retained.
+- **Cache characterization:** The shipped path verifies every staged image by exact canonical `repository@digest` before deciding to pull; committed-pin same-target production evidence exercised the cache path successfully.
+- **Evidence rendering:** Implemented as deterministic, allowlisted stage and evidence lines, including post-convergence capacity, persistent-state, prior-image, and normalized runtime identity readbacks.
+- **Shell behavior harness:** Implemented with the unprivileged deterministic harness for ordering and failure tests, a real Linux kernel-flock lifecycle test, an observed stage barrier rather than a fixed sleep, and separate BSD/GNU `stat` paths. Caller timeout tests cover `TERM`, `KILL`, reap, and settled output readers.
 
 ---
 
@@ -484,11 +523,13 @@ flowchart TB
 ## Sources and References
 
 - **Origin document:** `docs/brainstorms/2026-08-01-dashboard-deploy-image-retention-requirements.md`
-- **Primary implementation:** `apps/dashboard/src/deploy.ts`
-- **Primary tests:** `apps/dashboard/src/deploy.test.ts`
+- **Primary implementation:** `apps/dashboard/src/deploy.ts`, `apps/dashboard/src/remote-deploy.ts`
+- **Primary tests:** `apps/dashboard/src/deploy.test.ts`, `apps/dashboard/src/remote-deploy.test.ts`
 - **Workflow:** `.github/workflows/deploy-dashboard.yaml`
 - **CLI entry:** `packages/cli/src/commands/dashboard/deploy.ts`
 - **Gateway cleanup precedent:** `apps/gateway/src/deploy.ts`
 - **Rollback runbook:** `docs/runbooks/dashboard-released-image-rollback.md`
+- **Shipped proof solution:** [`docs/solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md`](../solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md)
+- **Linux harness solution:** [`docs/solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md`](../solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md)
 - **Incident recovery context:** dashboard release `2026.07.43` and infra audit PR `#994`
 - **External:** util-linux `flock(1)`, Docker image-prune docs, Linux `findmnt(8)`/`statfs(2)`, and Bun subprocess docs

--- a/docs/solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md
+++ b/docs/solutions/workflow-issues/dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md
@@ -1,0 +1,205 @@
+---
+title: 'Dashboard deployment correctness needs replacement, audit-pin, and same-target proofs'
+date: 2026-08-03
+category: workflow-issues
+module: apps/dashboard
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+applies_when:
+  - A production deployment replaces a digest-pinned dashboard image and writes the resulting pin back to the repository
+  - The audit-pin commit is intentionally excluded from automatic dashboard deployment
+  - A same-target deployment must validate the committed pin through the cache-first path
+tags:
+  - dashboard
+  - deployment
+  - image-retention
+  - digest-pinning
+  - convergence
+  - audit-pin
+  - github-actions
+  - docker-compose
+---
+
+# Dashboard deployment correctness needs three independent proofs
+
+## Context
+
+The dashboard deploy now has a locked, digest-first remote transaction. The relevant implementation landed in [PR #1005](https://github.com/marcusrbrown/infra/pull/1005), was hardened for GNU empty lock metadata in [PR #1007](https://github.com/marcusrbrown/infra/pull/1007), and gained post-convergence evidence plus container-ID normalization in [PR #1010](https://github.com/marcusrbrown/infra/pull/1010). This document is grounded against the current `main` tree at [`4c006fc`](https://github.com/marcusrbrown/infra/commit/4c006fc), with the production sequence below occurring immediately before and after the dashboard pin merge.
+
+The durable lesson is that deployment correctness required **three distinct production proofs**:
+
+1. **Replacement proof:** the requested release digest was staged, published, and is running.
+2. **Audit-pin proof:** the successful deployment produced the reviewed Compose pin recorded in `main`.
+3. **Same-target proof:** an explicit, environment-gated deployment from the committed pin reconverged the identical digest through the cache path without opening another audit PR.
+
+One green workflow does not establish all three.
+
+## Problem
+
+A versioned deployment can be healthy and still leave an incomplete evidence chain. The remote transaction proves the new image is live, but the audit-pin commit is a repository write-back that is deliberately skipped by the normal deploy router to avoid a deployment loop. Merging that audit commit therefore does not itself prove that the committed pin was deployed.
+
+There were several smaller proof gaps in the same boundary:
+
+- A capacity check before acquisition did not prove that the host still had the required headroom after Compose recreated the stack.
+- A staged image, active Compose file, and running container could be checked at different times without an explicit digest-parity contract.
+- The replaced image was intentionally retained only until the next deployment attempt, so local inspectability was bounded rollback evidence, not durable storage.
+- Caddy's persistent state needed explicit runtime evidence; seeing a healthy dashboard container alone did not prove that `caddy_data` and `caddy_config` survived recreation.
+- `docker compose ps -q` may return a short container ID while a full-ID inventory returns the same container with 64 characters. Comparing those strings directly can make a correct convergence look unverifiable.
+
+## Replacement proof: run 30785307051
+
+[Production run 30785307051](https://github.com/marcusrbrown/infra/actions/runs/30785307051) was the versioned deployment of `2026.08.1`. It checked out `main` at `3b9639090e5af675751293623579acd5352e1adb`, dispatched with the expected digest, and completed successfully at `2026-08-03T04:50:14Z`.
+
+The exact dashboard digest was:
+
+```text
+sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64
+```
+
+The production evidence formed a digest-parity chain across the release, staged, active, and runtime surfaces:
+
+| Surface | Run evidence | Result |
+| --- | --- | --- |
+| Release input | `DEPLOY_DIGEST: sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64` | Requested digest |
+| Staged acquisition | `evidence=image-verified:ghcr.io/fro-bot/dashboard@sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64` | Exact repository digest verified after pull |
+| Active Compose | `evidence=active-compose:post-convergence:ref=ghcr.io/fro-bot/dashboard:2026.08.1@sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64` | Published pin matches |
+| Runtime | `evidence=runtime-digest:sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64` and `evidence=running-dashboard:post-convergence:digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;health=healthy` | Running digest matches and is healthy |
+
+The old active image was also captured before mutation:
+
+```text
+evidence=active-compose:baseline:ref=ghcr.io/fro-bot/dashboard:2026.08.0@sha256:0225422b9b870c2cb748ca2868cd98624969ce00f53bdb910a56a24471acf6ce;digest=sha256:0225422b9b870c2cb748ca2868cd98624969ce00f53bdb910a56a24471acf6ce
+evidence=running-dashboard:baseline:digest=sha256:0225422b9b870c2cb748ca2868cd98624969ce00f53bdb910a56a24471acf6ce;health=healthy
+```
+
+The deploy also proved capacity at the final boundary, not only before acquisition:
+
+```text
+evidence=capacity:post-acquisition:free-bytes=19399602176
+evidence=capacity:post-convergence:free-bytes=19403386880
+```
+
+The post-convergence checkpoint is the acceptance boundary. The host must still satisfy the existing 6 GiB floor after dashboard and Caddy have converged; otherwise the deployment must fail rather than report success after a transiently sufficient pre-mutation check.
+
+## Persistent state and inspectability evidence
+
+The same run emitted fixed, redacted persistent-state evidence after convergence:
+
+```text
+evidence=persistent-state:dashboard-data=/data,bind,writable,canonical,uidgid=1000:1000,mode=0700;caddy-data=/data,volume,writable,labels=dashboard/caddy_data;caddy-config=/config,volume,writable,labels=dashboard/caddy_config
+```
+
+This proves the dashboard's `/data` bind mount is the canonical writable `1000:1000` directory and that Caddy has both writable named volumes with the expected Compose project and volume labels. It is the runtime proof that Caddy recreation preserved persistent volume state. Do not replace this with `docker compose down -v`; that destroys Caddy's ACME/TLS state.
+
+The replaced dashboard image was still locally inspectable immediately after replacement:
+
+```text
+evidence=prior-dashboard:post-convergence:digest=sha256:0225422b9b870c2cb748ca2868cd98624969ce00f53bdb910a56a24471acf6ce;local-inspectable=true
+```
+
+That retention is deliberately bounded. Pruning occurs at the beginning of the next deployment attempt, so the prior image is a temporary rollback generation, not a permanent rollback guarantee. The next attempt may remove it.
+
+## Normalize container identity before inspection
+
+Compose can emit a short ID while the inventory command emits the full ID. The convergence readback must request and compare canonical full IDs:
+
+```sh
+docker compose ps --no-trunc -q dashboard
+docker ps --no-trunc \
+  --filter 'label=com.docker.compose.project=dashboard' \
+  --filter 'label=com.docker.compose.service=dashboard' \
+  --format '{{.ID}}'
+```
+
+The `--no-trunc` change is part of [PR #1010](https://github.com/marcusrbrown/infra/pull/1010). The test case deliberately supplies `abcdef123456` from Compose and `abcdef1234567890` from inventory, then requires the full-ID path to succeed. Evidence output does not expose raw container IDs; normalize internally and emit only the fixed allowlisted evidence shapes.
+
+## Audit-pin proof: PR #1021 is evidence-only
+
+After the remote transaction converged and the advisory probes finished, the versioned workflow wrote the exact generated Compose pin into its worktree and opened [audit PR #1021](https://github.com/marcusrbrown/infra/pull/1021). The run log shows the ordering:
+
+```text
+✓ Remote dashboard transaction converged
+✓ Same-origin operator health check passed: .../operator/health → 200
+✓ Public HTTPS probe succeeded: .../api/healthz
+✓ Updated local compose pin: .../apps/dashboard/docker-compose.yaml
+✓ Deploy complete.
+```
+
+The audit PR commit was [`741524b`](https://github.com/marcusrbrown/infra/commit/741524b171a4d4455db47bebc8b780aa1a162ce3), and [PR #1021](https://github.com/marcusrbrown/infra/pull/1021) merged as [`bcf3d44`](https://github.com/marcusrbrown/infra/commit/bcf3d448c374faf4bf6f810101e69514f203eb81). It changed the committed dashboard pin from `2026.08.0@sha256:0225422b...` to `2026.08.1@sha256:85c114ef...`.
+
+The pin write-back is **evidence-only**. It records what already deployed successfully; it is not a second authorization path and it must not be treated as proof that the post-merge committed pin has reconverged in production.
+
+The deploy router explicitly excludes a dashboard commit whose message starts with `chore(dashboard): pin image to ` from automatic deployment in [`deploy.yaml`](https://github.com/marcusrbrown/infra/blob/main/.github/workflows/deploy.yaml#L174-L180). That exclusion is intentional: without it, a successful versioned deployment would open an audit PR, merge the pin, trigger another deployment, and repeat the audit write-back indefinitely.
+
+## Same-target proof: run 30786511189
+
+Because the audit-pin commit skips automatic deployment, the committed pin required a separate explicit dispatch. [Production run 30786511189](https://github.com/marcusrbrown/infra/actions/runs/30786511189) was manually dispatched against `main` at `bcf3d448c374faf4bf6f810101e69514f203eb81` on `2026-08-03`. It used the no-version/committed-pin mode behind the `dashboard` environment gate in [`deploy-dashboard.yaml`](https://github.com/marcusrbrown/infra/blob/main/.github/workflows/deploy-dashboard.yaml#L123-L127).
+
+This run is the required same-target proof, not a redundant rerun:
+
+```text
+evidence=active-compose:baseline:ref=ghcr.io/fro-bot/dashboard:2026.08.1@sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64
+evidence=running-dashboard:baseline:digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;health=healthy
+evidence=acquisition:mode=cache
+evidence=image-verified:ghcr.io/fro-bot/dashboard@sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64
+evidence=storage:post-convergence:probe=/var/lib/docker,/var/lib/containerd;mount=/;source=/dev/vda1;fstype=ext4;free-bytes=19422998528
+evidence=capacity:post-convergence:free-bytes=19422998528
+evidence=active-compose:post-convergence:ref=ghcr.io/fro-bot/dashboard:2026.08.1@sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64
+evidence=running-dashboard:post-convergence:digest=sha256:85c114ef372d1aa99a281797be48a43dd651c7c0e2b878f302d94e73dd1f2f64;health=healthy
+evidence=persistent-state:dashboard-data=/data,bind,writable,canonical,uidgid=1000:1000,mode=0700;caddy-data=/data,volume,writable,labels=dashboard/caddy_data;caddy-config=/config,volume,writable,labels=dashboard/caddy_config
+```
+
+The raw `prior-dashboard` line is intentionally omitted here. In same-target mode it equals the
+current digest and describes the pre-deploy baseline, not a distinct replaced generation. The
+replacement run is the retention proof; this run is the idempotent reconvergence proof.
+
+The run also showed the audit step as **skipped**, because no version input was supplied. It therefore reconverged the committed pin through the exact cache path and created no redundant audit PR. The two advisory probes again passed: same-origin operator health returned `200`, and the public `/api/healthz` probe succeeded.
+
+## Cache is a safety mechanism, not deployment authorization
+
+The cache-first path is safe only because it verifies the complete exact staged image set by `repository@digest`. Run 30786511189 recorded `acquisition:mode=cache` and verified both the dashboard digest above and the pinned Caddy digest:
+
+```text
+evidence=image-verified:caddy@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+```
+
+A cached image can make rollback or same-target reconvergence possible when the registry is unavailable, and a failed pull may fall back only if the complete exact cache is present. A tag-only image, a wrong digest, or an image merely left over from a prior deploy is not enough.
+
+Conversely, cache presence is **not authorization to deploy an unverified image**. Authorization still comes from the reviewed Compose pin or an explicit versioned dispatch whose resolved GHCR digest matches its supplied digest. If the image has not passed that release and digest verification, do not publish it just because Docker can find it locally. The rollback runbook records the same boundary: cache may assist recovery, but the reviewed Compose pin plus the normal gated deploy remains the source of truth.
+
+## What did not work
+
+- **Treating one green versioned workflow as the whole proof.** It proved replacement and enabled the audit write-back, but not deployment of the resulting committed pin.
+- **Treating the audit PR merge as a deployment.** The router intentionally skips the `chore(dashboard): pin image to ...` commit to prevent loops. A separate environment-gated dispatch is required.
+- **Checking capacity only before acquisition.** Image pull and Compose convergence can change disk usage; the post-convergence checkpoint is the final capacity acceptance boundary.
+- **Comparing a short Compose ID with a full inventory ID.** Use `--no-trunc` on both readbacks and normalize before inspection.
+- **Assuming the prior image is retained forever.** It remains inspectable only until the next deployment attempt's pre-acquisition prune.
+- **Treating any local cache hit as permission to deploy.** Exact digest verification and the reviewed/explicit release contract remain mandatory.
+
+## Durable procedure
+
+For a versioned dashboard release:
+
+1. Dispatch the environment-gated versioned workflow with the release version and, when available, the expected digest.
+2. Require exact release/staged/active/runtime digest parity.
+3. Require post-acquisition and post-convergence capacity checks; the latter must remain above the 6 GiB floor.
+4. Require explicit dashboard `/data`, Caddy `/data`, and Caddy `/config` persistent-state evidence.
+5. Require the prior digest to remain locally inspectable when a replacement occurred, while treating that retention as bounded.
+6. Run the advisory probes only after remote convergence; open the audit pin only after those steps succeed.
+7. Merge the audit pin, then explicitly dispatch the no-version committed-pin mode through the `dashboard` environment gate.
+8. Require same-target cache/committed-pin mode to verify the identical digest, reconverge it, pass the same evidence gates, and skip creation of another audit PR.
+
+For rollback, revert or otherwise review a specific Compose `tag@digest` pin and deploy it through the normal gated path. Never substitute an unverified cached image for that authorization.
+
+## Related
+
+- [PR #1005 — prevent deploy disk exhaustion](https://github.com/marcusrbrown/infra/pull/1005)
+- [PR #1007 — handle GNU empty lock metadata](https://github.com/marcusrbrown/infra/pull/1007)
+- [PR #1010 — verify post-convergence deploy state](https://github.com/marcusrbrown/infra/pull/1010)
+- [PR #1021 — pin image to 2026.08.1](https://github.com/marcusrbrown/infra/pull/1021)
+- [Run 30785307051 — versioned replacement](https://github.com/marcusrbrown/infra/actions/runs/30785307051)
+- [Run 30786511189 — same-target committed-pin reconvergence](https://github.com/marcusrbrown/infra/actions/runs/30786511189)
+- [`apps/dashboard/AGENTS.md`](https://github.com/marcusrbrown/infra/blob/main/apps/dashboard/AGENTS.md) — current deploy contract and anti-patterns
+- [`dashboard-released-image-rollback.md`](https://github.com/marcusrbrown/infra/blob/main/docs/runbooks/dashboard-released-image-rollback.md) — reviewed-pin rollback procedure and bounded cache retention
+- [`dashboard-caddy-bind-mount-stale-reload-2026-07-26.md`](../integration-issues/dashboard-caddy-bind-mount-stale-reload-2026-07-26.md) — Caddy recreation and persistent-volume warning

--- a/docs/solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md
+++ b/docs/solutions/workflow-issues/linux-deploy-harness-kernel-semantics-and-deadlines-2026-08-03.md
@@ -1,0 +1,150 @@
+---
+title: Production deploy harnesses must preserve Linux kernel semantics and deadline behavior
+date: 2026-08-03
+category: workflow-issues
+module: apps/dashboard
+problem_type: workflow_issue
+component: testing_framework
+severity: high
+applies_when:
+  - A deploy test replaces Linux primitives such as `flock`, `timeout`, or `stat` with stubs
+  - A shell harness runs on BSD/macOS while the production transaction runs on Linux
+  - A generated remote transaction has both remote and caller-side deadlines
+  - A contention test needs to prove lock ownership, release, and no mutation while waiting
+  - A production deploy path has been hardened but its verification still runs only in a normalized harness
+tags:
+  - dashboard
+  - deploy
+  - linux
+  - flock
+  - shell-harness
+  - deadlines
+  - portability
+  - testing
+---
+
+# Production deploy harnesses must preserve Linux kernel semantics and deadline behavior
+
+## Context
+
+The dashboard deploy is a generated Linux shell transaction, not just a TypeScript function. `apps/dashboard/src/remote-deploy.ts` validates a root-owned runtime directory, acquires `/run/dashboard-deploy/lock`, stages and verifies the payload, prunes images, checks storage, publishes active files, converges Compose, and records post-convergence evidence while the lock remains held. Both the GitHub Actions path and the local CLI path use this one remote transaction; the operational contract is documented in [`apps/dashboard/AGENTS.md`](../../../apps/dashboard/AGENTS.md) and [`apps/dashboard/README.md`](../../../apps/dashboard/README.md).
+
+The test harness must therefore preserve the Linux behaviors that make the transaction safe. A green test on macOS is insufficient when it has replaced the kernel lock with a function, normalized GNU output into BSD output, or used sleeps instead of observing a transaction boundary. PR [#1005](https://github.com/marcusrbrown/infra/pull/1005) introduced the locked transaction, bounded deadlines, Linux harness, and storage gates. PR [#1007](https://github.com/marcusrbrown/infra/pull/1007) fixed a real GNU `stat` incompatibility that had already blocked a production deploy.
+
+## Failure pattern
+
+### Stubbed `flock` can be falsely green
+
+`adaptProgramForUnprivilegedHarness` in `remote-deploy.test.ts` deliberately has a test-only path. Unless `stubFlock: false` or an explicit stub exit code is requested, it selects `REMOTE_TRANSACTION_TEST_PROGRAM` and replaces privileged operations for an unprivileged temporary directory. That path is useful for payload, ordering, storage, and failure tests, but it does not prove kernel mutual exclusion, owner-death release, or elapsed lock-wait behavior.
+
+The production program wraps the complete locked child transaction:
+
+```ts
+`flock -w ${REMOTE_LOCK_WAIT_SECONDS} -E 75 "$LOCK_PATH" /bin/bash -c ${shellQuote(remoteLockedChildProgram)}`
+```
+
+The default harness must not be treated as evidence for that line. A test that makes `flock()` return success can pass while two transactions would actually run concurrently. A test that makes it return `75` proves only the caller's contention mapping and pre-mutation boundary, not the kernel lock itself.
+
+### Platform normalization can hide the production contract
+
+The harness adapts BSD and GNU `stat` separately:
+
+```ts
+const hostFileStat = darwinStat
+  ? '/usr/bin/stat -f "%u:%g:%Lp:%HT" "$1"'
+  : String.raw`command stat -c "%u:%g:%a:%F" "$1"`
+```
+
+That is appropriate for making an unprivileged local harness runnable, but it must not turn a Linux-only contract into a platform-neutral one. The production remote command uses GNU `stat`; the Linux path needs its own execution proof.
+
+GNU `stat -c %F` also has a wording trap: an empty regular file is reported as `regular empty file`, not `regular file`. The original lock check compared the full human-readable type and failed before payload decode or mutation. PR #1007 changed the lock metadata check to numeric owner/group/mode while retaining the independent regular-file and no-symlink checks:
+
+```bash
+lock_stat="$(stat -c "%u:%g:%a" -- "$LOCK_PATH" 2>/dev/null)" || fail "unsafe-path" "lock path stat failed"
+[ "$lock_stat" = "$ROOT_OWNER:600" ] || fail "unsafe-path" "lock path ownership or mode is unsafe"
+```
+
+Use numeric `%u:%g:%a` checks for identity and permissions. Use `[ -f ]` plus `[ ! -L ]` for file shape. Do not make a human-readable `%F` string the sole proof of a regular empty lock file. The harness must exercise both the BSD command form and the GNU command form without claiming that their output vocabulary is identical.
+
+## Required verification shape
+
+### 1. Keep the shell harness for deterministic ordering
+
+The unprivileged harness remains valuable for proving that lock contention stops before `payload-decoded`, `baseline-evidence`, pruning, staging, or active publication. The existing contention test uses a stubbed `flock` exit `75` and expects exactly:
+
+```text
+stage=remote-transaction-started
+stage=lock-contention
+failure=lock-contention
+```
+
+It also asserts that no dashboard root or `attempt.*` staging directory exists. This is a deterministic pre-mutation test, not a kernel-lock test.
+
+Stage output is the synchronization contract. The stage-boundary test requires one `stage=remote-transaction-started` marker immediately before `stage=lock-acquired`. The real-lock test waits for the owner output marker and child PID by reading stdout:
+
+```ts
+while (!firstOutput.includes('stage=lock-acquired\n') || ownerPid === undefined) {
+  const next = await firstReader.read()
+  if (next.done)
+    throw new Error(`lock owner exited before acquisition: ${firstOutput}\nstderr=${await firstStderrPromise}`)
+  firstOutput += firstDecoder.decode(next.value, {stream: true})
+  const pidMatch = /test-child-pid=(\d+)/.exec(firstOutput)
+  if (pidMatch) ownerPid = Number(pidMatch[1])
+}
+```
+
+Do not replace this barrier with `sleep(10)`, polling a guessed elapsed time, or assuming that process creation means lock acquisition. A fixed sleep can race on a busy host and can make a contender test green without ever observing the owner holding the lock.
+
+### 2. Run one real Linux kernel-flock lifecycle test
+
+The `uses the real kernel flock lifecycle and releases it on owner death` test is skipped unless util-linux `flock` supports `--conflict-exit-code`. When available, it:
+
+1. Runs the production transaction program with `stubFlock: false` and a shortened one-second wait only through the test seam.
+2. Waits for `stage=lock-acquired` and the child PID, not a sleep.
+3. Starts a contender and asserts exit `75`, `stage=lock-contention`, and no `payload-decoded` or `baseline-evidence`.
+4. Terminates the lock-owning child and waits for the wrapper to exit.
+5. Runs a retry and asserts successful completion, the same lock inode, and no leftover `attempt.*` directory.
+
+This is the test that proves the kernel owns the lifecycle: contention is real, the lock is released when the owner dies, and no stale-lock cleanup is needed. A platform-normalized or stubbed substitute cannot establish those facts.
+
+### 3. Test the deadline layers as a lifecycle
+
+The current production values are:
+
+| Boundary | Contract |
+| --- | ---: |
+| Kernel lock wait | 180 seconds, `flock` conflict exit `75` |
+| Remote transaction | 900 seconds |
+| Remote kill-after | 15 seconds after `TERM` |
+| Caller watchdog | 960 seconds |
+
+`buildRemoteSshCommand` wraps the remote program with GNU `timeout` using `TERM`, then `KILL` after 15 seconds. The caller-side `runRemoteTransaction` has a separate watchdog. When it fires, the caller must abort output readers, send `SIGTERM`, wait a bounded grace period, send `SIGKILL` if the SSH process is still alive, wait for the process to reap, and settle the output readers before returning the timeout error. The tests `kills and returns when the caller watchdog sees a never-settling process`, `settles cancelled output readers before returning caller timeout`, and `waits for a post-KILL process reap before returning timeout` pin those obligations.
+
+The SSH command wrapper normalizes GNU `timeout` exits `124` and `137` to the reserved `transaction-timeout` result. GNU `timeout` cannot distinguish its own kill-after status `137` from a child that independently exits `137`, so the normalization is deliberately conservative.
+
+The watchdog is not an arbitrary round number. The source requires it to exceed SSH connect timeout plus remote timeout, kill-after, and drain margin: `10 + 900 + 15 + 30 = 955` seconds, so the production default is 960 seconds. Keep that inequality when changing any deadline; otherwise the caller can kill the SSH process before the remote wrapper has completed its own escalation and output drain.
+
+## Production proof
+
+The production lock drill used a holder that retained the lock for 240 seconds and a real contender. The contender failed after **180.241 seconds** with exit **75**, reported lock contention, and stopped before payload decode or any mutation. The 240-second holder / 180.241-second contender drill is separate from GHA deployment runs [30785307051](https://github.com/marcusrbrown/infra/actions/runs/30785307051) and [30786511189](https://github.com/marcusrbrown/infra/actions/runs/30786511189); it is a production lock verification exercise, not a deployment run itself. That proves the bounded wait is enforced against the real kernel lock rather than merely asserted by a stub.
+
+The design intentionally has **no stale-lock cleanup**. The lock file is a stable, root-owned `0600` regular file; the advisory lock is associated with the kernel-held file descriptor, and process death releases it. Deleting or replacing the file to “recover” would create a second race and could let two transactions operate against different inodes. Recovery is to wait for the owner to finish or die, then rerun after the bounded contention failure.
+
+## Reusable guidance
+
+- Separate harness claims: a stubbed shell harness proves ordering and failure boundaries; a real Linux run proves kernel and GNU semantics.
+- Preserve stage markers as barriers. Synchronize on observed output and, where needed, a child PID; never on fixed sleeps.
+- Test the exact generated remote program with `bash -n` and a Linux execution path before treating the TypeScript wrapper as verified.
+- Prefer numeric `stat` fields for owner, group, mode, and size. Keep file-type and symlink checks independent of human-readable GNU wording.
+- Keep the entire remote mutation inside one lock-owning transaction. Do not add a separate lock holder or stale-lock cleanup phase.
+- Verify every deadline layer and the caller's `TERM` → bounded wait → `KILL` → reap sequence. A timeout test that only checks an error string is incomplete.
+- Repeat the production contention drill after changing lock paths, timeout values, generated shell structure, or caller process handling.
+
+For operator recovery after a bounded deploy failure, use [`dashboard-released-image-rollback.md`](../../runbooks/dashboard-released-image-rollback.md); it documents lock contention, transaction timeouts, the no-automatic-rollback posture, and the requirement to inspect state before rerunning.
+
+## Related links
+
+- [`apps/dashboard/AGENTS.md`](../../../apps/dashboard/AGENTS.md)
+- [`apps/dashboard/README.md`](../../../apps/dashboard/README.md)
+- [`dashboard-released-image-rollback.md`](../../runbooks/dashboard-released-image-rollback.md)
+- [`dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md`](dashboard-deploy-proof-replacement-audit-same-target-2026-08-03.md)


### PR DESCRIPTION
## Summary
This doc set captures the image-retention rollout and the verification trail for the production-safe replacement path.

### Linux deploy harness notes
- Added/confirmed guidance for the Linux deploy harness around `flock`, `stat`, and deploy deadlines to reduce race risk and make lock + timing behavior explicit.

### Evidence and rollout sequence
- Documented the replacement → audit-pin → explicit same-target production proof path.
- Production proof references run IDs `30785307051` and `30786511189`, and is aligned to PR `#1021`.

### Plan status reconciliation
- Reconciled the original image-retention plan and marked it completed against shipped work in PRs `#1005`, `#1007`, and `#1010`.

### Verification
- `bun run lint`
- `git diff --check`
- Markdown relative link checks over changed docs
