### PR TITLE
fix(renovate): skip changesets ghcommit temp branches

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,7 +8,10 @@ on:
   pull_request:
     types: [edited]
   push:
-    branches-ignore: [main]
+    # changesets/action pushes through a short-lived changesets-ghcommit-temp/* branch and
+    # deletes it immediately, so a run triggered on one fails checkout with
+    # "couldn't find remote ref" before Renovate ever starts.
+    branches-ignore: [main, changesets-ghcommit-temp/**]
   workflow_dispatch:
     inputs:
       log-level:


### PR DESCRIPTION
Every release currently produces two failed Renovate runs:

```
git fetch --no-tags --depth=100 origin main changesets-ghcommit-temp/changeset-release/main
fatal: couldn't find remote ref changesets-ghcommit-temp/changeset-release/main
```

`changesets/action` v2 pushes through the GitHub API rather than git, and to do that it creates a temporary `changesets-ghcommit-temp/*` branch and deletes it moments later. Creating it fires a `push` event, which this workflow listens for on everything except `main`. Renovate then starts against a branch that no longer exists and dies in `actions/checkout`, before Renovate itself ever runs.

Fourteen runs have been triggered on those branches since the v2 upgrade in #1105. All fourteen failed, none has ever succeeded, and every one is the same checkout race — none involve Renovate or changeset generation.

Ignoring the pattern in the push trigger is enough. `changeset-release/main` is deliberately left alone: those runs are real and currently succeed.