### PR TITLE
ci(renovate): bump renovate-changesets action to 0.2.42

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@d581508ba1c030b68d57bf0f79fe7f16298b8e6a # renovate-changesets@0.2.41
+        uses: bfra-me/.github/.github/actions/renovate-changesets@647b362a3b620c468a0af1836de10b97eb0a2509 # renovate-changesets@0.2.42
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-back: 'true'


### PR DESCRIPTION
The changeset check on #1132 fails with:

```
Action failed: PR #1132 row 1 has no valid version transition
```

Row 1 of that pull request is an ordinary npm range bump:

```
| [@goke/mcp](...) | [`^0.0.11` → `^0.0.13`](...) | ... | dependencies | patch |
```

0.2.41's version-transition pattern does not permit a leading range operator, so the caret prevents a match and the row throws. Range transitions are the normal shape for npm dependencies, so this blocks every grouped non-major update — which here run every couple of days.

0.2.42 permits `[<>=~^]*` on both sides of the transition. I confirmed all three of #1132's real rows parse cleanly against it, including the empty `Type` cell on row 2 and the `v`-prefixed action bump on row 3.

That release also completes the update-type handling. Renovate emits ten canonical types and only four were recognised; rollback was being classified as a major bump, replacement dropped the new package name entirely, and digest pinning was only working by accident — the version regex happened to scrape matching digits from both sides of a tag-to-digest change without ever seeing the digest.

Pin verified: tag `renovate-changesets@0.2.42` resolves to `647b362a3b620c468a0af1836de10b97eb0a2509`, and `package.json` at that tag reads 0.2.42.