### PR TITLE
ci(renovate): bump renovate-changesets action to 0.2.39

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@afac84b2d9a09f0fc20d45ec7a1b22b3f0852adf # renovate-changesets@0.2.37
+        uses: bfra-me/.github/.github/actions/renovate-changesets@3a9311132493d2714aecabcab60bcbf497c72d5a # renovate-changesets@0.2.39
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
Moves the `renovate-changesets` pin from 0.2.37 to 0.2.39, picking up three fixes.

The action can no longer report success having written nothing. A write failure previously came back as a warning and an empty file list, which the caller could not distinguish from "there was nothing to do", so the run went green having produced no changeset. It now fails and names both the changeset and the underlying error.

A Renovate pull request from an unrecognised bot identity now fails visibly. The accepted logins were a hardcoded set of three, and anything else exited cleanly — which is precisely how changeset generation went quiet in the first place, since this repository's pull requests come from `mrbro-bot[bot]`. Non-Renovate bots such as Dependabot still skip silently, as they should.

Workspace discovery now expands real globs. It previously string-compared against exactly `packages/*` and `apps/*`, so anything else — `libs/*`, nested globs, Yarn's object form — silently discovered nothing and quietly attributed every change to `target-package`. Packages are also deduplicated, and truncation past the analysis limit now warns instead of dropping them in silence.

0.2.37 is already proving out here. #1124 was a real `eceasy/cli-proxy-api` bump under `apps/cliproxy`, the same package and path that blocked the release workflow twice on Sunday. It produced a single, valid changeset:

```
---
'@marcusrbrown/infra': patch
---

Update Docker image `eceasy/cli-proxy-api` from `7.2.134` to `7.2.135`
```

Correct filename convention, no mixed release set naming the versionless `infra-cliproxy`, and `changeset status` assembles cleanly.

Pin verified: tag `renovate-changesets@0.2.39` resolves to `3a9311132493d2714aecabcab60bcbf497c72d5a`, and `package.json` at that tag reads 0.2.39.