### PR TITLE
fix(fro-bot): allowlist autoheal health hosts in storage-job egress policy

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -874,6 +874,7 @@ jobs:
             sts.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443 s3.amazonaws.com:443
             s3.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443
             ${{ vars.FRO_BOT_S3_BUCKET }}.s3.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443
+            kw.igg.ms:443 metrics.fro.bot:443 dashboard.fro.bot:443 broker.fro.bot:443
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/runbooks/agent-s3-durable-storage.md
+++ b/docs/runbooks/agent-s3-durable-storage.md
@@ -137,13 +137,14 @@ The operator applies the verifier's diff to `.github/workflows/fro-bot.yaml`. Th
 
 The storage job must also have an explicit positive `timeout-minutes` value. Replace `timeout: 0`; an unbounded job is not an acceptable storage contract. The `aws-actions/configure-aws-credentials` step must request `role-duration-seconds` of at least `7200`, and its `role-session-name` must include the GitHub run ID (and attempt when available) for CloudTrail attribution.
 
-The storage job's harden-runner or equivalent egress policy must allow only:
+The storage job's harden-runner (or equivalent) egress policy stays in `block` mode as defense-in-depth — the scheduled autoheal run ingests untrusted content (issue/PR bodies, CI logs, other repos, live pages) and the job holds credentials (`FRO_BOT_PAT`, and STS/OIDC material reachable through the action's process tree), so an allowlist bounds arbitrary-host exfiltration. It must allow the exact set the storage job needs and nothing more:
 
-- GitHub's OIDC endpoint;
-- AWS STS; and
-- the regional S3 endpoint for the provisioned bucket.
+- GitHub's OIDC endpoint, AWS STS, and the regional S3 endpoint for the provisioned bucket (durable storage);
+- `github.com`, `*.githubusercontent.com`, `registry.npmjs.org`, `nodejs.org` (checkout, `bun install`, `npx agent-browser` binary download);
+- `cliproxy.fro.bot` (model calls); and
+- the deployment health hosts the autoheal prompt probes and reviews (`kw.igg.ms`, `metrics.fro.bot`, `dashboard.fro.bot`, `broker.fro.bot`).
 
-It must not reopen arbitrary outbound egress. Action references in workflow files use `.yaml` files and immutable SHA pins with version comments.
+Because it is fail-closed, a missing host silently breaks the corresponding report-only check (see the `#1026` regression: the four health hosts were absent, so deploy-health curls and the live-site review failed and filed a false outage). Add hosts the autoheal legitimately needs; do not switch to unrestricted egress. Action references in workflow files use `.yaml` files and immutable SHA pins with version comments.
 
 ### 5. Run the verifier again
 


### PR DESCRIPTION
The content/storage split (PR #1013) moved the daily autohealing prompt into the egress-blocked `fro-bot-storage` job, but the harden-runner allowlist omitted the first-party deploy-health hosts the autoheal probes and reviews. Deploy-health curls and the live-site review failed closed on the first scheduled run, filing a false-outage report (#1026).

## Fix

Add the four first-party health hosts to the storage-job allowlist:
`kw.igg.ms`, `metrics.fro.bot`, `dashboard.fro.bot`, `broker.fro.bot`.

**Keep `egress-policy: block` as defense-in-depth.** The scheduled autoheal ingests untrusted content (issue/PR bodies, CI logs, other repos, live pages) and the job holds `FRO_BOT_PAT` plus STS/OIDC material reachable through the action process tree — so bounding arbitrary-host egress is warranted, not optional. An independent review confirmed the storage job is prompt-injectable and credential-bearing, so removing the control (the alternative considered) was rejected in favor of widening it.

`npx agent-browser` downloads its binary from `github.com` / `*.githubusercontent.com` (already allowlisted); its live-site target `kw.igg.ms` is now allowlisted. The runbook documents the full allowlist contract and the `#1026` regression.

## Verification

- Conventions 141/0, lint 0 errors, YAML valid, diff clean.
- Post-merge: a scheduled-equivalent dispatch will confirm deploy-health + live-site review pass under the widened allowlist; harden-runner block-reports name any residual host explicitly (fail-loud). #1026 closes once verified.