### PR TITLE
chore(renovate): cap TypeScript below v7

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,13 @@
       groupName: null,
     },
     {
+      matchDatasources: ['npm'],
+      matchPackageNames: ['typescript'],
+      // @typescript-eslint/* peers require typescript >=4.8.4 <6.1.0; lift this ceiling when
+      // TypeScript 7 support lands upstream in typescript-eslint#10940.
+      allowedVersions: '<7',
+    },
+    {
       // ghcr.io/fro-bot/dashboard is the upstream-published, smoke-tested image consumed by
       // apps/dashboard via docker-compose.yaml (tag@digest pin). The implicit docker-compose
       // manager tracks digest bumps; this rule adds PR context and requires operator approval


### PR DESCRIPTION
Keep Renovate from proposing TypeScript 7 until the ecosystem can support it.

TypeScript 7 is structurally blocked: every `@typescript-eslint/*` package declares the peer range `>=4.8.4 <6.1.0`, and CI lint crashes after the frozen install with a `reading 'Cjs'` error. TypeScript 7 is the Go-native `tsgo` rewrite and ships no public compiler API yet, so typescript-eslint has nothing to adopt.

Lift the ceiling when `typescript-eslint#10940` is resolved. Renovate PR #1107 will be closed as blocked-upstream.