### PR TITLE
fix(release): verify and alert failed publishes

### DIFF
--- a/.github/workflows/release-alert.yaml
+++ b/.github/workflows/release-alert.yaml
@@ -1,0 +1,70 @@
+---
+name: Release Alert
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: release-alert
+  cancel-in-progress: false
+
+jobs:
+  alert:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+    steps:
+      - name: Report failed release
+        run: |
+          set -euo pipefail
+
+          label='release-publish-failure'
+          marker='<!-- release-publish-failure:v1 -->'
+          title='Release workflow failure'
+          body=$(printf '%s\n' \
+            "$marker" \
+            'The Release workflow failed.' \
+            '' \
+            "- Run: $RUN_URL" \
+            "- Head SHA: $HEAD_SHA" \
+            "- Conclusion: $CONCLUSION")
+
+          if ! gh label view "$label" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            gh label create "$label" --repo "$REPOSITORY" --color b60205 --description 'Release workflow failures'
+          fi
+
+          issues=$(gh issue list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --label "$label" \
+            --search "$title in:title" \
+            --limit 100 \
+            --json number,body)
+          issue_count=$(jq 'length' <<<"$issues")
+          marked_issue_count=$(jq -r --arg marker "$marker" \
+            '[.[] | select(.body != null and (.body | contains($marker)))] | length' \
+            <<<"$issues")
+          if ((marked_issue_count != issue_count)); then
+            printf '::error::open release issue with label %s is missing the canonical marker\n' "$label" >&2
+            exit 1
+          fi
+
+          issue_number=$(jq -r --arg marker "$marker" \
+            '[.[] | select(.body != null and (.body | contains($marker)))] | sort_by(.number) | .[0].number // empty' \
+            <<<"$issues")
+
+          if [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" --repo "$REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$REPOSITORY" --title "$title" --label "$label" --body "$body"
+          fi

--- a/.github/workflows/release-alert.yaml
+++ b/.github/workflows/release-alert.yaml
@@ -50,15 +50,6 @@ jobs:
             --search "$title in:title" \
             --limit 100 \
             --json number,body)
-          issue_count=$(jq 'length' <<<"$issues")
-          marked_issue_count=$(jq -r --arg marker "$marker" \
-            '[.[] | select(.body != null and (.body | contains($marker)))] | length' \
-            <<<"$issues")
-          if ((marked_issue_count != issue_count)); then
-            printf '::error::open release issue with label %s is missing the canonical marker\n' "$label" >&2
-            exit 1
-          fi
-
           issue_number=$(jq -r --arg marker "$marker" \
             '[.[] | select(.body != null and (.body | contains($marker)))] | sort_by(.number) | .[0].number // empty' \
             <<<"$issues")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,3 +70,42 @@ jobs:
           pr-title: 'chore(🦋📦): version packages'
           version-script: bun run version-changesets
           publish-script: bunx changeset publish
+
+      - name: Verify published packages
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs['published-packages'] }}
+        run: |
+          set -euo pipefail
+
+          max_attempts=5
+          retry_delay_seconds=3
+          summary_file="$GITHUB_STEP_SUMMARY"
+
+          if ! jq -e 'type == "array" and length > 0' <<<"$PUBLISHED_PACKAGES" >/dev/null; then
+            printf '%s\n' '::error::changesets reported published=true without any published packages' >&2
+            exit 1
+          fi
+          printf '%s\n' '## Verified npm publishes' >>"$summary_file"
+
+          while IFS=$'\t' read -r name version; do
+            verified=false
+            for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+              actual_version="$(npm view "${name}@${version}" version --registry=https://registry.npmjs.org 2>/dev/null || true)"
+              if [[ "$actual_version" == "$version" ]]; then
+                verified=true
+                break
+              fi
+              if ((attempt < max_attempts)); then
+                sleep "$retry_delay_seconds"
+              fi
+            done
+
+            if [[ "$verified" != true ]]; then
+              printf '::error::npm registry did not resolve %s@%s after %d attempts\n' "$name" "$version" "$max_attempts" >&2
+              exit 1
+            fi
+
+            printf -- '- `%s@%s` — verified\n' "$name" "$version" >>"$summary_file"
+            printf 'Verified %s@%s\n' "$name" "$version"
+          done < <(jq -r '.[] | [.name, .version] | @tsv' <<<"$PUBLISHED_PACKAGES")


### PR DESCRIPTION
A Release run could previously succeed while shipping nothing, and failed runs surfaced nowhere useful.

The release workflow now requires a non-empty published package list when publishing is reported, verifies every published version resolves from npm with bounded retries, and records the verified versions in the run summary. The alert workflow watches failed Release runs and reconciles one canonical GitHub issue, commenting on it for subsequent failures instead of duplicating issues.

The nine-day npm outage from August 13–23, 2026 exposed the gap.