### PR TITLE
feat(cliproxy): add active Caddy upstream health check

### DIFF
--- a/apps/cliproxy/config/Caddyfile
+++ b/apps/cliproxy/config/Caddyfile
@@ -1,4 +1,9 @@
 # Caddy automatically provisions and renews HTTPS certificates via Let's Encrypt.
 {$CLIPROXY_DOMAIN} {
-  reverse_proxy cli-proxy-api:8317
+	reverse_proxy cli-proxy-api:8317 {
+		health_uri /healthz
+		health_interval 30s
+		health_timeout 5s
+		health_status 2xx
+	}
 }


### PR DESCRIPTION
Caddy had no upstream health awareness and could keep routing traffic to an unhealthy CLIProxyAPI backend until connection failure. This adds active checks to `/healthz` every 30 seconds with a 5-second timeout, explicitly accepting 2xx responses.

The droplet probe returned `200` with `{"status":"ok"}` in `4.194ms`, so the interval is useful without hammering the backend and the timeout is comfortably above the observed latency. Passive ejection is deliberately out of scope.

Takes effect on the next cliproxy deploy.