### PR TITLE
ci(renovate): track renovate-changesets action tags and bump to 0.2.33

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -104,6 +104,23 @@
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'semver-coerced',
     },
+    {
+      customType: 'regex',
+      // bfra-me/.github tags the same commits twice: `v4.16.x` for the repo and
+      // `renovate-changesets@x.y.z` for the action. The built-in github-actions manager resolves
+      // only the repo tags, so this pin sat at 0.2.31 for four months while 0.2.32 shipped.
+      // extractVersionTemplate restricts candidates to the action tag family, and capturing
+      // currentDigest + currentValue together moves the SHA and its comment in one update.
+      // The digest rule above is scoped to matchManagers: ['github-actions'] and does not apply.
+      managerFilePatterns: ['/^\\.github/workflows/renovate-changesets\\.yaml$/'],
+      matchStrings: [
+        'uses:\\s*bfra-me/\\.github/\\.github/actions/renovate-changesets@(?<currentDigest>[a-f0-9]{40})\\s*#\\s*renovate-changesets@(?<currentValue>\\d+\\.\\d+\\.\\d+)',
+      ],
+      depNameTemplate: 'bfra-me/.github',
+      datasourceTemplate: 'github-tags',
+      extractVersionTemplate: '^renovate-changesets@(?<version>.+)$',
+      versioningTemplate: 'semver',
+    },
   ],
   // postUpgradeTasks run after Renovate applies file changes but before the commit.
   // For github-actions manager updates (workflow SHA pins), Renovate does NOT run

--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@e12bc8f1bf2cb475954f0c34147d123ff1bad2c9 # renovate-changesets@0.2.31
+        uses: bfra-me/.github/.github/actions/renovate-changesets@abb57164065c549e7e2867c21dd045e677c53bec # renovate-changesets@0.2.33
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
The `renovate-changesets` action pin sat at `0.2.31` for four months while `0.2.32` was available, and Renovate never proposed the update.

The cause is that `bfra-me/.github` tags the same commits twice — `v4.16.x` for the repo, and `renovate-changesets@x.y.z` for the action. The built-in `github-actions` manager only resolves the repo tags, so this line was effectively unmanaged:

```yaml
uses: bfra-me/.github/.github/actions/renovate-changesets@e12bc8f1... # renovate-changesets@0.2.31
```

Renovate was clearly reading the file — it bumped `actions/checkout` in it twice in July (#758, #895). It just never had a resolvable version for this dependency.

This adds a regex `customManager` that tracks the action's own tag family and bumps the pin to `0.2.33`.

`extractVersionTemplate` restricts candidates to `renovate-changesets@*`, so `v4.16.x` tags aren't considered. Capturing `currentDigest` and `currentValue` in one match means the SHA and its version comment move together, rather than the bare digest churn that #157 disabled — that rule is scoped to `matchManagers: ['github-actions']` and doesn't apply to a `custom.regex` manager.

After this, all three `bfra-me/.github` references resolve to the same commit: the two reusable workflows via `v4.16.47`, and the action via `renovate-changesets@0.2.33`.

## What's in 0.2.33

Two releases' worth. `0.2.32` was never picked up here, and `0.2.33` is a substantial rewrite that derives updates from Renovate's PR body instead of re-parsing lockfiles and Dockerfiles.

Relevant to this repo specifically:

- Docker tags like `22.04 → 22.10` were classified as major updates, because anything that didn't parse as strict semver fell through to major.
- Commit SHAs were parsed as versions — `3d3c42e5… → 08c6903c…` extracted as `1 → 08` and published a major bump.
- CalVer Docker tags such as `20240101 → 20250101` were treated as digest refreshes.

All three affect `apps/**` Docker bumps, which is most of what this workflow generates changesets for.

One behaviour change: summary lines no longer carry an emoji prefix by default. The action gained an `emoji` input, defaulting to disabled. Set `emoji: 'true'` in the step to restore the previous appearance — the existing `with:` block here is otherwise unaffected, and all five inputs this workflow passes are still declared.

## Verification

Config validates with `renovate-config-validator`. I checked the regex against the actual pinned line rather than trusting it by eye — both capture groups resolve, and `v4.16.47` is correctly excluded from version candidates.
