### PR TITLE
docs: capture npm publish outage learnings and agent provisioner shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Bun workspace monorepo for personal infrastructure — KeeWeb deploy automation,
 | Copilot instructions | `.github/copilot-instructions.md` | References this file |
 | OpenCode commands | `.opencode/commands/` | Markdown slash commands |
 | Document solved problem | `docs/solutions/` | Compound learning with YAML frontmatter |
+| Search past solutions | `docs/solutions/` | Categorized by problem type; frontmatter `module`, `tags`, `problem_type`. Relevant when implementing or debugging in a documented area |
 | Find operational runbook | `docs/runbooks/` | Operator-facing day-2 procedures (rotation, revocation, restore) |
 
 ## CONVENTIONS
@@ -181,7 +182,7 @@ bun run provision:agent                         # Provision agent OIDC/S3/IAM re
 - `FRO_BOT_S3_ROLE_TO_ASSUME`, `FRO_BOT_S3_BUCKET`, `FRO_BOT_S3_REGION`, `FRO_BOT_S3_PREFIX`, and `FRO_BOT_S3_EXPECTED_BUCKET_OWNER` are non-secret repository variables written by `agent storage` from the provisioner handoff manifest. The consumer repository must pre-create the `fro-bot-storage` GitHub Environment with a required reviewer and an exact main-only deployment-branch policy before the workflow references it. The storage preflight requires the local `aws` CLI; the storage workflow uses GitHub OIDC → AWS STS and never static AWS keys.
 - `OPENCODE_AUTH_JSON`, `OPENCODE_CONFIG`, `FRO_BOT_PAT` are repo-level secrets. `FRO_BOT_MODEL` is a repo variable.
 - `OPENCODE_CONFIG` must set `baseURL` with `/v1` suffix: `{"provider":{"anthropic":{"options":{"baseURL":"https://cliproxy.fro.bot/v1"}}}}`.
