### PR TITLE
chore(changesets): ignore @marcusrbrown/infra-gateway

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "changelog": ["@svitejs/changesets-changelog-github-compact", {"repo": "marcusrbrown/infra"}],
   "commit": false,
   "fixed": [],
-  "ignore": ["@marcusrbrown/infra-vpn"],
+  "ignore": ["@marcusrbrown/infra-gateway", "@marcusrbrown/infra-vpn"],
   "linked": [],
   "privatePackages": {"tag": true, "version": true},
   "updateInternalDependencies": "patch"

--- a/.changeset/renovate-46d5af8-0.md
+++ b/.changeset/renovate-46d5af8-0.md
@@ -1,7 +1,5 @@
 ---
-'@marcusrbrown/infra-gateway': minor
+'@marcusrbrown/infra': minor
 ---
 
 Group update for npm dependencies: `@aws-sdk/client-iam`, `@aws-sdk/client-lightsail`, `@aws-sdk/client-s3`
-
-**Multi-package update** for packages: `@marcusrbrown/infra-gateway`.


### PR DESCRIPTION
`apps/gateway` is a private, never-published app. It was becoming a release target because it declares `@aws-sdk/client-s3`, so release PR #1142 was set to bump it 0.0.0 → 0.1.0 and create a changelog for something that is not published.

That is not a bug in `renovate-changesets` — gateway genuinely declares the dependency that was updated, so naming it is correct under file/dependency ownership. Whether a private never-published app should be a release target is a config question, and `ignore` is where it belongs.

## Changes

**`.changeset/config.json`** — add `@marcusrbrown/infra-gateway` to `ignore`, alongside `@marcusrbrown/infra-vpn`.

**`.changeset/renovate-46d5af8-0.md`** — retarget from gateway to `@marcusrbrown/infra`.

The retarget matters. That changeset names *only* gateway, so once gateway is ignored it contributes nothing and the AWS SDK update disappears from the changelog entirely. Retargeting to root matches what the action itself now generates when the only directly affected package is unreleasable — the same fallback that produced the `eceasy/cli-proxy-api` changeset for versionless `apps/cliproxy` in #1124.

## Verification

`changeset status` against the real CLI:

```
Packages to be bumped at minor:
- @marcusrbrown/infra
```

Gateway and shared appear in no pending changeset. Future updates touching only gateway will fall back to the root target automatically, since the action reads `ignore` from this config when filtering releasable packages.