### PR TITLE
fix(release): restore npm publish token auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
         name: Create Release Pull Request or Publish
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           github-token: ${{ steps.get-app-token.outputs.token }}
           commit-message: 'chore(changesets): version packages'

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -298,6 +298,7 @@ describe('repo conventions', () => {
 
   it('release workflow passes auth through changesets/action with NODE_AUTH_TOKEN', async () => {
     const text = await Bun.file(resolve(REPO_ROOT, '.github/workflows/release.yaml')).text()
+    const npmrc = await Bun.file(resolve(REPO_ROOT, '.npmrc')).text()
     const parsed = parseYaml(text) as {
       jobs?: {release?: {steps?: {id?: string; env?: Record<string, string>; with?: Record<string, string>}[]}}
     }
@@ -309,6 +310,8 @@ describe('repo conventions', () => {
     expect(changesetsStep?.env).not.toHaveProperty('GITHUB_TOKEN')
     expect(changesetsStep?.env?.NODE_AUTH_TOKEN).toBe('$' + '{{ secrets.NPM_TOKEN }}')
     expect(changesetsStep?.env).not.toHaveProperty('NPM_TOKEN')
+    expect(npmrc).toContain('//registry.npmjs.org/:_authToken=$' + '{NODE_AUTH_TOKEN}')
+    expect(npmrc).not.toContain('$' + '{NPM_TOKEN}')
   })
 
   it('no `bundledDependencies` in any package.json', async () => {

--- a/packages/cli/src/conventions.test.ts
+++ b/packages/cli/src/conventions.test.ts
@@ -296,7 +296,7 @@ describe('repo conventions', () => {
     expect(workflows.length).toBeGreaterThan(0)
   })
 
-  it('release workflow passes the app token only through changesets/action input', async () => {
+  it('release workflow passes auth through changesets/action with NODE_AUTH_TOKEN', async () => {
     const text = await Bun.file(resolve(REPO_ROOT, '.github/workflows/release.yaml')).text()
     const parsed = parseYaml(text) as {
       jobs?: {release?: {steps?: {id?: string; env?: Record<string, string>; with?: Record<string, string>}[]}}
@@ -307,7 +307,8 @@ describe('repo conventions', () => {
     expect(changesetsStep).toBeDefined()
     expect(changesetsStep?.with?.['github-token']).toBe('$' + '{{ steps.get-app-token.outputs.token }}')
     expect(changesetsStep?.env).not.toHaveProperty('GITHUB_TOKEN')
-    expect(changesetsStep?.env?.NPM_TOKEN).toBe('$' + '{{ secrets.NPM_TOKEN }}')
+    expect(changesetsStep?.env?.NODE_AUTH_TOKEN).toBe('$' + '{{ secrets.NPM_TOKEN }}')
+    expect(changesetsStep?.env).not.toHaveProperty('NPM_TOKEN')
   })
 
   it('no `bundledDependencies` in any package.json', async () => {


### PR DESCRIPTION
npm publishing has been dead since 2026-08-15 and I only caught it because the registry was two releases behind the repo.

`changesets/action` v2.0.0 removed its `.npmrc` handling for `NPM_TOKEN` ([#695](https://github.com/changesets/action/pull/695)) — v1 wrote the npmrc itself, v2 expects standard npm auth. We took v2 in #1105 and kept passing `NPM_TOKEN`, which is now inert. `actions/setup-node` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, so the token interpolated empty and every publish went out anonymous.

npm masks unauthorized writes as 404 rather than 401/403, so the failure looked like a missing package instead of an auth problem:

```
E404: Not Found - PUT https://registry.npmjs.org/@marcusrbrown%2finfra - Not found
The requested resource '@marcusrbrown/infra@0.17.0' could not be found or you do not have permission to access it.
```

## Impact

Two releases were lost. Registry is on `0.15.4` (2026-08-13, the last run before the v2 bump) while `main` says `0.17.0`.

| Merge | Target | Result |
| --- | --- | --- |
| #1093 (2026-08-19) | `0.16.0` | E404 |
| #1142 (2026-08-22) | `0.17.0` | E404 |

Only release-PR merges attempt a publish, so every other Release run stayed green and hid this for nine days.

No git tags or GitHub Releases were created for either version, so there is nothing to unwind. Re-running Release after this merges will publish `0.17.0`; `0.16.0` is skipped permanently since its changesets were already folded into the `0.17.0` bump.

## Change

One env var, plus a regression assertion in `conventions.test.ts` alongside the existing release-wiring checks from #1113. The assertion was verified to fail against the old wiring before being committed.

Not migrating to Trusted Publishing here — `provenance: true` and `id-token: write` are already in place and were never the cause. That's a separate decision.
