### PR TITLE
fix(changesets): drop packages Changesets cannot release

### DIFF
--- a/.changeset/renovate-group--marcusrbrown-infra-workspace.md
+++ b/.changeset/renovate-group--marcusrbrown-infra-workspace.md
@@ -1,9 +1,0 @@
----
-'@marcusrbrown/infra-workspace': minor
----
-
-Group update for npm dependencies: `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, `@aws-sdk/client-s3`, `fro-bot/agent`
-
-**Multi-package update** for packages: `@marcusrbrown/infra-workspace`.
-
-**Impact:** 4 packages directly affected, 2 indirectly affected.

--- a/.changeset/renovate-merged-fb42e10.md
+++ b/.changeset/renovate-merged-fb42e10.md
@@ -1,15 +1,13 @@
 ---
-'@marcusrbrown/infra-agent': minor
 '@marcusrbrown/infra-gateway': minor
 '@marcusrbrown/infra-shared': minor
-'@marcusrbrown/infra-vpn': minor
 '@marcusrbrown/infra': minor
 ---
 
-Update dependencies across 5 packages
+Update dependencies across 3 packages
 
 **Dependencies updated**: `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, `@aws-sdk/client-s3`
 
 **Merged changeset** combining 2 related updates across affected packages.
 
-**Affected packages**: `@marcusrbrown/infra`, `@marcusrbrown/infra-agent`, `@marcusrbrown/infra-gateway`, `@marcusrbrown/infra-shared`, `@marcusrbrown/infra-vpn`
+**Affected packages**: `@marcusrbrown/infra`, `@marcusrbrown/infra-gateway`, `@marcusrbrown/infra-shared`


### PR DESCRIPTION
The release workflow is failing again, on a different error than #1118:

```
Error: Found changeset renovate-group--marcusrbrown-infra-workspace
for package @marcusrbrown/infra-workspace which is not in the workspace
```

PR #1119 generated two changesets, both invalid, and they fail in sequence.

`renovate-group--marcusrbrown-infra-workspace.md` names only `@marcusrbrown/infra-workspace` — the private workspace root. Changesets only accepts workspace members, so this one aborts the run before anything else is evaluated.

`renovate-merged-fb42e10.md` is the one that would fail next. It pairs `@marcusrbrown/infra-agent` and `@marcusrbrown/infra-vpn` with three releasable packages. Both are un-releasable — vpn is in `ignore`, and neither declares a `version`, which Changesets also treats as ignored. Removing only the first file surfaces it immediately:

```
Found mixed changeset renovate-merged-fb42e10
Found ignored packages: @marcusrbrown/infra-agent @marcusrbrown/infra-vpn
Found not ignored packages: @marcusrbrown/infra-gateway @marcusrbrown/infra-shared @marcusrbrown/infra
```

So this deletes the first and strips the two un-releasable names from the second, rather than deleting both — the minor release for `@marcusrbrown/infra`, `@marcusrbrown/infra-gateway`, and `@marcusrbrown/infra-shared` is legitimate and worth keeping. The summary text is corrected to match the frontmatter.

`changeset status` then resolves cleanly to those three packages at minor.

Root cause is upstream, same as #1118: `renovate-changesets` builds release sets from the workspace dependency graph without checking whether Changesets will accept them. It reads no `.changeset/config.json`, treats a versionless package as releasable, and will nominate the workspace root as a fallback target. Four packages here are un-releasable one way or another — `infra-cliproxy`, `infra-agent`, `infra-vpn`, and the root itself.

That fix is in progress in `bfra-me/.github`, backed by a contract harness that runs the action against a copy of this repository's shape and validates the output with the real Changesets CLI. Until it ships and the pin moves, Renovate PRs touching those packages will keep producing changesets that block releases.