### PR TITLE
ci(renovate): bump renovate-changesets action to 0.2.36

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@5e31de3d001d1b3cc0a77070365d6dc2fc1033c6 # renovate-changesets@0.2.35
+        uses: bfra-me/.github/.github/actions/renovate-changesets@30566a16fca4d3e06f999b28750f2f90287672d8 # renovate-changesets@0.2.36
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
Moves the `renovate-changesets` pin from 0.2.35 to 0.2.36.

0.2.36 fixes the impact counts in multi-package changeset summaries. The changeset generated for #1103 released both `@marcusrbrown/infra-umami` and `@marcusrbrown/infra-shared`, then described itself as `0 packages directly affected, 2 indirectly affected` — zero of two, in a summary listing two releases. The analyzer recomputed directness from manifests alone, so a Docker image (present in no `package.json`) left the package whose own file changed filed as merely indirect. Peer and optional dependency updates were misclassified the same way.

Diagnostic only. Release selection was always correct, which is why #1103's changeset had the right packages despite the wrong counts — so this changes the wording of future summaries, not what gets released.

Pin verified: tag `renovate-changesets@0.2.36` resolves to `30566a16fca4d3e06f999b28750f2f90287672d8`, and `package.json` at that tag reads 0.2.36.