### PR TITLE
ci(security): harden Renovate changeset workflow

### DIFF
--- a/.github/workflows/renovate-changesets.yaml
+++ b/.github/workflows/renovate-changesets.yaml
@@ -3,6 +3,8 @@ name: Renovate Changesets
 
 on:
   pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -11,7 +13,10 @@ jobs:
   renovate-changesets:
     name: Create Renovate Changeset
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]'
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.user.login == github.actor &&
+      (github.actor == 'renovate[bot]' || github.actor == 'mrbro-bot[bot]')
     steps:
       - id: get-app-token
         name: Get Workflow Access Token
@@ -19,6 +24,8 @@ jobs:
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
 
       - name: Setup Git user
         env:
@@ -34,7 +41,9 @@ jobs:
         with:
           fetch-depth: 2
           ref: ${{ github.head_ref }}
+          repository: ${{ github.repository }}
           token: ${{ steps.get-app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Generate Renovate changesets
         uses: bfra-me/.github/.github/actions/renovate-changesets@8aba87302817a5b675c08d32e32443bfab7fc224 # renovate-changesets@0.2.44


### PR DESCRIPTION
Defense-in-depth on the one `pull_request_target` workflow that mints a privileged App token. No currently-exploitable path — I checked before writing this — but the blast radius if the actor allowlist were ever bypassed is the whole repo.

## The actual problem

`create-github-app-token` was called with no `permission-*` inputs, so the minted token inherits **every permission approved for the installation** — `administration`, `secrets`, `workflows`, `environments`, `actions`, `contents`, all at write. The top-level `permissions: contents: read` doesn't constrain it; that only applies to the automatic `GITHUB_TOKEN`, which this job never uses.

Scoped it to what the changesets action actually needs: `contents: write` to commit back, `pull-requests: read` to inspect PR metadata. Deliberately left out `permission-workflows: write` — if it turns out to be required for changesets on workflow-update PRs, that'll surface in CI and I'd rather add it knowingly.

## Fork guard

`actions/checkout` here omits `repository:`, so `ref: github.head_ref` resolves against the base repo — fork-head code is never actually checked out today, and the pinned action executes no project code (Octokit plus git via `@actions/exec`, no install, no lifecycle scripts). The guard is belt-and-braces, not a fix for a live hole.

Added alongside it a check that the PR author matches the triggering actor, so a bot-triggered event can't authorize a differently-authored PR before the action's own internal check runs.

## Trigger and checkout

Made the trigger explicit — `types` documents the existing implicit default, `branches: [main]` is the real narrowing. Made `repository:` explicit so base-repo resolution is intentional rather than accidental, and set `persist-credentials: false`; the action rewrites `origin` to an authenticated URL itself before pushing, so checkout doesn't need to leave the token on disk.

## Not touched

The `# renovate-changesets@0.2.44` comment on the pinned action stays byte-identical. It looks off-convention but it's load-bearing — the custom regex manager in `.github/renovate.json5` matches on that exact shape, and breaking it is what left the pin stale at 0.2.31 for four months. #1129 asked for it to be "fixed"; that was a false positive and is closed.

Behavior for legitimate bot PRs is unchanged.
