### PR TITLE
fix(changeset): correct release targets for AWS SDK group update

### DIFF
--- a/.changeset/renovate-ab0a87e-0.md
+++ b/.changeset/renovate-ab0a87e-0.md
@@ -1,13 +1,5 @@
 ---
-'@marcusrbrown/infra-gateway': minor
-'@marcusrbrown/infra-shared': minor
+'@marcusrbrown/infra': minor
 ---
 
 Group update for npm dependencies: `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, `@aws-sdk/client-s3`
-
-**Multi-package update** for packages: `@marcusrbrown/infra-gateway`, `@marcusrbrown/infra-shared`.
-
-**Package relationships:**
-- `@marcusrbrown/infra-gateway` → `@marcusrbrown/infra-shared` (internal-dependency)
-
-**Impact:** 4 packages directly affected, 2 indirectly affected.


### PR DESCRIPTION
The release pull request would bump `@marcusrbrown/infra-gateway` and `@marcusrbrown/infra-shared`. Neither has ever been released here — every release in this repository's history has bumped `packages/cli` alone, and neither has a changelog.

One changeset is responsible, `renovate-ab0a87e-0.md`, and it was generated before the release-propagation fix landed upstream. It names both packages for an update to `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, and `@aws-sdk/client-s3`.

`packages/shared` declares only `yaml` and `zod`. It consumes nothing that changed. It was pulled in purely because `apps/gateway` depends on it, and the old relationship traversal walked that edge backwards — from consumer to provider, which is the wrong direction for deciding what to release.

The action no longer does this. Every changeset generated since that fix targets the right packages; this one predates it and rode along.

The AWS SDK updates it describes are already covered by `renovate-merged-fb42e10.md`, which correctly targets `@marcusrbrown/infra`. The frontmatter here is corrected to match rather than deleting the entry, since its summary names the specific packages updated.

Verified with the Changesets CLI: the pending release is now `@marcusrbrown/infra` at minor, and nothing else.