### PR TITLE
docs(solutions): autoheal reconciliation deadlock + credentialed-job egress learnings

### DIFF
--- a/docs/solutions/integration-issues/fro-bot-storage-egress-allowlist-false-outage-2026-08-03.md
+++ b/docs/solutions/integration-issues/fro-bot-storage-egress-allowlist-false-outage-2026-08-03.md
@@ -1,0 +1,92 @@
+---
+title: Egress allowlist on the credential-bearing autoheal job blocked its own health checks
+date: 2026-08-03
+category: integration-issues
+module: fro-bot
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "Report-only health curls to kw.igg.ms, metrics.fro.bot, dashboard.fro.bot, broker.fro.bot returned 000 / connection refused"
+  - "npx agent-browser open https://kw.igg.ms failed with net::ERR_CONNECTION_REFUSED"
+  - "The autoheal filed a false-outage issue (#1026) although every endpoint was up"
+  - "DNS resolved for each host but the TLS connection was blocked"
+root_cause: incomplete_setup
+resolution_type: config_change
+related_components:
+  - autoheal
+  - harden-runner
+  - egress
+tags:
+  - fro-bot
+  - harden-runner
+  - egress-allowlist
+  - fail-closed
+  - prompt-injection
+  - credential-bearing
+  - agent-browser
+  - false-outage
+---
+
+# Egress allowlist on the credential-bearing autoheal job blocked its own health checks
+
+## Problem
+
+A content/storage job split (PR #1013) moved the daily-autoheal prompt into the `fro-bot-storage` job, which runs under `step-security/harden-runner` with `egress-policy: block`. The allowlist did not include the first-party deploy-health hosts the autoheal probes or the live-site-review browser target, so those report-only checks failed closed and the autoheal misread the block as an outage.
+
+## Symptoms
+
+- `curl --connect-timeout 10 https://kw.igg.ms` (and `metrics.fro.bot`, `dashboard.fro.bot`, `broker.fro.bot`) returned `000` / "Failed to connect ... port 443".
+- `npx agent-browser open "https://kw.igg.ms"` → `net::ERR_CONNECTION_REFUSED`.
+- `getent hosts` resolved every host correctly — DNS worked; only the TLS connect was blocked.
+- The autoheal filed **#1026** "Public endpoints unreachable from scheduled autoheal" even though all endpoints were healthy.
+
+## What Didn't Work
+
+**Removing harden-runner entirely.** The initial fix direction was to delete the egress block, justified as "the storage job runs operator-only triggers (`schedule`/`workflow_dispatch@main`) with a fixed prompt, and `fro-bot/agent` scrubs `AWS_*` from the model environment, so the credentials are unreachable." An independent security review disproved every premise:
+
+- **The autoheal ingests untrusted content mid-run** — it reads issue/PR/comment bodies, other repositories' files, and drives a headless browser to live pages. Indirect prompt injection enters through that content, so an operator-*triggered* run is not a trusted *session*.
+- **The job holds `FRO_BOT_PAT` in the model session by design.** `configureGhAuth` writes the PAT into `GH_CONFIG_DIR/hosts.yml` specifically so the env-scrubbed model bash can run `gh`; model bash can `gh auth token` / read `hosts.yml` and exfiltrate it.
+- **The AWS/OIDC credentials are reachable via `/proc`.** Env scrubbing (`filter-env.ts` `DENY_PREFIXES = ['AWS_', 'INPUT_']` at the pinned `v0.96.0`) only protects the OpenCode *child*; the parent `fro-bot/agent` action process still holds the credentials, and same-UID descendants can read the ancestor's initial environment via `/proc/<pid>/environ`.
+
+So the storage job is genuinely prompt-injectable and credential-bearing; unrestricted egress would enable arbitrary-host exfiltration. Removal was rejected.
+
+## Solution
+
+**Widen the allowlist; keep `egress-policy: block`** (PR #1029). Add the four first-party health hosts the autoheal legitimately reaches:
+
+```yaml
+allowed-endpoints: >-
+  api.github.com:443 github.com:443 *.githubusercontent.com:443
+  *.actions.githubusercontent.com:443 nodejs.org:443 registry.npmjs.org:443
+  cliproxy.fro.bot:443 sts.amazonaws.com:443
+  sts.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443 s3.amazonaws.com:443
+  s3.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443
+  ${{ vars.FRO_BOT_S3_BUCKET }}.s3.${{ vars.FRO_BOT_S3_REGION }}.amazonaws.com:443
+  kw.igg.ms:443 metrics.fro.bot:443 dashboard.fro.bot:443 broker.fro.bot:443
+```
+
+`npx agent-browser` downloads its binary from `github.com` / `*.githubusercontent.com` (already allowlisted); its live-site target `kw.igg.ms` is now allowlisted.
+
+**Verified live** on run `30797628035` — harden-runner's own endpoint report showed all four health hosts + `cliproxy.fro.bot` as "endpoint called" (none denied), `kw.igg.ms` loaded by the `chrome` process, `EgressPolicy: block` still in force, and the storage path completed with 0 AccessDenied.
+
+## Why This Works
+
+A fail-closed allowlist blocks the TLS connect *after* DNS resolves, so a missing host looks like a connection refusal rather than a policy block. Enumerating every host the agent legitimately reaches makes the allowlist match the job's real network behavior — the report-only checks succeed — while every other destination stays blocked, preserving the exfiltration bound around a credential-bearing, prompt-injectable job.
+
+## Prevention
+
+- **A fail-closed egress allowlist on an agent job must enumerate every host the agent reaches** — health probes, live-site targets, and package/browser-binary downloads. A missing host silently breaks a check and can be misread as an outage.
+- **Audit the agent's actual network behavior before tightening egress.** When a job that runs an LLM agent gains egress restrictions, read what the prompt does on the network first.
+- **Widen, don't remove.** A credential-bearing, prompt-injectable agent job should keep egress bounded as defense-in-depth; removing the control to fix a functionality break trades a real (if partial) exfil bound for none.
+- **A fail-closed allowlist cannot distinguish "blocked by policy" from "endpoint down."** Teach the agent/report to consult the harden-runner block report before declaring an outage.
+
+The honest limit: `api.github.com` is allowlisted and the PAT posts issues, so GitHub itself is an app-layer exfil channel — harden-runner is defense-in-depth, not DLP. It still blocks arbitrary-destination exfiltration, which is why widening beats removing.
+
+## Related Issues
+
+- [`gateway-mention-loop-supervisor-timeout-2026-06-03.md`](gateway-mention-loop-supervisor-timeout-2026-06-03.md) — the fail-closed egress-allowlist precedent: one missing host silently breaks a downstream tool; verify against ground truth.
+- [`gateway-mention-loop-model-config-2026-06-04.md`](gateway-mention-loop-model-config-2026-06-04.md) — adjacent "looks like an egress block, verify actual output" lesson.
+- [`../best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md`](../best-practices/dedicated-hermetic-aws-child-env-for-cli-subprocess-2026-08-03.md) — sibling credential-boundary lesson from the same rollout (env scrubbing is not process isolation).
+- [`agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md`](agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md) — same durable-storage rollout.
+- Issues/PRs: #1026 (false outage), #1013 (the content/storage split), #1029 (fix).

--- a/docs/solutions/workflow-issues/autoheal-single-report-reconciliation-label-anchor-deadlock-2026-08-03.md
+++ b/docs/solutions/workflow-issues/autoheal-single-report-reconciliation-label-anchor-deadlock-2026-08-03.md
@@ -1,0 +1,90 @@
+---
+title: Autoheal single-report reconciliation deadlocked on an unseeded trust-anchor label
+date: 2026-08-03
+category: workflow-issues
+module: fro-bot
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+symptoms:
+  - "13 open 'Daily Autohealing Report — <date>' issues (#897..#1012) accumulated instead of converging to one"
+  - "Every report had author fro-bot and the body marker but no autoheal-report label"
+  - "The autoheal-report label did not exist in the repository at all"
+  - "Each daily run punted all older reports to 'Needs Human Attention' and closed nothing"
+root_cause: incomplete_setup
+resolution_type: workflow_improvement
+related_components:
+  - autoheal
+  - github-issues
+tags:
+  - fro-bot
+  - autoheal
+  - reconciliation
+  - trust-anchor
+  - label
+  - workflow-migration
+  - daily-report
+---
+
+# Autoheal single-report reconciliation deadlocked on an unseeded trust-anchor label
+
+## Problem
+
+The daily-autoheal prompt in `.github/workflows/fro-bot.yaml` enforces a single-report reconciliation contract: exactly one open "Daily Autohealing Report — `<date>`" issue should remain, and older ones are closed as superseded. Trust is gated on a label that was never seeded into the repository, so no report was ever eligible for reconciliation and the reports piled up.
+
+## Symptoms
+
+- 13 daily-report issues (#897 → #1012, 2026-07-21 → 2026-08-02) were simultaneously open.
+- Every one had author `fro-bot` and the body marker `<!-- fro-bot:autoheal-report:v1 -->`, but **none** carried the `autoheal-report` label — the label did not exist in the repo.
+- Each run correctly logged all older reports under "Needs Human Attention" and closed nothing (the contract forbids touching untrusted issues).
+
+## What Didn't Work
+
+**Concluding "PAT permission gap."** A first investigation pass blamed the `FRO_BOT_PAT` for being unable to create/apply labels. That was wrong:
+
+- The PAT applies labels fine — other `fro-bot`-authored issues carry labels (`#933`/`#934` → `bug`, `#925` → `technical-debt`/`code-quality`).
+- The PAT *created* the `autoheal-report` label on the 2026-08-03 run.
+- The `gh label list` that showed no autoheal label was run minutes **before** that day's scheduled run created it — a timing artifact, not proof of a permission failure.
+
+The real cause is a contract/migration gap, not permissions.
+
+## Solution
+
+The reconciliation contract makes the label a load-bearing trust anchor:
+
+```
+b. Managed-report trust boundary: ... An issue can become managed only when
+   `author.login` is exactly `fro-bot`, label `autoheal-report` is present, AND
+   its body contains `<!-- fro-bot:autoheal-report:v1 -->`. A matching title
+   alone is untrusted. Never ... close ... it; link it under "Needs Human
+   Attention" instead.
+c. Ensure label `autoheal-report` exists, then retrieve open issue metadata ...
+e. Close every OTHER trusted managed report ...
+```
+
+But the label's creation was only `gh label create autoheal-report ... 2>/dev/null || true` — errors swallowed, no guarantee it persisted, and no step to adopt reports created before the label existed. With zero trusted reports, the "close every OTHER trusted report" loop had nothing to reconcile.
+
+The forward mechanism self-healed once the 2026-08-03 run created the label and applied it to its report (#1028). The 13 legacy unlabeled reports were then closed in a **one-time manual cleanup**, each with a supersession comment and `--reason "not planned"`:
+
+```bash
+gh issue comment "$n" --body "Superseded by #1028 — current daily autohealing report. ... <!-- fro-bot:autoheal-superseded:v1 canonical=#1028 -->"
+gh issue close "$n" --reason "not planned"
+```
+
+## Why This Works
+
+The reconciliation loop only closes reports **after** trusted classification. Once the label exists and is applied, each run produces exactly one trusted canonical report and supersedes the rest. Legacy reports created before the label existed can never enter the trusted set, so they required an explicit one-time adoption/close outside the automated flow.
+
+## Prevention
+
+- **Seed a contract's trust-anchor resource idempotently and up front.** When a workflow makes a label (or any resource) the load-bearing trust boundary, create it deterministically before it is depended on — do not rely on best-effort creation inside the agent prompt.
+- **Never swallow trust-anchor creation errors.** `2>/dev/null || true` on the label-create hid a contract-breaking failure; a failed create should be visible.
+- **Migrations that add a new trust requirement must adopt pre-existing artifacts.** Reports created before the label existed became permanently orphaned; a migration step should backfill the label onto them (or the contract must expect a one-time manual cleanup).
+- **Surface the deadlock as an anomaly.** "Trusted report count == 0 while N untrusted title collisions exist" is exactly the failure signature — reporting it makes the deadlock visible on day one instead of after a two-week pile-up.
+
+## Related Issues
+
+- [`workflow-issues/fro-bot-schedule-session-bloat-no-op-2026-06-14.md`](fro-bot-schedule-session-bloat-no-op-2026-06-14.md) — same `fro-bot.yaml` daily-autoheal surface, different failure mode (session bloat / silent no-op).
+- [`integration-issues/cliproxy-claude-oauth-refresh-expiry-2026-06-20.md`](../integration-issues/cliproxy-claude-oauth-refresh-expiry-2026-06-20.md) — durable canonical-issue/marker state as health signal (closed/absent == healthy).
+- [`integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md`](../integration-issues/agent-s3-key-layout-diverged-from-pinned-action-2026-08-03.md) — sibling "a contract's assumed authority was never actually verified/seeded."
+- Issues: #1028 (canonical), #905 (introduced the label contract), #897–#1012 (the orphaned reports).


### PR DESCRIPTION
Two compound learnings from the board-cleanup work.

## New docs

**`workflow-issues/autoheal-single-report-reconciliation-label-anchor-deadlock-2026-08-03.md`**
The daily-autoheal single-report reconciliation contract makes an `autoheal-report` label the load-bearing trust anchor, but the label was never seeded into the repo — so no report was ever "trusted managed", the "close superseded" step closed nothing, and 13 daily reports (#897–#1012) piled up. Lesson: seed a contract's trust-anchor resource idempotently, don't swallow its create errors, and migrations that add a trust requirement must adopt pre-existing artifacts. Also documents the "PAT permission gap" misdiagnosis (a timing artifact, not a permission failure).

**`integration-issues/fro-bot-storage-egress-allowlist-false-outage-2026-08-03.md`**
The content/storage split (#1013) moved the autoheal into an egress-blocked job whose allowlist omitted the first-party deploy-health hosts + the live-site browser target, so DNS resolved but TLS was blocked → a false-outage report (#1026). The fix widens the allowlist and keeps `egress-policy: block`. Documents why removal was rejected after security review: the job is prompt-injectable (autoheal reads untrusted content mid-run), holds `FRO_BOT_PAT` in-session by design, and AWS/OIDC creds are reachable via `/proc` despite child-env scrubbing. Verified live via harden-runner's endpoint report.

## Notes

Docs-only — no changeset, no deploy. Frontmatter validated against the solutions schema; all cross-references resolve. Security-reviewed (reasoning confirmed accurate, no secrets).