### PR TITLE
feat(cli): distinguish running and latest CLIProxyAPI versions

### DIFF
--- a/.changeset/bright-dogs-report.md
+++ b/.changeset/bright-dogs-report.md
@@ -1,0 +1,5 @@
+---
+'@marcusrbrown/infra': minor
+---
+
+Report running and latest CLIProxyAPI versions separately in status output.

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -290,25 +290,28 @@ describe('cliproxy status helpers', () => {
     it('parses the deployed CLIProxyAPI image version from SSH output', async () => {
       const spawn = makeSpawnResult('cli-proxy-api\teceasy/cli-proxy-api:v7.2.138@sha256:deadbeef\n')
 
-      const result = await checkRunningVersion('cliproxy.example.com', spawn)
+      const result = await checkRunningVersion('cliproxy-example-com', spawn)
 
       expect(result).toEqual({title: 'Running version', level: 'ok', summary: 'v7.2.138'})
     })
 
     it('degrades to a warning when SSH is unavailable', async () => {
-      const result = await checkRunningVersion('cliproxy.example.com', makeSpawnResult('', 'Permission denied\n', 255))
+      const result = await checkRunningVersion('cliproxy-example-com', makeSpawnResult('', 'Permission denied\n', 255))
 
       expect(result.title).toBe('Running version')
       expect(result.level).toBe('warning')
       expect(result.summary).toContain('SSH command failed')
     })
 
-    it('rejects an invalid host before invoking SSH', async () => {
+    it('degrades for an invalid host before invoking SSH', async () => {
       const neverSpawn: SpawnFn = () => {
         throw new Error('spawn must not be called for an invalid host')
       }
 
-      await expect(checkRunningVersion('-oProxyCommand=evil', neverSpawn)).rejects.toThrow('Invalid CLIPROXY_DOMAIN')
+      const result = await checkRunningVersion('-oProxyCommand=evil', neverSpawn)
+
+      expect(result.level).toBe('warning')
+      expect(result.summary).toContain('Invalid CLIPROXY_DOMAIN')
     })
   })
 
@@ -340,6 +343,12 @@ describe('cliproxy status helpers', () => {
       expect(
         formatVersionSummary(check('ok', 'v7.2.139'), check('error', 'GET latest-version failed with HTTP 500')),
       ).toBe('v7.2.139 (latest unknown)')
+    })
+
+    it('labels a rate-limited latest version distinctly', () => {
+      expect(
+        formatVersionSummary(check('ok', 'v7.2.139'), check('warning', 'Rate limited by management API (HTTP 429).')),
+      ).toBe('v7.2.139 (latest rate-limited)')
     })
 
     it('labels a missing management key without leaking the diagnostic into the cell', () => {
@@ -429,7 +438,13 @@ describe('cliproxyStatusAction (Tier-2 ctx capture, failure-path parity)', () =>
 
     globalThis.fetch = createFetchImplementation(async () => new Response('ok', {status: 200}))
 
-    await expect(cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)).rejects.toMatchObject({
+    await expect(
+      cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      ),
+    ).rejects.toMatchObject({
       name: 'MockProcessExit',
       code: 1,
     })
@@ -447,7 +462,11 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
     globalThis.fetch = createFetchImplementation(async () => new Response('ok', {status: 200}))
 
     const {ctx, captured} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.example.com'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(expectCapturedToInclude(captured, 'CLIProxyAPI status')).toBe(true)
     expect(expectCapturedToInclude(captured, 'HTTP reachability')).toBe(true)
@@ -460,7 +479,11 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
     const {ctx, captured} = createCapturedCtx()
     let threw: unknown
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       threw = error
     }
@@ -477,7 +500,11 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
     delete process.env.CLIPROXY_MANAGEMENT_KEY
     try {
       const {ctx, captured} = createCapturedCtx()
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
 
       expect(expectCapturedToInclude(captured, 'CLIPROXY_MANAGEMENT_KEY')).toBe(true)
     } finally {
@@ -493,7 +520,7 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
 
     const {ctx, captured} = createCapturedCtx()
     await cliproxyStatusAction(
-      {url: 'https://cliproxy.example.com'},
+      {url: 'https://cliproxy.fro.bot'},
       ctx,
       makeSpawnResult('', 'ssh: connect failed\n', 255),
     )
@@ -502,6 +529,47 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
     expect(output).toContain('[OK] HTTP reachability')
     expect(output).toContain('[WARN] Running version')
     expect(output).toContain('ssh: connect failed')
+    expect(captured.exit).toBeNull()
+  })
+
+  it('skips SSH for an explicit URL override without failing status', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.endsWith('/healthz')) return new Response('ok', {status: 200})
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    let spawnCalls = 0
+    const neverSpawn: SpawnFn = () => {
+      spawnCalls++
+      throw new Error('SSH must not run for an explicit URL override')
+    }
+    const {ctx, captured} = createCapturedCtx()
+
+    await cliproxyStatusAction({url: 'https://other-cliproxy.example.com'}, ctx, neverSpawn)
+
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toContain('[WARN] Running version')
+    expect(output).toContain('Not checked for explicit URL override')
+    expect(captured.exit).toBeNull()
+    expect(spawnCalls).toBe(0)
+  })
+
+  it('keeps HTTP healthy when the URL hostname fails validation', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.endsWith('/healthz')) return new Response('ok', {status: 200})
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const neverSpawn: SpawnFn = () => {
+      throw new Error('SSH must not run for an invalid host')
+    }
+    const {ctx, captured} = createCapturedCtx()
+
+    await cliproxyStatusAction({url: 'https://[::1]'}, ctx, neverSpawn)
+
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toContain('[OK] HTTP reachability')
+    expect(output).toContain('Invalid CLIPROXY_DOMAIN')
     expect(captured.exit).toBeNull()
   })
 })
