### PR TITLE
docs(cli): correct MCP exclusion rationale

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -4,16 +4,18 @@ import {createMcpAction} from '@goke/mcp'
 /**
  * Commands intentionally excluded from MCP exposure (not in MCP_ALLOWLIST):
  *
- * Infrastructure / streaming (deferred or not MCP-suitable):
- * - `gateway deploy`   — subprocess streaming (Bun.spawn with stdout: 'inherit'), deferred to MCP v2 (#291)
- * - `cliproxy deploy`  — subprocess streaming, deferred to MCP v2 (#291)
- * - `keeweb deploy`    — subprocess streaming, deferred to MCP v2 (#291)
- * - `gateway logs`     — subprocess streaming, deferred to MCP v2 (#291)
+ * Infrastructure / deferred deploy-trigger work or not MCP-suitable:
+ * - `gateway deploy`   — remote workflow dispatch only (deploy-trigger capability), deferred to MCP v2 (#291)
+ * - `cliproxy deploy`  — remote workflow dispatch only (deploy-trigger capability), deferred to MCP v2 (#291)
+ * - `keeweb deploy`    — remote workflow dispatch only (deploy-trigger capability); blocked until the nginx step is gated, deferred to MCP v2 (#291)
  * - `cliproxy login`   — interactive (OAuth callback URL paste, requires TTY)
  * - `cliproxy open`    — interactive (SSH TUI session, requires TTY)
  * - `cliproxy setup`   — interactive (@clack/prompts wizard, requires TTY)
- * - `gateway restore`  — destructive policy (replaces mitmproxy CA on live gateway, deferred to MCP v2 #292)
+ * - `gateway restore`  — destructive policy (replaces mitmproxy CA on live gateway, requires approval-gating prerequisite before re-exposure #292)
  * - `keeweb open`      — host-machine side effect (spawns local browser, requires user intent)
+ *
+ * Intentionally CLI-only (mutating or sensitive):
+ * - `gateway logs`     — sensitive: streams logs that may emit secrets or user data; CLI-only
  * - `umami deploy`     — intentionally CLI-only: mutates live deployment and requires environment approval
  * - `umami logs`       — intentionally CLI-only: streams logs that may emit sensitive data (DB passwords, app secrets)
  * - `dashboard deploy` — intentionally CLI-only: mutates live deployment and requires environment approval


### PR DESCRIPTION
Corrects stale MCP exclusion comments so they match the current tracking decisions.

Issue #291 is described as deferred deploy-trigger work using remote workflow dispatch, not postponed subprocess streaming. `gateway logs` is documented as a permanent security exclusion because output may contain Discord tokens, S3 credentials, or user data. The keeweb nginx prerequisite and #292's approval-gating prerequisite are recorded as well.