### PR TITLE
fix(changesets): drop packages that do not consume the updated deps

### DIFF
--- a/.changeset/renovate-merged-fb42e10.md
+++ b/.changeset/renovate-merged-fb42e10.md
@@ -1,13 +1,7 @@
 ---
-'@marcusrbrown/infra-gateway': minor
-'@marcusrbrown/infra-shared': minor
 '@marcusrbrown/infra': minor
 ---
 
-Update dependencies across 3 packages
+Update dependencies
 
 **Dependencies updated**: `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, `@aws-sdk/client-s3`
-
-**Merged changeset** combining 2 related updates across affected packages.
-
-**Affected packages**: `@marcusrbrown/infra`, `@marcusrbrown/infra-gateway`, `@marcusrbrown/infra-shared`


### PR DESCRIPTION
The pending release would have bumped `@marcusrbrown/infra-gateway` and `@marcusrbrown/infra-shared` and created changelogs for both. Neither has ever been released here — every release in this repository's history has bumped `packages/cli` and nothing else.

It comes from a single changeset, `renovate-merged-fb42e10.md`, generated by #1119. Every other pending changeset correctly names only `@marcusrbrown/infra`.

That pull request updated `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, and `@aws-sdk/client-s3`. Checking what actually consumes them:

- `@marcusrbrown/infra-gateway` depends on `@aws-sdk/client-s3`
- `@marcusrbrown/infra-shared` depends on `yaml` and `zod`
- `@marcusrbrown/infra` depends on `@clack/prompts`, `@goke/mcp`, `goke`, `string-dedent`, and `zod`

So `infra-shared` consumes nothing that changed. It was added by workspace relationship traversal — it is a *dependency of* gateway, not a consumer of anything updated, and the traversal walks that edge in the wrong direction for release purposes.

This changeset was already edited once, in #1120, to unblock the release workflow. That edit removed `infra-agent` and `infra-vpn` because they were un-releasable and hard-failing Changesets. It did not question whether the surviving packages belonged, which is why this survived.

Now it names `@marcusrbrown/infra` alone, consistent with the other pending changesets and with every previous release. `changeset status` confirms a single package bumped at minor.

The upstream cause is a known defect in `renovate-changesets`: release sets are expanded through every recorded workspace relationship, including edges that do not imply a release. A package that neither changed nor consumes an updated dependency can still be nominated. A fix is in progress in `bfra-me/.github`, with a contract scenario reproducing this exact shape.