### PR TITLE
ci(renovate): bump renovate-changesets action to 0.2.35

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@ab105bafa93214969210a90bad60bdc41860f452 # renovate-changesets@0.2.34
+        uses: bfra-me/.github/.github/actions/renovate-changesets@5e31de3d001d1b3cc0a77070365d6dc2fc1033c6 # renovate-changesets@0.2.35
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
Moves this repo's `renovate-changesets` pin from 0.2.34 to 0.2.35.

0.2.35 fixes grouped multi-package changesets being silently dropped. The action's writer tries `@changesets/write` first, which loads this repo's Prettier config — and that config points at `@bfra.me/prettier-config/120-proof`, which cannot resolve because the action runs before any dependency install. The single-package path already caught that and composed the file by hand; the grouped path just logged a warning and threw the changeset away.

That is why #1103 (the postgres digest update) has no changeset. It touches `apps/umami/`, which resolves to two workspace packages, so it took the grouped path.

Both writer paths now share the same fallback upstream, so re-running #1103 after this merges should produce its changeset.

Pin verified: tag `renovate-changesets@0.2.35` resolves to `5e31de3d001d1b3cc0a77070365d6dc2fc1033c6`, and `package.json` at that tag reads 0.2.35.