-- `APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `DIGITALOCEAN_ACCESS_TOKEN`, `NPM_TOKEN` are repo-level secrets.
+- `APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `DIGITALOCEAN_ACCESS_TOKEN`, `NPM_TOKEN` are repo-level secrets. npm publishing uses tokenless OIDC trusted publishing (no `NODE_AUTH_TOKEN`, no `.npmrc`); `NPM_TOKEN` is retained only as a rollback path and is not referenced by any workflow.
 - Deploy target: `box.heatvision.co` (Mail-In-A-Box server). Site path: `/home/user-data/www/kw.igg.ms/`.
 - Activation script on server (`/usr/local/bin/kw-deploy-activate`) sets permissions to 775 with setgid to preserve group-write for deploy user.
 - `dorny/paths-filter` used for change detection because native `paths:` breaks `workflow_dispatch`. Deploy condition: `workflow_dispatch || keeweb-changed`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ System shape and invariants for this monorepo. For where things live, see [`STRU
 
 ## Bird's Eye Overview
 
-This is a Bun-workspace monorepo that deploys and manages personal infrastructure: KeeWeb (`box.heatvision.co`), a CLIProxyAPI Claude proxy (`cliproxy.fro.bot`), the Fro Bot Discord gateway (`gateway.fro.bot`), Umami analytics (`metrics.fro.bot`), a Fro Bot monitoring dashboard (`dashboard.fro.bot`), an OIDC credential broker (`broker.fro.bot`), and a WireGuard VPN egress box on AWS Lightsail (`eu-west-1`). Each deployable lives under `apps/`; each is self-contained (its own Docker Compose stack or build, a TypeScript deploy script, and a provisioning script). DigitalOcean droplets host the Docker apps; KeeWeb deploys to a Mail-in-a-Box server over SSH/rsync; the VPN box runs native `wg-quick@wg0` + systemd on AWS Lightsail, provisioned via `@aws-sdk/client-lightsail`.
+This is a Bun-workspace monorepo that deploys and manages personal infrastructure: KeeWeb (`box.heatvision.co`), a CLIProxyAPI Claude proxy (`cliproxy.fro.bot`), the Fro Bot Discord gateway (`gateway.fro.bot`), Umami analytics (`metrics.fro.bot`), a Fro Bot monitoring dashboard (`dashboard.fro.bot`), an OIDC credential broker (`broker.fro.bot`), and a WireGuard VPN egress box on AWS Lightsail (`eu-west-1`). Each deployable lives under `apps/`; each is self-contained (its own Docker Compose stack or build, a TypeScript deploy script, and a provisioning script). DigitalOcean droplets host the Docker apps; KeeWeb deploys to a Mail-in-a-Box server over SSH/rsync; the VPN box runs native `wg-quick@wg0` + systemd on AWS Lightsail, provisioned via `@aws-sdk/client-lightsail`. `apps/agent` is the one non-deployable: a private, operator-run AWS provisioner for `fro-bot/agent` durable S3 session storage (account-level OIDC provider, dedicated bucket, per-repo IAM role/policy) — it has no deploy script, Docker Compose stack, or deploy workflow; `bun run provision:agent` is its only entry point.
 
 `packages/cli` is the unified operator surface — a goke CLI (`@marcusrbrown/infra`) with one command group per app plus a unified `status` dashboard. `packages/shared` holds cross-app provisioning helpers. The same CLI exposes a read-only subset of its commands over an MCP bridge so coding agents can query deployment state. GitHub Actions runs the deploy pipeline (one gated workflow per app behind a per-app GitHub Environment) and automation (Fro Bot review, Renovate, releases via Changesets).
 
@@ -37,6 +37,10 @@ Role → path. Reference symbols and files; no line numbers (they rot).
 | Broker mint/revoke client | `apps/broker/src/mint.ts` (`mintKey`, `revokeKey`, `listApiKeys`, single-flight lock) |
 | Broker sweeper | `apps/broker/src/sweeper.ts` (`sweepExpired`, `reconcile`, `startupReconcile`, `startSweeper`) |
 | Broker CLI command group | `packages/cli/src/commands/broker/` (`status.ts`, `deploy.ts`, `logs.ts`, `index.ts` → `registerBrokerCommands`) |
+| Agent AWS provisioner (operator-run, no deploy) | `apps/agent/server/provision.ts` (IAM + S3 convergence, readback verification, handoff manifest, `--teardown`) |
+| Agent action key layout | `apps/agent/src/key-layout.ts` (version-pinned S3 session/coordination-lock paths; unknown layouts fail closed) |
+| Agent CLI command group | `packages/cli/src/commands/agent/` (`index.ts` → `registerAgentCommands` → `registerAgentSetup` (`agent setup`, wraps shared `setup-core`) + `registerAgentStorageCommand` (`agent storage`, `agent storage teardown`)) |
+| Agent workflow verifier | `packages/cli/src/commands/agent/workflow-verify.ts` (`verifyWorkflow` — validates `fro-bot.yaml` job-split, `fro-bot-storage` environment gate, and reachability before wiring storage vars) |
 | Per-app host validators | `apps/<name>/src/host.ts` and `packages/cli/src/commands/<app>/host.ts` |
 | Deploy pipeline | `.github/workflows/deploy.yaml` (router) + `deploy-<app>.yaml` |
 | Pinned SSH host keys | `.github/known_hosts` |
@@ -62,7 +66,7 @@ operator (CLI) or agent (MCP)
 
 Enforceable rules. Many are gated by `packages/cli/src/conventions.test.ts`, ESLint, or review; mirror the `(enforced)` anti-patterns in the root `AGENTS.md`.
 
-1. **`apps/` are deployable units; `packages/` are reusable libraries.** `packages/` never imports from `apps/`.
+1. **`apps/` are deployable units; `packages/` are reusable libraries.** `packages/` never imports from `apps/`. `apps/agent` is the sole non-deployable exception — a private operator-run provisioner with no deploy script or deploy workflow.
 2. **Only `apps/keeweb/deploy.sh` is Bash.** Every other script is TypeScript run via `bun run`.
 3. **Never pass secret bytes via argv.** Secret material is piped through SSH stdin (`writeRemoteFile` pattern); `--body <value>` patterns are banned.
 4. **Host validation before SSH.** Every SSH-spawning command validates the host (`host.ts`, rejecting `-`-prefixed and invalid values) before constructing the SSH command.
@@ -87,6 +91,7 @@ Enforceable rules. Many are gated by `packages/cli/src/conventions.test.ts`, ESL
 Integration-level patterns; for the mechanical file layout see [`STRUCTURE.md`](STRUCTURE.md).
 
 - **New deployable app** → create `apps/<name>/` mirroring the closest existing app (`apps/cliproxy/` for a Docker-Compose droplet app, `apps/vpn/` for a native-systemd AWS Lightsail app): Compose config or deploy script, `src/deploy.ts`, `server/provision.ts` (using `packages/shared/server/droplet-helpers.ts` for SSH helpers, or `@aws-sdk/client-lightsail` for Lightsail), `src/host.ts`. New provisioners use `provision.ts`; the existing DigitalOcean apps keep their `provision-droplet.ts` filenames. Add it to `package.json` `workspaces`, add `provision:<name>` / `deploy:<name>` root scripts, add a CLI command group under `packages/cli/src/commands/<name>/`, add a gated `deploy-<name>.yaml` workflow wired into `deploy.yaml`'s paths-filter, create the `<name>` GitHub Environment, and add `apps/<name>/AGENTS.md`.
+- **New operator-only provisioning tool (no deploy step)** → mirror `apps/agent/`: `private: true` package, `server/provision.ts` entry point, no `src/deploy.ts`, no `src/host.ts`, no deploy workflow, no GitHub Environment. Add only `provision:<name>` to root `package.json` scripts and, if operator interaction is needed, a CLI command group under `packages/cli/src/commands/<name>/`.
 - **New CLI command group** → add `register<Name>Commands` and a `commands/<name>/` directory with per-action files and a barrel `index.ts`; register it in `packages/cli/src/cli.ts`. Expose a command over MCP only by adding it to `MCP_ALLOWLIST`, and only if it is read-only.
 - **New shared provisioning helper** → add it to `packages/shared/server/droplet-helpers.ts` with a colocated test; consume it from each app's provisioning script (`provision-droplet.ts` for cliproxy/gateway/umami, `provision.ts` for vpn).
 - **New deploy workflow** → copy an existing `deploy-<app>.yaml`, keep the per-app Environment gate and `paths-filter` negations, and wire it into `deploy.yaml`.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -5,14 +5,15 @@ Where things live and where to put new code. For system shape, data flow, and in
 ## Directory Layout
 
 ```text
-├── apps/                       Deployable units (one self-contained deploy each)
+├── apps/                       Deployable units (one self-contained deploy each; apps/agent is provisioning-only, no deploy)
 │   ├── keeweb/                 KeeWeb static-site deploy (SSH/rsync to Mail-in-a-Box)
 │   ├── cliproxy/               CLIProxyAPI Claude proxy (DigitalOcean + Docker Compose)
 │   ├── gateway/                Fro Bot Discord gateway (DigitalOcean + Docker Compose)
 │   ├── umami/                  Umami analytics (DigitalOcean + Docker Compose)
 │   ├── dashboard/              Fro Bot monitoring dashboard (DigitalOcean + Docker Compose)
 │   ├── vpn/                    WireGuard egress box (AWS Lightsail eu-west-1, native wg-quick@wg0)
-│   └── broker/                 OIDC credential broker (DigitalOcean + Docker Compose)
+│   ├── broker/                 OIDC credential broker (DigitalOcean + Docker Compose)
+│   └── agent/                  Operator-run AWS provisioner for fro-bot/agent S3 durable storage (no deploy step)
 ├── packages/                   Reusable libraries (never import from apps/)
 │   ├── cli/                    @marcusrbrown/infra goke CLI + MCP bridge + VPN peer model
 │   └── shared/                 Cross-app SSH/SCP/provisioning helpers
@@ -26,7 +27,7 @@ Where things live and where to put new code. For system shape, data flow, and in
 
 ### `apps/`
 
-One subdirectory per deployable. Each app owns its Compose/build config (or native systemd config for VPN), a TypeScript deploy script (`src/deploy.ts`; KeeWeb uses `src/build.ts` + `deploy.sh`), a provisioning script (except keeweb — `server/provision-droplet.ts` for the DigitalOcean Docker apps including dashboard and broker, `server/provision.ts` for the `@aws-sdk/client-lightsail` VPN box), a deploy-side host validator (`src/host.ts` where the deploy spawns SSH), and an `AGENTS.md` runbook. Apps never share code by importing each other — shared logic lives in `packages/shared`, and the VPN peer model is published from `packages/cli`.
+One subdirectory per deployable. Each app owns its Compose/build config (or native systemd config for VPN), a TypeScript deploy script (`src/deploy.ts`; KeeWeb uses `src/build.ts` + `deploy.sh`), a provisioning script (except keeweb — `server/provision-droplet.ts` for the DigitalOcean Docker apps including dashboard and broker, `server/provision.ts` for the `@aws-sdk/client-lightsail` VPN box), a deploy-side host validator (`src/host.ts` where the deploy spawns SSH), and an `AGENTS.md` runbook. Apps never share code by importing each other — shared logic lives in `packages/shared`, and the VPN peer model is published from `packages/cli`. `apps/agent` is the non-deployable exception: a `private: true` operator-run AWS provisioner with no `src/deploy.ts`, no `src/host.ts`, and no deploy workflow — just `server/provision.ts` (IAM + S3 convergence) and `src/key-layout.ts` (pinned S3 key layout).
 
 ### `packages/`
 
@@ -65,6 +66,8 @@ OpenCode slash commands (Markdown). The `generating-project-docs` skill (`.agent
 | --- | --- |
 | `apps/<name>/server/provision-droplet.ts` | DigitalOcean droplet provisioning (cliproxy, gateway, umami, dashboard, broker) |
 | `apps/vpn/server/provision.ts` | Lightsail provisioning (`@aws-sdk/client-lightsail`) |
+| `apps/agent/server/provision.ts` | Operator-run AWS IAM + S3 convergence for `fro-bot/agent` durable storage; no deploy step |
+| `apps/agent/src/key-layout.ts` | Version-pinned S3 session/coordination-lock key layout; unknown layouts fail closed |
 | `apps/<name>/src/host.ts` | Deploy-side host validator (rejects `-`-prefixed / invalid hosts) |
 | `apps/gateway/upstream.json` | Pinned `fro-bot/agent` daemon ref |
 | `apps/dashboard/docker-compose.yaml` | Digest-pinned `ghcr.io/fro-bot/dashboard` image (tag@sha256 in the `image:` line; Renovate tracks bumps) |
@@ -113,6 +116,7 @@ OpenCode slash commands (Markdown). The `generating-project-docs` skill (`.agent
 Mechanical layout; for the integration rationale see [`ARCHITECTURE.md`](ARCHITECTURE.md).
 
 - **New app** → `apps/<name>/` mirroring `apps/cliproxy/` (Docker Compose on DigitalOcean) or `apps/vpn/` (native systemd on AWS Lightsail): Compose config or deploy script, `src/deploy.ts`, `server/provision.ts` (new apps use `provision.ts`; existing DigitalOcean apps keep `provision-droplet.ts`), `src/host.ts`, `AGENTS.md`. Add to `package.json` `workspaces` + `provision:<name>`/`deploy:<name>` scripts; run `bun install` to refresh `bun.lock`.
+- **New operator-only tool (no deploy)** → mirror `apps/agent/`: `private: true`, `server/provision.ts` only — no `src/deploy.ts`, `src/host.ts`, deploy workflow, or GitHub Environment. Add `provision:<name>` to root `package.json` scripts.
 - **New CLI command** → `packages/cli/src/commands/<app>/<action>.ts` + colocated test; export it from the group's `index.ts` barrel.
 - **New shared helper** → `packages/shared/server/droplet-helpers.ts` + colocated test.
 - **New test** → colocate `*.test.ts` beside the source; fixtures/snapshots in `__fixtures__/`/`__snapshots__/`.

--- a/docs/solutions/integration-issues/npm-publish-stacked-auth-failures-2026-08-23.md
+++ b/docs/solutions/integration-issues/npm-publish-stacked-auth-failures-2026-08-23.md
@@ -1,0 +1,144 @@
+---
+title: npm publishing silently failed for nine days from stacked workflow-auth and expired-token causes
+date: 2026-08-23
+category: integration-issues
+module: .github/workflows/release.yaml
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - "changeset publish fails with E404: Not Found - PUT https://registry.npmjs.org/@marcusrbrown%2finfra"
+  - "Versions 0.16.0, 0.17.0, and 0.18.0 never reached the registry while package.json advanced"
+  - "Release workflow runs report success on every merge that does not attempt a publish"
+  - "The published package remains resolvable, so the 404 looks like a missing-package error"
+root_cause: config_error
+resolution_type: workflow_improvement
+severity: high
+related_components:
+  - tooling
+  - authentication
+tags:
+  - npm
+  - publishing
+  - changesets
+  - github-actions
+  - trusted-publishing
+  - oidc
+  - release-pipeline
+---
+
+# npm publishing silently failed for nine days from stacked workflow-auth and expired-token causes
+
+## Problem
+
+npm publishing for `@marcusrbrown/infra` broke on 2026-08-13 and stayed broken until 2026-08-23. Versions `0.16.0`, `0.17.0`, and `0.18.0` were versioned, tagged in `package.json`, and merged to `main` but never reached the registry — npm continued serving `0.15.4` as `latest` while the repo believed it had shipped three releases.
+
+## Symptoms
+
+```text
+No changesets found. Attempting to publish any unpublished packages to npm
+[command]/home/runner/.bun/bin/bunx changeset publish
+🦋 changeset v3.0.1
+These packages will be published as they were not found in the registry:
+@marcusrbrown/infra@0.17.0
+Some packages failed to publish:
+@marcusrbrown/infra@0.17.0
+└ E404: Not Found - PUT https://registry.npmjs.org/@marcusrbrown%2finfra - Not found
+```
+
+Two properties made this hard to see:
+
+- **The error is non-diagnostic.** npm returns `E404` on `PUT` for anonymous requests, expired tokens, and unauthorized-scope writes alike — never `401` or `403`. The status code carries no information about which failure occurred, and reads as though the package does not exist.
+- **The failing path runs rarely.** Only a release-PR merge attempts a publish. Every other Release run took the version path, regenerated the release PR, and reported success. The workflow was green for nine days while publishing was dead.
+
+## What Didn't Work
+
+- **Blaming `changesets/action` v2 alone.** This was a real defect and the fix was necessary, but insufficient — the identical `E404` persisted afterward. Treating a partially-correct diagnosis as complete cost an extra failed release. When a confirmed fix does not change the symptom, the correct inference is a second independent cause, not a bad fix.
+- **Suspecting Bun.** `bunx changeset publish` looks like it should route through `bun publish`, which has no OIDC support. It does not. Verified in installed source at `node_modules/.bun/@changesets+cli@3.0.1/node_modules/@changesets/cli/dist/getPublishPlan.mjs`: `getPublishTool()` branches only to pnpm and yarn, and everything else — Bun included — falls through to `return npm_exports`, whose publish calls `exec("npm", ["publish", ...])`. Its `sanitizeEnv` strips only `NPM_CONFIG_OTP`/`npm_config_otp`, so `ACTIONS_ID_TOKEN_REQUEST_*` reach the npm child process intact.
+- **Expecting the repair merge to publish.** Merging the fix did not republish the pending version. A changeset was still present on `main`, so the run took the version path and regenerated the release PR instead. Only a merge with no pending changesets reaches the publish path.
+
+## Solution
+
+### Cause 1 — workflow wiring (PR #1163)
+
+`changesets/action` v2.0.0 (upstream PR #695, commit `469993c`) removed its `.npmrc` handling:
+
+> Removed `.npmrc` handling when the `NPM_TOKEN` environment variable is set. Authentication should be handled via Trusted Publishing instead. If a token is still needed, use `actions/setup-node` … via the `registry-url` option.
+
+v1 wrote the npmrc itself, so `NPM_TOKEN` alone sufficed. This repo adopted v2 at commit `92b7ee2` (2026-08-15) and kept passing `NPM_TOKEN`, which v2 ignores. With `actions/setup-node` + `registry-url`, the generated npmrc is `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` — that variable was never set, so it interpolated empty and every publish went out anonymous.
+
+### Cause 2 — expired credential
+
+The npm granular token behind the `NPM_TOKEN` secret expired in the same window, with no trusted publisher configured as a fallback. Rotating it was operator-side work; nothing in the repo could detect or report it.
+
+Recovery once both were addressed — `workflow_dispatch` is supported, so no empty commit is needed:
+
+```bash
+gh workflow run release.yaml --ref main
+```
+
+This published `0.19.0`.
+
+### Eliminating the credential (PR #1171)
+
+Restoring token auth left the same failure scheduled to recur at the next expiry. The durable fix was migrating to npm Trusted Publishing over GitHub OIDC, which removes the long-lived credential entirely:
+
+```diff
+       - id: changesets
+         name: Create Release Pull Request or Publish
+         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+-        env:
+-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+         with:
+           github-token: ${{ steps.get-app-token.outputs.token }}
+```
+
+The root `.npmrc` was **deleted**, not just emptied of its value:
+
+```diff
+-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+Both removals are mandatory. npm silently stays on the token path and skips OIDC entirely if it finds any auth token configuration, so a leftover npmrc would have produced a confusing partial migration that still depended on a credential.
+
+Preconditions, all already satisfied by the existing workflow: job-level `id-token: write`, Node ≥ 22.14.0 (repo uses 24), npm ≥ 11.5.1 (Node 24 bundles npm 11), and `actions/setup-node` with `registry-url`. The npm-side Trusted Publisher is registered against `marcusrbrown/infra`, workflow `release.yaml`, no environment — the workflow filename and the absence of an `environment:` key must match exactly.
+
+## Why This Works
+
+Two independent faults produced one indistinguishable symptom, and each masked the other: correcting the wiring still hit the dead token, and rotating the token alone would still have interpolated into an unset variable. Because `E404` is npm's response to every authentication and authorization failure, the error text could not partition the causes — and the natural reading of "404 on a package that exists" points at the wrong subsystem entirely.
+
+Registry metadata is what separated them:
+
+```bash
+curl -s https://registry.npmjs.org/@marcusrbrown%2Finfra
+```
+
+`0.15.4` showed a successful publish on 2026-08-13 with `_npmUser: marcusrbrown` and intact provenance attestations — under the same workflow shape that was now failing. A workflow-only defect could not explain a version that had published cleanly days earlier, which moved the credential from "unlikely" to "primary suspect".
+
+The same technique proved the OIDC migration rather than trusting a green check:
+
+|                    | `0.19.0` (token)               | `0.20.0` (OIDC)                                 |
+| ------------------ | ------------------------------ | ----------------------------------------------- |
+| `_npmUser`         | `marcusrbrown <npm@mrbro.dev>` | `GitHub Actions <npm-oidc-no-reply@github.com>` |
+| `trustedPublisher` | absent                         | `id: github`, `oidcConfigId: oidc:…`            |
+| Provenance         | present                        | present (SLSA v1)                               |
+
+The publisher identity changing to GitHub Actions with a `trustedPublisher` record is registry-side proof the OIDC path executed — not a token publish that happened to succeed.
+
+`npm/cli#8976` (open since 2026-02-12) reports scoped package + OIDC + changesets failing with this exact `E404`. That is this repository's configuration and it did not reproduce, so the upstream bug is narrower than its title suggests.
+
+## Prevention
+
+- **Encode the auth contract as a test.** `packages/cli/src/conventions.test.ts` has `release workflow uses tokenless npm trusted publishing`, which asserts the changesets step carries neither `NODE_AUTH_TOKEN` nor `NPM_TOKEN`, that the job grants `id-token: write`, that `actions/setup-node` sets `registry-url`, and — critically — globs _every_ `.npmrc` outside `node_modules` and fails on any `_authToken` line. Guarding only the root path would miss a reintroduction one directory away.
+- **Read registry metadata before reading logs.** On any publish failure, compare `_npmUser`, version presence, `trustedPublisher`, and attestations against the last known-good release. This distinguishes a wiring change from a credential change in one request; workflow logs cannot.
+- **Treat `E404` on `PUT` as an auth failure until proven otherwise.** It never means the package is missing.
+- **Do not stop at the first confirmed cause.** A verified fix that leaves the symptom unchanged is evidence of a second independent fault, not of a bad fix.
+- **A failure signal nobody watches is not a signal.** This ran nine days because failed Release runs surfaced nowhere anyone looked. The structural fix is removing the failure mode — OIDC has no credential to expire — rather than adding another alarm to an unwatched channel.
+- **Verify rare paths after changing shared workflow dependencies.** A `changesets/action` major bump only manifests on the publish path, which most merges never touch. Assume a green pipeline has not exercised it.
+
+## Related Issues
+
+- [`docs/solutions/workflow-issues/release-changeset-graphql-premature-close-2026-06-28.md`](../workflow-issues/release-changeset-graphql-premature-close-2026-06-28.md) — same changesets release lane, different failure class.
+- [`docs/solutions/best-practices/cli-bun-build-publish-model-2026-06-20.md`](../best-practices/cli-bun-build-publish-model-2026-06-20.md) — how the published CLI is bundled; adjacent packaging boundary.
+- [`docs/solutions/workflow-issues/renovate-changesets-monorepo-targeting-2026-04-15.md`](../workflow-issues/renovate-changesets-monorepo-targeting-2026-04-15.md) — same release-automation family.
+- [`docs/solutions/integration-issues/cliproxy-claude-oauth-refresh-expiry-2026-06-20.md`](./cliproxy-claude-oauth-refresh-expiry-2026-06-20.md) — credential-expiry analogue in a different subsystem.
+- Upstream: `changesets/action` PR #695 (removed npmrc handling), `npm/cli#8976` (scoped + OIDC + changesets `E404`).


### PR DESCRIPTION
npm publishing was dead for nine days (2026-08-13 → 2026-08-23). Versions 0.16.0, 0.17.0, and 0.18.0 were versioned and merged but never reached the registry, while npm kept serving 0.15.4 as `latest`.

Two independent causes stacked, and each masked the other:

- `changesets/action` v2.0.0 removed its `.npmrc` handling for `NPM_TOKEN` (upstream PR #695). We adopted v2 at `92b7ee2` and kept passing the now-inert variable, so every publish went out anonymous.
- The npm granular token expired in the same window.

npm returns `E404` on `PUT` for anonymous, expired, and unauthorized writes alike — never 401 or 403 — so the error text could not partition the causes, and reads like a missing-package error on a package that plainly exists. Fixing either cause alone reproduced the identical failure.

What actually separated them was registry metadata: `0.15.4` had published cleanly days earlier under the same workflow shape, which ruled out a workflow-only defect and moved the credential to prime suspect. The same technique later proved the OIDC migration worked, rather than trusting a green check — `0.20.0` carries `_npmUser: GitHub Actions` and a `trustedPublisher` record where `0.19.0` carries mine.

This documents the diagnosis, the repair in #1163, and the migration to tokenless trusted publishing in #1171. The most useful section is *What Didn't Work* — it records the partial diagnosis that looked complete, the Bun-blocks-OIDC theory that source inspection refuted, and the wrong assumption about which path a merge would take.

Also in here:

- `AGENTS.md` now surfaces `docs/solutions/` as a searchable store with its frontmatter fields, so it gets read rather than only written to. The `NPM_TOKEN` line no longer implies it is the active publish credential.
- `ARCHITECTURE.md` and `STRUCTURE.md` pick up `apps/agent` — the non-deployable operator-run provisioner — including its exception to the apps/-are-deployable invariant and guidance for future operator-only tools. That was uncommitted work from earlier; it belongs with this.