### PR TITLE
ci(renovate): bump renovate-changesets action to 0.2.37

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@30566a16fca4d3e06f999b28750f2f90287672d8 # renovate-changesets@0.2.36
+        uses: bfra-me/.github/.github/actions/renovate-changesets@afac84b2d9a09f0fc20d45ec7a1b22b3f0852adf # renovate-changesets@0.2.37
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
Moves the `renovate-changesets` pin from 0.2.36 to 0.2.37.

This is the release that stops the action generating changesets this repository cannot release. Two of them blocked the release workflow yesterday, in #1118 and #1120:

```
Mixed changesets that contain both ignored and not ignored packages are not allowed
```
```
Found changeset renovate-group--marcusrbrown-infra-workspace
for package @marcusrbrown/infra-workspace which is not in the workspace
```

Four packages here are un-releasable, for three different reasons. `infra-cliproxy` and `infra-agent` declare no `version`. `infra-vpn` declares no version and is in `ignore`. The workspace root declares no version and is not a workspace member. The action previously nominated all of them.

0.2.37 reads `.changeset/config.json` and applies the same releaseability rule Changesets does — version present, not ignored, and either public or covered by `privatePackages.version`. When nothing directly affected is releasable, it falls back to the configured `target-package` rather than releasing a dependent that was only reached through the workspace graph. Fallback targets must also be genuine workspace members, which is what closes the second error above.

It also carries two other fixes. Grouped and multiple changeset filenames now use the `renovate-<sha>` convention instead of being keyed on package names, so two different updates touching the same packages no longer collide and silently overwrite one another. And multi-package impact summaries stop reporting `0 packages directly affected` when a Docker file changed.

Pin verified: tag `renovate-changesets@0.2.37` resolves to `afac84b2d9a09f0fc20d45ec7a1b22b3f0852adf`, and `package.json` at that tag reads 0.2.37.

Upstream, the three failure cases from this repository are now pinned by contract tests that run the action against a copy of this workspace's shape and validate the output with the real Changesets CLI.