@@ -592,7 +660,12 @@ describe('management auth failure surfaces in unified summary (FIX 4)', () => {
       return new Response('ok', {status: 200})
     })
 
-    const summary = await getCliproxyStatusSummary('https://cliproxy.example.com', 'bad-key', false)
+    const summary = await getCliproxyStatusSummary(
+      'https://cliproxy.example.com',
+      'bad-key',
+      false,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     // Must NOT show the no-key sentinel — a bad key is distinct from no key
     expect(summary.version).not.toBe('— (no key)')
@@ -622,7 +695,11 @@ describe('ban body word-boundary detection (FIX 5)', () => {
 
     const {ctx, captured} = createCapturedCtx()
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: 'any-key'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', key: 'any-key'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       if (!(error instanceof MockProcessExit)) throw error
     }
@@ -645,7 +722,11 @@ describe('ban body word-boundary detection (FIX 5)', () => {
 
     const {ctx, captured} = createCapturedCtx()
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: 'any-key'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', key: 'any-key'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       if (!(error instanceof MockProcessExit)) throw error
     }
@@ -669,7 +750,7 @@ describe('reachability probe targets /healthz liveness endpoint', () => {
     })
 
     const {ctx, captured} = createCapturedCtx()
-    await cliproxyStatusAction({url: BASE}, ctx)
+    await cliproxyStatusAction({url: BASE}, ctx, makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'))
 
     const output = [...captured.stdout, ...captured.stderr].join('\n')
     expect(output).toContain('OK')
@@ -684,7 +765,7 @@ describe('reachability probe targets /healthz liveness endpoint', () => {
       return new Response('ok', {status: 200})
     })
 
-    const summary = await getCliproxyStatusSummary(BASE, '', false)
+    const summary = await getCliproxyStatusSummary(BASE, '', false, makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'))
 
     expect(summary.http).toMatch(/^OK/)
   })
@@ -719,7 +800,11 @@ describe('management auth probe (ban-awareness)', () => {
     const {ctx} = createCapturedCtx()
     // Auth failure yields error-level result → exit(1) → MockProcessExit thrown
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: 'bad-key'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', key: 'bad-key'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       if (!(error instanceof MockProcessExit)) throw error
     }
@@ -743,7 +828,11 @@ describe('management auth probe (ban-awareness)', () => {
     const {ctx, captured} = createCapturedCtx()
     // 403+ban → error level → exit(1)
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: 'any-key'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', key: 'any-key'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       if (!(error instanceof MockProcessExit)) throw error
     }
@@ -766,7 +855,11 @@ describe('management auth probe (ban-awareness)', () => {
     const {ctx, captured} = createCapturedCtx()
     // 401 → error level → exit(1)
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: secretKey}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', key: secretKey},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       if (!(error instanceof MockProcessExit)) throw error
     }
@@ -802,7 +895,11 @@ describe('management auth probe (ban-awareness)', () => {
     })
 
     const {ctx} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://cliproxy.example.com', key: 'valid-key'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.example.com', key: 'valid-key'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(fetchedUrls.some(u => u.includes('/v0/management/latest-version'))).toBe(true)
     expect(fetchedUrls.some(u => u.includes('/v0/management/usage-queue'))).toBe(true)
@@ -825,7 +922,12 @@ describe('management auth probe (ban-awareness)', () => {
       return new Response('ok', {status: 200})
     })
 
-    await getCliproxyStatusSummary('https://cliproxy.example.com', 'bad-key', false)
+    await getCliproxyStatusSummary(
+      'https://cliproxy.example.com',
+      'bad-key',
+      false,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(managementFetchUrls.length).toBe(1)
   })
@@ -875,7 +977,11 @@ describe('cliproxyStatusAction — ambient key does not follow agent-supplied UR
 
     const {ctx} = createCapturedCtx()
     try {
-      await cliproxyStatusAction({url: 'https://evil.example.com'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://evil.example.com'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch {
       // exit(1) expected or not — either way, we just care about key leakage
     }
@@ -907,7 +1013,11 @@ describe('cliproxyStatusAction — ambient key does not follow agent-supplied UR
 
     const {ctx} = createCapturedCtx()
     // Default URL is https://cliproxy.fro.bot — pass it explicitly
-    await cliproxyStatusAction({url: 'https://cliproxy.fro.bot'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.fro.bot'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(capturedManagementKeys).toContain('secret-ambient-key')
   })
@@ -934,7 +1044,11 @@ describe('cliproxyStatusAction — ambient key does not follow agent-supplied UR
     })
 
     const {ctx} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://other-cliproxy.example.com', key: 'explicit-key'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://other-cliproxy.example.com', key: 'explicit-key'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(capturedManagementKeys).toContain('explicit-key')
   })
@@ -946,7 +1060,11 @@ describe('cliproxyStatusAction — ambient key does not follow agent-supplied UR
     })
 
     const {ctx, captured} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://other-cliproxy.example.com'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://other-cliproxy.example.com'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     const output = [...captured.stdout, ...captured.stderr].join('\n')
     expect(output).toMatch(/CLIPROXY_MANAGEMENT_KEY|no key|skipping/i)
@@ -1206,7 +1324,11 @@ describe('cliproxyStatusAction — provider auth probe wiring', () => {
     })
 
     const {ctx, captured} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://cliproxy.example.com'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.example.com'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     const output = [...captured.stdout, ...captured.stderr].join('\n')
     expect(output).toMatch(/CLIPROXY_API_KEY|skipping upstream provider probe/i)
@@ -1229,7 +1351,11 @@ describe('cliproxyStatusAction — provider auth probe wiring', () => {
     })
 
     const {ctx, captured} = createCapturedCtx()
-    await cliproxyStatusAction({url: 'https://cliproxy.example.com', apiKey: 'my-api-key'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.example.com', apiKey: 'my-api-key'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(fetchedUrls.some(u => u.includes('/v1/chat/completions'))).toBe(true)
     const output = [...captured.stdout, ...captured.stderr].join('\n')
@@ -1259,7 +1385,11 @@ describe('cliproxyStatusAction — provider auth probe wiring', () => {
 
     const {ctx} = createCapturedCtx()
     // Explicit --url override to a non-trusted host — ambient key must NOT follow
-    await cliproxyStatusAction({url: 'https://evil.example.com'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://evil.example.com'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     // The ambient API key must not appear in any Authorization header sent to evil host
     expect(capturedAuthHeaders.some(h => h.includes('ambient-api-key-secret'))).toBe(false)
@@ -1302,7 +1432,11 @@ describe('cliproxyStatusAction — provider auth probe wiring', () => {
 
     const {ctx} = createCapturedCtx()
     // Default trusted URL — ambient key SHOULD be used
-    await cliproxyStatusAction({url: 'https://cliproxy.fro.bot'}, ctx)
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.fro.bot'},
+      ctx,
+      makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+    )
 
     expect(capturedAuthHeaders.some(h => h.includes('ambient-api-key-trusted'))).toBe(true)
   })
@@ -1317,7 +1451,11 @@ describe('cliproxyStatusAction — provider auth probe wiring', () => {
     const {ctx, captured} = createCapturedCtx()
     let threw: unknown
     try {
-      await cliproxyStatusAction({url: 'https://cliproxy.example.com', apiKey: 'my-api-key'}, ctx)
+      await cliproxyStatusAction(
+        {url: 'https://cliproxy.example.com', apiKey: 'my-api-key'},
+        ctx,
+        makeSpawnResult('eceasy/cli-proxy-api:v7.2.139\n'),
+      )
     } catch (error) {
       threw = error
     }

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -5,15 +5,18 @@ import {
   checkHttpReachability,
   checkProviderAuth,
   checkProviderAuthState,
+  checkRunningVersion,
   checkUsageStats,
   checkVersion,
   cliproxyStatusAction,
   formatDurationMs,
   formatUsageSummaryLine,
+  formatVersionSummary,
   getCliproxyStatusSummary,
   levelLabel,
   stripTrailingSlash,
   toNumber,
+  type SpawnFn,
 } from './status'
 
 const originalFetch = globalThis.fetch
@@ -31,6 +34,25 @@ function createFetchImplementation(handler: FetchReplacement): typeof fetch {
     },
     {preconnect: originalFetch.preconnect},
   )
+}
+
+function makeSpawnResult(stdoutText: string, stderrText = '', exitCode = 0): SpawnFn {
+  const encoder = new TextEncoder()
+  return (_cmd, _opts) => ({
+    stdout: new ReadableStream({
+      start(controller) {
+        if (stdoutText.length > 0) controller.enqueue(encoder.encode(stdoutText))
+        controller.close()
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        if (stderrText.length > 0) controller.enqueue(encoder.encode(stderrText))
+        controller.close()
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+  })
 }
 
 describe('cliproxy status helpers', () => {
@@ -264,6 +286,75 @@ describe('cliproxy status helpers', () => {
     })
   })
 
+  describe('checkRunningVersion', () => {
+    it('parses the deployed CLIProxyAPI image version from SSH output', async () => {
+      const spawn = makeSpawnResult('cli-proxy-api\teceasy/cli-proxy-api:v7.2.138@sha256:deadbeef\n')
+
+      const result = await checkRunningVersion('cliproxy.example.com', spawn)
+
+      expect(result).toEqual({title: 'Running version', level: 'ok', summary: 'v7.2.138'})
+    })
+
+    it('degrades to a warning when SSH is unavailable', async () => {
+      const result = await checkRunningVersion('cliproxy.example.com', makeSpawnResult('', 'Permission denied\n', 255))
+
+      expect(result.title).toBe('Running version')
+      expect(result.level).toBe('warning')
+      expect(result.summary).toContain('SSH command failed')
+    })
+
+    it('rejects an invalid host before invoking SSH', async () => {
+      const neverSpawn: SpawnFn = () => {
+        throw new Error('spawn must not be called for an invalid host')
+      }
+
+      await expect(checkRunningVersion('-oProxyCommand=evil', neverSpawn)).rejects.toThrow('Invalid CLIPROXY_DOMAIN')
+    })
+  })
+
+  describe('formatVersionSummary', () => {
+    const check = (level: 'ok' | 'warning' | 'error', summary: string) => ({
+      title: 'version',
+      level,
+      summary,
+    })
+
+    it('formats differing healthy versions as running with latest context', () => {
+      expect(formatVersionSummary(check('ok', 'v7.2.139'), check('ok', 'v7.2.140'))).toBe('v7.2.139 (latest v7.2.140)')
+    })
+
+    it('collapses equal healthy versions to a latest marker', () => {
+      expect(formatVersionSummary(check('ok', 'v7.2.139'), check('ok', 'v7.2.139'))).toBe('v7.2.139 (latest)')
+    })
+
+    it('compacts an unavailable running version', () => {
+      expect(
+        formatVersionSummary(
+          check('warning', 'SSH command failed (exit 255): Permission denied'),
+          check('ok', 'v7.2.140'),
+        ),
+      ).toBe('unknown (latest v7.2.140)')
+    })
+
+    it('compacts an unavailable latest version', () => {
+      expect(
+        formatVersionSummary(check('ok', 'v7.2.139'), check('error', 'GET latest-version failed with HTTP 500')),
+      ).toBe('v7.2.139 (latest unknown)')
+    })
+
+    it('labels a missing management key without leaking the diagnostic into the cell', () => {
+      expect(formatVersionSummary(check('ok', 'v7.2.139'), check('warning', 'Not checked (no management key).'))).toBe(
+        'v7.2.139 (latest: no key)',
+      )
+    })
+
+    it('collapses both unavailable versions to unknown', () => {
+      expect(formatVersionSummary(check('warning', 'SSH unavailable'), check('error', 'management API failed'))).toBe(
+        'unknown',
+      )
+    })
+  })
+
   describe('formatUsageSummaryLine', () => {
     it('formats a recent-activity summary with no errors', () => {
       const result = formatUsageSummaryLine({
@@ -392,6 +483,26 @@ describe('cliproxyStatusAction (Tier-2 ctx capture)', () => {
     } finally {
       if (savedKey !== undefined) process.env.CLIPROXY_MANAGEMENT_KEY = savedKey
     }
+  })
+
+  it('keeps HTTP checks healthy when the running-version SSH check fails', async () => {
+    globalThis.fetch = createFetchImplementation(async url => {
+      if (url.endsWith('/healthz')) return new Response('ok', {status: 200})
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const {ctx, captured} = createCapturedCtx()
+    await cliproxyStatusAction(
+      {url: 'https://cliproxy.example.com'},
+      ctx,
+      makeSpawnResult('', 'ssh: connect failed\n', 255),
+    )
+
+    const output = [...captured.stdout, ...captured.stderr].join('\n')
+    expect(output).toContain('[OK] HTTP reachability')
+    expect(output).toContain('[WARN] Running version')
+    expect(output).toContain('ssh: connect failed')
+    expect(captured.exit).toBeNull()
   })
 })
 

--- a/packages/cli/src/commands/cliproxy/status.test.ts
+++ b/packages/cli/src/commands/cliproxy/status.test.ts
@@ -362,6 +362,15 @@ describe('cliproxy status helpers', () => {
         'unknown',
       )
     })
+
+    it('keeps a rate-limit label when both version checks are degraded', () => {
+      expect(
+        formatVersionSummary(
+          check('warning', 'SSH unavailable'),
+          check('warning', 'Rate limited by management API (HTTP 429).'),
+        ),
+      ).toBe('unknown (latest rate-limited)')
+    })
   })
 
   describe('formatUsageSummaryLine', () => {

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -5,6 +5,11 @@ import type {StatusSummary} from '../status'
 import {HTTP_TIMEOUT_MS, managementHeaders} from '@marcusrbrown/infra-shared/cliproxy/management'
 import {z} from 'zod'
 
+import {buildKnownHostsArgs} from '../../lib/known-hosts'
+import {redactHost} from '../../lib/redact'
+import {buildIdentityArgs} from '../../lib/ssh-identity'
+import {validateCliproxyHost} from './host'
+
 /** Minimal ctx surface consumed by cliproxy status actions. Satisfied by both GokeExecutionContext and CapturedCtx. */
 // ActionCtx imported from lib/action-ctx — single source of truth for action ctx shape
 
@@ -22,6 +27,22 @@ interface CheckResult {
   level: CheckLevel
   summary: string
   details?: string[]
+}
+
+export type SpawnFn = (
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+) => {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+}
+
+function defaultSpawn(
+  cmd: string[],
+  opts: {env: Record<string, string>; stdout: 'pipe'; stderr: 'pipe'},
+): ReturnType<SpawnFn> {
+  return Bun.spawn(cmd, opts) as ReturnType<SpawnFn>
 }
 
 export function levelLabel(level: CheckLevel): string {
@@ -191,7 +212,7 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
 
     if (response.status === 429) {
       return {
-        title: 'Latest version',
+        title: 'Latest available version',
         level: 'warning',
         summary: 'Rate limited by management API (HTTP 429). Retry in a few moments.',
       }
@@ -199,7 +220,7 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
 
     if (!response.ok) {
       return {
-        title: 'Latest version',
+        title: 'Latest available version',
         level: 'error',
         summary: `GET /v0/management/latest-version failed with HTTP ${response.status}`,
       }
@@ -210,18 +231,81 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
     if (payload && typeof payload === 'object') {
       const version = (payload as Record<string, unknown>)['latest-version']
       if (typeof version === 'string' && version.length > 0) {
-        return {title: 'Latest version', level: 'ok', summary: version}
+        return {title: 'Latest available version', level: 'ok', summary: version}
       }
     }
 
     return {
-      title: 'Latest version',
+      title: 'Latest available version',
       level: 'warning',
       summary: 'Response did not include a latest-version string.',
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    return {title: 'Latest version', level: 'error', summary: `Unable to check latest version: ${message}`}
+    return {title: 'Latest available version', level: 'error', summary: `Unable to check latest version: ${message}`}
+  }
+}
+
+export async function checkRunningVersion(host: string, spawn: SpawnFn = defaultSpawn): Promise<CheckResult> {
+  validateCliproxyHost(host)
+
+  let cleanup: () => void = () => undefined
+
+  try {
+    const knownHostsArgs = buildKnownHostsArgs()
+    const identity = buildIdentityArgs(process.env.CLIPROXY_SSH_KEY)
+    cleanup = identity.cleanup
+
+    const sshCmd = [
+      'ssh',
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ConnectTimeout=10',
+      '-o',
+      'StrictHostKeyChecking=yes',
+      ...knownHostsArgs,
+      ...identity.args,
+      `root@${host}`,
+      `docker ps --format '{{.Image}}'`,
+    ]
+
+    const env: Record<string, string> = {
+      PATH: process.env.PATH ?? '/usr/bin:/bin',
+      HOME: process.env.HOME ?? '/tmp',
+      ...(process.env.SSH_AUTH_SOCK ? {SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK} : {}),
+    }
+
+    const child = spawn(sshCmd, {env, stdout: 'pipe', stderr: 'pipe'})
+    const [stdoutText, stderrText, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ])
+
+    if (exitCode !== 0) {
+      return {
+        title: 'Running version',
+        level: 'warning',
+        summary: `SSH command failed (exit ${exitCode}): ${redactHost(stderrText.trim(), host) || 'unknown error'}`,
+      }
+    }
+
+    const imageMatch = /(?:^|\s)eceasy\/cli-proxy-api:([^\s@]+)/m.exec(stdoutText)
+    if (!imageMatch) {
+      return {
+        title: 'Running version',
+        level: 'warning',
+        summary: 'No running eceasy/cli-proxy-api container found.',
+      }
+    }
+
+    return {title: 'Running version', level: 'ok', summary: imageMatch[1] ?? 'unknown'}
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {title: 'Running version', level: 'warning', summary: `Unable to check running version via SSH: ${message}`}
+  } finally {
+    cleanup()
   }
 }
 
@@ -485,6 +569,28 @@ function formatCheckSummary(result: CheckResult): string {
   return `${levelLabel(result.level)}: ${result.summary}`
 }
 
+export function formatVersionSummary(running: CheckResult, available: CheckResult): string {
+  const latestFailure = /auth|\b40[13]\b|ip banned/i.test(available.summary) ? 'auth' : 'unknown'
+
+  if (running.level === 'ok' && available.level === 'ok') {
+    return running.summary === available.summary
+      ? `${running.summary} (latest)`
+      : `${running.summary} (latest ${available.summary})`
+  }
+
+  if (running.level === 'ok') {
+    return available.summary === 'Not checked (no management key).'
+      ? `${running.summary} (latest: no key)`
+      : `${running.summary} (latest ${latestFailure})`
+  }
+
+  if (available.level === 'ok') {
+    return `unknown (latest ${available.summary})`
+  }
+
+  return latestFailure === 'auth' ? 'unknown (auth)' : 'unknown'
+}
+
 export function formatUsageSummaryLine(result: CheckResult): string | null {
   // v7 recent-window format: "recent: N" or "recent: N, errors: M"
   const recentMatch = /recent:\s*(\d+)/.exec(result.summary)
@@ -497,25 +603,31 @@ export function formatUsageSummaryLine(result: CheckResult): string | null {
   return `Recent requests: ${total}${errors > 0 ? `, ${errors} errors` : ''}`
 }
 
-export async function getCliproxyStatusSummary(baseUrl: string, key: string, verbose: boolean): Promise<StatusSummary> {
+export async function getCliproxyStatusSummary(
+  baseUrl: string,
+  key: string,
+  verbose: boolean,
+  spawn: SpawnFn = defaultSpawn,
+): Promise<StatusSummary> {
   const normalizedBaseUrl = stripTrailingSlash(baseUrl)
-  const [httpResult, mgmt] = await Promise.all([
+  const host = new URL(normalizedBaseUrl).hostname
+  const [httpResult, mgmt, running] = await Promise.all([
     checkHttpReachability(`${normalizedBaseUrl}/healthz`, verbose),
     runManagementChecks(normalizedBaseUrl, key || undefined),
+    checkRunningVersion(host, spawn),
   ])
 
-  let version: string
+  let available: CheckResult
   let usageStats: string
 
   if (mgmt.kind === 'no-key') {
-    version = '— (no key)'
+    available = {title: 'Latest available version', level: 'warning', summary: 'Not checked (no management key).'}
     usageStats = '— (no key)'
   } else if (mgmt.kind === 'auth-failure') {
-    const authSummary = formatCheckSummary(mgmt.result)
-    version = authSummary
-    usageStats = authSummary
+    available = mgmt.result
+    usageStats = formatCheckSummary(mgmt.result)
   } else {
-    version = formatCheckSummary(mgmt.version)
+    available = mgmt.version
     usageStats = formatCheckSummary(mgmt.usage)
   }
 
@@ -523,7 +635,7 @@ export async function getCliproxyStatusSummary(baseUrl: string, key: string, ver
     app: 'cliproxy',
     http: formatCheckSummary(httpResult),
     lastDeploy: '—',
-    version,
+    version: formatVersionSummary(running, available),
     contentHash: '—',
     usageStats,
   }
@@ -537,7 +649,11 @@ export interface StatusOptions {
   verbose?: boolean
 }
 
-export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCtx): Promise<void> {
+export async function cliproxyStatusAction(
+  options: StatusOptions,
+  ctx: ActionCtx,
+  spawn: SpawnFn = defaultSpawn,
+): Promise<void> {
   let errorCount = 0
   try {
     const verbose = options.verbose === true
@@ -560,7 +676,12 @@ export async function cliproxyStatusAction(options: StatusOptions, ctx: ActionCt
     ctx.console.log('CLIProxyAPI status')
     ctx.console.log('')
 
-    const results: CheckResult[] = [await checkHttpReachability(`${baseUrl}/healthz`, verbose)]
+    const host = new URL(baseUrl).hostname
+    const [httpResult, runningResult] = await Promise.all([
+      checkHttpReachability(`${baseUrl}/healthz`, verbose),
+      checkRunningVersion(host, spawn),
+    ])
+    const results: CheckResult[] = [httpResult, runningResult]
 
     let capturedUsageResult: CheckResult | undefined
 

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -606,7 +606,11 @@ export function formatVersionSummary(running: CheckResult, available: CheckResul
     return `unknown (latest ${available.summary})`
   }
 
-  return latestFailure === 'auth' ? 'unknown (auth)' : 'unknown'
+  if (latestFailure === 'auth') {
+    return 'unknown (auth)'
+  }
+
+  return latestFailure === 'rate-limited' ? 'unknown (latest rate-limited)' : 'unknown'
 }
 
 function getRunningVersionNotChecked(host: string): CheckResult {

--- a/packages/cli/src/commands/cliproxy/status.ts
+++ b/packages/cli/src/commands/cliproxy/status.ts
@@ -247,11 +247,11 @@ export async function checkVersion(baseUrl: string, key: string): Promise<CheckR
 }
 
 export async function checkRunningVersion(host: string, spawn: SpawnFn = defaultSpawn): Promise<CheckResult> {
-  validateCliproxyHost(host)
-
   let cleanup: () => void = () => undefined
 
   try {
+    validateCliproxyHost(host)
+
     const knownHostsArgs = buildKnownHostsArgs()
     const identity = buildIdentityArgs(process.env.CLIPROXY_SSH_KEY)
     cleanup = identity.cleanup
@@ -569,8 +569,26 @@ function formatCheckSummary(result: CheckResult): string {
   return `${levelLabel(result.level)}: ${result.summary}`
 }
 
+const RUNNING_VERSION_NOT_CHECKED_SUMMARY = 'Not checked for explicit URL override.'
+
 export function formatVersionSummary(running: CheckResult, available: CheckResult): string {
-  const latestFailure = /auth|\b40[13]\b|ip banned/i.test(available.summary) ? 'auth' : 'unknown'
+  const latestFailure = /429|rate limit/i.test(available.summary)
+    ? 'rate-limited'
+    : /auth|\b40[13]\b|ip banned/i.test(available.summary)
+      ? 'auth'
+      : 'unknown'
+
+  if (running.summary === RUNNING_VERSION_NOT_CHECKED_SUMMARY) {
+    if (available.level === 'ok') {
+      return `not checked (latest ${available.summary})`
+    }
+
+    if (available.summary === 'Not checked (no management key).') {
+      return 'not checked (latest: no key)'
+    }
+
+    return `not checked (latest ${latestFailure})`
+  }
 
   if (running.level === 'ok' && available.level === 'ok') {
     return running.summary === available.summary
@@ -589,6 +607,16 @@ export function formatVersionSummary(running: CheckResult, available: CheckResul
   }
 
   return latestFailure === 'auth' ? 'unknown (auth)' : 'unknown'
+}
+
+function getRunningVersionNotChecked(host: string): CheckResult {
+  try {
+    validateCliproxyHost(host)
+    return {title: 'Running version', level: 'warning', summary: RUNNING_VERSION_NOT_CHECKED_SUMMARY}
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {title: 'Running version', level: 'warning', summary: `Unable to validate running-version host: ${message}`}
+  }
 }
 
 export function formatUsageSummaryLine(result: CheckResult): string | null {
@@ -677,9 +705,12 @@ export async function cliproxyStatusAction(
     ctx.console.log('')
 
     const host = new URL(baseUrl).hostname
+    const runningCheck = urlIsExplicitlyOverridden
+      ? Promise.resolve(getRunningVersionNotChecked(host))
+      : checkRunningVersion(host, spawn)
     const [httpResult, runningResult] = await Promise.all([
       checkHttpReachability(`${baseUrl}/healthz`, verbose),
-      checkRunningVersion(host, spawn),
+      runningCheck,
     ])
     const results: CheckResult[] = [httpResult, runningResult]
 

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -19,7 +19,7 @@ const healthyCliproxy: StatusSummary = {
   app: 'cliproxy',
   http: 'OK',
   lastDeploy: '—',
-  version: 'v1.2.3',
+  version: 'v1.2.3 (latest v1.2.4)',
   contentHash: '—',
   usageStats: '12 req / 0 fail',
 }
@@ -92,7 +92,9 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
       expectCapturedToInclude(captured, '| App | HTTP | Last Deploy | Version | Content Hash | Usage Stats |'),
     ).toBe(true)
     expect(expectCapturedToInclude(captured, '| keeweb | OK | 2026-04-12 10:00 | — | match | — |')).toBe(true)
-    expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
+    expect(
+      expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 (latest v1.2.4) | — | 12 req / 0 fail |'),
+    ).toBe(true)
     expect(expectCapturedToInclude(captured, '| gateway | OK: gateway:running/healthy | — | — | — | — |')).toBe(true)
     expect(expectCapturedToInclude(captured, '| umami | OK: umami:running/healthy | — | — | — | — |')).toBe(true)
     expect(expectCapturedToInclude(captured, '| dashboard | OK: dashboard:running/healthy | — | — | — | — |')).toBe(
@@ -176,7 +178,9 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
         '| keeweb | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded | ❌ Keeweb exploded |',
       ),
     ).toBe(true)
-    expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 | — | 12 req / 0 fail |')).toBe(true)
+    expect(
+      expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 (latest v1.2.4) | — | 12 req / 0 fail |'),
+    ).toBe(true)
     // Rejection reason must also appear in stderr so MCP consumers can see it
     expect(captured.stderr.join('')).toContain('keeweb status check failed: Keeweb exploded')
   })
@@ -202,7 +206,7 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
     }
 
     expect(parsed.keeweb.http).toBe('OK')
-    expect(parsed.cliproxy.version).toBe('v1.2.3')
+    expect(parsed.cliproxy.version).toBe('v1.2.3 (latest v1.2.4)')
     expect(parsed.gateway.http).toBe('OK: gateway:running/healthy')
     expect(parsed.umami.http).toBe('OK: umami:running/healthy')
     expect(parsed.dashboard.http).toBe('OK: dashboard:running/healthy')
@@ -218,6 +222,44 @@ describe('top-level status command (Tier-2 ctx capture)', () => {
     // Verify output went to ctx capture, not global console
     expect(captured.stdout.length).toBeGreaterThan(0)
     expect(expectCapturedToInclude(captured, '| App |')).toBe(true)
+  })
+
+  it('renders an equal cliproxy version as the latest marker', async () => {
+    const {ctx, captured} = createCapturedCtx()
+
+    await unifiedStatusAction(
+      {},
+      ctx,
+      makeDeps({
+        getCliproxyStatusSummary: async () => ({...healthyCliproxy, version: 'v1.2.3 (latest)'}),
+      }),
+    )
+
+    expect(expectCapturedToInclude(captured, '| cliproxy | OK | — | v1.2.3 (latest) | — | 12 req / 0 fail |')).toBe(
+      true,
+    )
+  })
+
+  it('keeps every compact version branch scannable in the unified table', async () => {
+    const branches = [
+      ['v1.2.3 (latest)', 'v1.2.3 (latest)'],
+      ['v1.2.3 (latest v1.2.4)', 'v1.2.3 (latest v1.2.4)'],
+      ['unknown (latest v1.2.4)', 'unknown (latest v1.2.4)'],
+      ['v1.2.3 (latest unknown)', 'v1.2.3 (latest unknown)'],
+      ['v1.2.3 (latest: no key)', 'v1.2.3 (latest: no key)'],
+      ['unknown', 'unknown'],
+    ] as const
+
+    for (const [version, expected] of branches) {
+      const {ctx, captured} = createCapturedCtx()
+      await unifiedStatusAction(
+        {},
+        ctx,
+        makeDeps({getCliproxyStatusSummary: async () => ({...healthyCliproxy, version})}),
+      )
+
+      expect(expectCapturedToInclude(captured, `| cliproxy | OK | — | ${expected} | — | 12 req / 0 fail |`)).toBe(true)
+    }
   })
 })
 


### PR DESCRIPTION
`infra status` was reporting a version the box wasn't running.

The cliproxy `Version` column came from `GET /v0/management/latest-version`, which is the **latest available upstream release** — it has nothing to do with what's deployed. I hit all three sources at the same moment and got three different numbers:

| Source | Value |
| --- | --- |
| `/v0/management/latest-version` (what the column showed) | `v7.2.140` |
| Pin in `apps/cliproxy/docker-compose.yaml` | `v7.2.139` |
| Actually running on the droplet | `v7.2.138` |

The dashboard confidently displayed `v7.2.140` while the box was two releases behind and the v7.2.140 deploy was still sitting unapproved at its gate. A status view that reports the wrong version is worse than not having one — it's the exact question you consult it to answer.

## Change

Report both, clearly separated. There's no HTTP endpoint for the running version (`/version`, `/v1/version`, `/v0/management/version`, `/v0/management/status`, `/v0/management/info` all 404), so it reads the running image over SSH — the same approach `gateway`, `umami`, and `dashboard` status already use, going through the existing host validator, known-hosts, and identity helpers rather than a new SSH path.

Unified table:

| Case | Cell |
| --- | --- |
| Skew — the actionable case | `v7.2.139 (latest v7.2.140)` |
| In sync | `v7.2.139 (latest)` |
| SSH unavailable | `unknown (latest v7.2.140)` |
| No management key | `v7.2.139 (latest: no key)` |

Detailed `cliproxy status` keeps full diagnostics as separate `Running version` and `Latest available version` checks, with real error text intact.

## Degradation

`cliproxy status` previously needed no SSH key and still doesn't. If SSH is unavailable the running-version check degrades to a warning, the HTTP checks still run, and a healthy proxy still reports healthy — no new hard dependency, and no change to exit behavior. Stays read-only and MCP-safe; output threads through `ctx`.

Verified against live production, not just mocks.
